### PR TITLE
Fix invalid environment error in PlatformIO

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -736,7 +736,7 @@ lib_deps = ${esp8266.lib_deps}
 # codm-controller-0.6 can also be used for the TYWE3S controller
 # ------------------------------------------------------------------------------
 
-[env:codm-controller-0.6]
+[env:codm-controller-0_6]
 board = esp_wroom_02
 platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
@@ -745,7 +745,7 @@ build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags_esp8266}
 lib_deps = ${esp8266.lib_deps}
 
-[env:codm-controller-0.6-rev2]
+[env:codm-controller-0_6-rev2]
 board = esp_wroom_02
 platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@
 ; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32s2_saola, esp32c3, esp32s3dev_8MB
 
 # Build everything
-; default_envs = esp32dev, esp8285_4CH_MagicHome, codm-controller-0.6-rev2, codm-controller-0.6, esp32s2_saola, d1_mini_5CH_Shojo_PCB, d1_mini, sp501e, nodemcuv2, esp32_eth, anavi_miracle_controller, esp07, esp01_1m_full, m5atom, h803wf, d1_mini_ota, heltec_wifi_kit_8, esp8285_H801, d1_mini_debug, wemos_shield_esp32, elekstube_ips
+; default_envs = esp32dev, esp8285_4CH_MagicHome, codm-controller-0_6-rev2, codm-controller-0_6, esp32s2_saola, d1_mini_5CH_Shojo_PCB, d1_mini, sp501e, nodemcuv2, esp32_eth, anavi_miracle_controller, esp07, esp01_1m_full, m5atom, h803wf, d1_mini_ota, heltec_wifi_kit_8, esp8285_H801, d1_mini_debug, wemos_shield_esp32, elekstube_ips
 
 # Single binaries (uncomment your board)
 ; default_envs = elekstube_ips
@@ -733,7 +733,7 @@ lib_deps = ${esp8266.lib_deps}
 
 # ------------------------------------------------------------------------------
 # codm pixel controller board configurations
-# codm-controller-0.6 can also be used for the TYWE3S controller
+# codm-controller-0_6 can also be used for the TYWE3S controller
 # ------------------------------------------------------------------------------
 
 [env:codm-controller-0_6]


### PR DESCRIPTION
PlatformIO gives error on codm environments
``Error: Invalid environment name 'codm-controller-0.6'. The name can contain alphanumeric, underscore, and hyphen characters (a-z, 0-9, -, _)``