### PR TITLE
WM8978 support for Ohmic Pico DSP, etc.

### DIFF
--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -1755,6 +1755,23 @@ class AudioReactive : public Usermod {
 
           if (audioSource) audioSource->initialize(i2swsPin, i2ssdPin, i2sckPin, mclkPin);
           break;
+        case 7:
+        #ifdef use_wm8978_mic
+          DEBUGSR_PRINTLN(F("AR: WM8978 Source (Mic)"));
+        #else
+          DEBUGSR_PRINTLN(F("AR: WM8978 Source (Line-In)"));
+        #endif
+          audioSource = new WM8978Source(SAMPLE_RATE, BLOCK_SIZE, 1.0f);
+          //useInputFilter = 0; // to disable low-cut software filtering and restore previous behaviour
+          delay(100);
+          // WLEDMM align global pins
+          if ((sdaPin >= 0) && (i2c_sda < 0)) i2c_sda = sdaPin; // copy usermod prefs into globals (if globals not defined)
+          if ((sclPin >= 0) && (i2c_scl < 0)) i2c_scl = sclPin;
+          if (i2c_sda >= 0) sdaPin = -1;                        // -1 = use global
+          if (i2c_scl >= 0) sclPin = -1;
+
+          if (audioSource) audioSource->initialize(i2swsPin, i2ssdPin, i2sckPin, mclkPin);
+          break;
 
         #if  !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
         // ADC over I2S is only possible on "classic" ESP32
@@ -2562,7 +2579,11 @@ class AudioReactive : public Usermod {
       #else
         oappend(SET_F("addOption(dd,'ES8388 ☾',6);"));
       #endif
-
+      #if SR_DMTYPE==7
+        oappend(SET_F("addOption(dd,'WM8978 ☾ (⎌)',7);"));
+      #else
+        oappend(SET_F("addOption(dd,'WM8978 ☾',7);"));
+      #endif
       #ifdef SR_SQUELCH
         oappend(SET_F("addInfo('AudioReactive:config:squelch',1,'<i>&#9100; ")); oappendi(SR_SQUELCH); oappend("</i>');");  // 0 is field type, 1 is actual field
       #endif

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -378,7 +378,7 @@
 #ifdef ESP8266
 #define SETTINGS_STACK_BUF_SIZE 2048
 #else
-#define SETTINGS_STACK_BUF_SIZE 3792   // WLEDMM added 696 bytes of margin (was 3096) for audioreactive UI
+#define SETTINGS_STACK_BUF_SIZE 3802   // WLEDMM added 696+10 bytes of margin (was 3096) for audioreactive UI
 #endif
 
 #ifdef WLED_USE_ETHERNET


### PR DESCRIPTION
Essentially a similar type of chip to the ES8388 - I2S codec configured over I2C. 

Configured for **line-in** with pass-thru on the Ohmic ESP32 Pico D4 DSP board:

https://github.com/ohmic-net/puca_dsp

May not work out of the box with all WM8978 boards because of the vast configuration options in the codec, but could easily be adjusted for various configurations. Not that there's many out there. :)