### PR TITLE
Speed up builds by caching build_cache

### DIFF
--- a/.github/workflows/wled-ci.yml
+++ b/.github/workflows/wled-ci.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-${{ environment}}-${{ hashFiles('platformio.ini') }}
+        key: ${{ runner.os }}-${{ matrix.environment}}-${{ hashFiles('platformio.ini') }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/wled-ci.yml
+++ b/.github/workflows/wled-ci.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+        key: ${{ runner.os }}-${{ environment}}-${{ hashFiles('platformio.ini') }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/wled-ci.yml
+++ b/.github/workflows/wled-ci.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+        key: ${{ runner.os }}-${{ hashFiles('platform.ini') }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/wled-ci.yml
+++ b/.github/workflows/wled-ci.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-${{ hashFiles('platform.ini') }}
+        key: ${{ runner.os }}-${{ hashFiles('platformio.ini') }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/platformio.ini
+++ b/platformio.ini
@@ -2078,3 +2078,4 @@ build_flags = ${esp32_4MB_V4_S_base.build_flags}
 ;lib_ignore = IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
 ; RAM:   [===       ]  25.4% (used 83144 bytes from 327680 bytes)
 ; Flash: [==========]  96.4% (used 1516029 bytes from 1572864 bytes)
+;

--- a/platformio.ini
+++ b/platformio.ini
@@ -88,7 +88,7 @@ default_envs =
 
 src_dir  = ./wled00
 data_dir = ./wled00/data
-build_cache_dir = ~/.buildcache
+build_cache_dir = ~/.platformio/buildcache
 extra_configs =
   platformio_override.ini
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -3,7 +3,7 @@
 /*
    Main sketch, global variable declarations
    @title WLED project sketch
-   @version 0.14.0-b2
+   @version 0.14.0-bX
    @author Christian Schwinne
  */
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2308140
+#define VERSION 2308141
 
 //uncomment this if you have a "my_config.h" file you'd like to use
 //#define WLED_USE_MY_CONFIG

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -3,7 +3,7 @@
 /*
    Main sketch, global variable declarations
    @title WLED project sketch
-   @version 0.14.0-bX
+   @version 0.14.0-bXX
    @author Christian Schwinne
  */
 


### PR DESCRIPTION
Caching of ~/.platformio broken as cache key does not reference the right file, so have state cache that doesn't get updates

Build cache is outside of the ~/.platformio directory, so all the code, including libraries being rebuild for every environment every build