### PR TITLE
Fix return value (frameDelay) of FX_MODE_STATIC

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -80,7 +80,7 @@ static int8_t tristate_square8(uint8_t x, uint8_t pulsewidth, uint8_t attdec) {
  */
 uint16_t mode_static(void) {
   SEGMENT.fill(SEGCOLOR(0));
-  return 350;
+  return FRAMETIME;
 }
 static const char _data_FX_MODE_STATIC[] PROGMEM = "Solid";
 

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -80,7 +80,7 @@ static int8_t tristate_square8(uint8_t x, uint8_t pulsewidth, uint8_t attdec) {
  */
 uint16_t mode_static(void) {
   SEGMENT.fill(SEGCOLOR(0));
-  return FRAMETIME;
+  return FRAMETIME_FIXED_SLOW;    // WLEDMM to ensure smooth color changes from DMX (PR #73)
 }
 static const char _data_FX_MODE_STATIC[] PROGMEM = "Solid";
 


### PR DESCRIPTION
`FX_MODE_STATIC` used a hard coded return value of 350.
This causes visible lag/stuttering when updating the strip brightness via artnet/dmx.

This PR returns `FRAMETIME` instead of 350 to fix that.

