### PR TITLE
Change lables for digital mic to be their name

### DIFF
--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -1840,9 +1840,9 @@ class AudioReactive : public Usermod {
       oappend(SET_F("addOption(dd,'Send',1);"));
       oappend(SET_F("addOption(dd,'Receive',2);"));
       oappend(SET_F("addInfo('AudioReactive:digitalmic:type',1,'<i>requires reboot!</i>');"));  // 0 is field type, 1 is actual field
-      oappend(SET_F("addInfo('AudioReactive:digitalmic:pin[]',0,'I2S SD');"));
-      oappend(SET_F("addInfo('AudioReactive:digitalmic:pin[]',1,'I2S WS');"));
-      oappend(SET_F("addInfo('AudioReactive:digitalmic:pin[]',2,'I2S SCK');"));
+      oappend(SET_F("addInfo('AudioReactive:digitalmic:pin[]',0,'I2S Serial Data (SD / DATA / DOUT) ');"));
+      oappend(SET_F("addInfo('AudioReactive:digitalmic:pin[]',1,'I2S Left/Right Clock (WS / CLK / LRCK)');"));
+      oappend(SET_F("addInfo('AudioReactive:digitalmic:pin[]',2,'I2S Serial Clock (SCK / BCLK)');"));
       #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
         oappend(SET_F("addInfo('AudioReactive:digitalmic:pin[]',3,'I2S Master CLK <br/><i>only use -1, 0, 1 or 3 for MCLK</i>');"));
       #else


### PR DESCRIPTION
Change lables for digital mic to be their name with common acronyms listed after rather than assuming everyone uses INMP441 or referring to the wiki for other names https://github.com/atuline/WLED/wiki/Digital-Microphone-Hookup

![Screenshot from 2022-11-19 12-45-50](https://user-images.githubusercontent.com/442066/202851564-c063b11f-3452-4188-aeb6-4754f872edf0.png)
