### PR TITLE
audio-enhanced standard effects

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1245,7 +1245,9 @@ static uint16_t mode_fireworks_core(bool useaudio) {
         float musicIndex = logf(FFT_MajorPeak);             // log scaling of peak freq
         soundColor = mapf(musicIndex, 4.6f, 9.06f, 0, 255); // pick color from frequency (4.6 = ln(100), 9.06 = ln(8600))
         soundColor = constrain(soundColor, 0, 255);         // remove over-shoot
-        if (samplePeak > 0) myIntensity -= myIntensity / 4; // increase effect intensity at peaks
+        if (samplePeak > 0) myIntensity -= myIntensity / 2; // increase effect intensity at peaks
+        else if (volumeSmth > 96.0f) myIntensity -= myIntensity / 4; // increase effect intensity slightly when music plays
+        myIntensity = constrain(myIntensity, 0, 129);
     } else {                                              // silence -> fade away
       valid1 = valid2 = false;   // do not copy last pixels
       addPixels = false;         // don't add new pixels
@@ -3430,10 +3432,10 @@ static uint16_t mode_starburst_core(bool useaudio) {
     // WLEDMM begin
     if (useaudio) {
       doNewStar = false;
-      int burstplus = (volumeSmth > 159)? 128:0;                // high volume -> more stars
+      int burstplus = (volumeSmth > 159)? 96:0;                // high volume -> more stars
       if (volumeRaw <= 56) burstplus = -64;                     // low volume  -> fewer stars
       int birthrate = (144-(SEGMENT.speed >> 1)) - burstplus;
-      birthrate = constrain(birthrate, 0, 144);
+      birthrate = constrain(birthrate, 4, 144);
       if (   (volumeSmth > 1.0f)                          // no bursts in silence
           && ((samplePeak > 0) || (volumeRaw > 48))       // try to burst with sound
           && (random8(birthrate) == 0) )                  // original random rate

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -336,7 +336,15 @@ void strip_wait_until_idle(String whoCalledMe); // WLEDMM implemented in FX_fcn.
 #define FX_MODE_ARTIFX                 187 //WLEDMM ARTIFX
 #define FX_MODE_PARTYJERK              188
 
-#define MODE_COUNT                     189
+// Experimental Audioresponsive modes from WLED-SR
+// #define FX_MODE_3DSphereMove           189 // experimental WLED-SR "cube" mode
+#define FX_MODE_POPCORN_AR             190 // WLED-SR audioreactive popcorn
+// #define FX_MODE_MULTI_COMET_AR         191 // WLED-SR audioreactive multi-comet
+#define FX_MODE_STARBURST_AR           192 // WLED-SR audioreactive fireworks starburst
+// #define FX_MODE_PALETTE_AR             193 // WLED-SR audioreactive palette
+#define FX_MODE_FIREWORKS_AR           194 // WLED-SR audioreactive fireworks 1D
+
+#define MODE_COUNT                     195
 
 typedef enum mapping1D2D {
   M12_Pixels = 0,

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2312290
+#define VERSION 2312310
 
 // WLEDMM  - you can check for this define in usermods, to only enabled WLEDMM specific code in the "right" fork. Its not defined in AC WLED.
 #define _MoonModules_WLED_


### PR DESCRIPTION
Audio Reactive enhanced versions of "Fireworks", "Fireworks Starburst", "Popcorn" (back-ported from WLED-SR)

This was a prove-of-concept for making audio-responsive versions of standard effects, and we almost forgot about it 😅
* The concept works for many effects that use some "random trigger"
* trigger events (popcorn pop, etc) are synchronised with audio onsets. As our peak detection still needs improvements, Audio volume is used as a second trigger condition.
* effects slowly suspend in silence

The perfect feature for New Years Eve 👍 
- clap your hands -> popcorn
- hear a rocket explode -> starburst