### PR TITLE
spinning matrix hack (experimental)

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7893,7 +7893,7 @@ uint16_t mode_2DAkemi(void) {
   const uint16_t cols = SEGMENT.virtualWidth();
   const uint16_t rows = SEGMENT.virtualHeight();
 
-  // if (SEGENV.call == 0) SEGMENT.setUpLeds(); 
+  if (SEGENV.call == 0) SEGMENT.setUpLeds(); // WLEDMM we want akemi to look perfect. No fould compromizes.
 
   uint16_t counter = (strip.now * ((SEGMENT.speed >> 2) +2)) & 0xFFFF;
   counter = counter >> 8;

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -828,11 +828,12 @@ class WS2812FX {  // 96 bytes
       setTargetFps(uint8_t fps),
       enumerateLedmaps(); //WLEDMM (from fcn_declare)
 
-    void setColor(uint8_t slot, uint8_t r, uint8_t g, uint8_t b, uint8_t w = 0) { setColor(slot, RGBW32(r,g,b,w)); }
-    void fill(uint32_t c) { for (int i = 0; i < getLengthTotal(); i++) setPixelColor(i, c); } // fill whole strip with color (inline)
+    inline void setColor(uint8_t slot, uint8_t r, uint8_t g, uint8_t b, uint8_t w = 0) { setColor(slot, RGBW32(r,g,b,w)); }
+    inline void fill(uint32_t c) { int lTotal = getLengthTotal(); for (int i = 0; i < lTotal; i++) setPixelColor(i, c); } // fill whole strip with color (inline)
     void addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name); // add effect to the list; defined in FX.cpp
     void setupEffectData(void); // add default effects to the list; defined in FX.cpp
 
+    void DOsetPixelColorXY(int x, int y, uint32_t col); // set without mapping
     // outsmart the compiler :) by correctly overloading
     inline void setPixelColor(int n, uint8_t r, uint8_t g, uint8_t b, uint8_t w = 0) { setPixelColor(n, RGBW32(r,g,b,w)); }
     inline void setPixelColor(int n, CRGB c) { setPixelColor(n, c.red, c.green, c.blue); }
@@ -877,9 +878,9 @@ class WS2812FX {  // 96 bytes
     uint16_t
       ablMilliampsMax,
       currentMilliamps,
-      getLengthPhysical(void),
+      __attribute__((pure)) getLengthPhysical(void),
       __attribute__((pure)) getLengthTotal(void), // will include virtual/nonexistent pixels in matrix //WLEDMM attribute added
-      getFps();
+      __attribute__((pure)) getFps();
 
     inline uint16_t getFrameTime(void) { return _frametime; }
     inline uint16_t getMinShowDelay(void) { return MIN_SHOW_DELAY; }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -839,6 +839,8 @@ class WS2812FX {  // 96 bytes
     void setCanvas(int xStart, int xWidth, int yStart, int yHeight);
     void noCanvas(void);
     void DOsetPixelColorXY(int x, int y, uint32_t col); // set without mapping
+    void smoothEdges(void); // experimental
+
     // outsmart the compiler :) by correctly overloading
     inline void setPixelColor(int n, uint8_t r, uint8_t g, uint8_t b, uint8_t w = 0) { setPixelColor(n, RGBW32(r,g,b,w)); }
     inline void setPixelColor(int n, CRGB c) { setPixelColor(n, c.red, c.green, c.blue); }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -833,6 +833,11 @@ class WS2812FX {  // 96 bytes
     void addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name); // add effect to the list; defined in FX.cpp
     void setupEffectData(void); // add default effects to the list; defined in FX.cpp
 
+    // WLEDMM rotating matrix hack
+    void beginFrame(void); // advance rotation time, enable spin, clear pixels
+    void endFrame(void); // disable spin
+    void setCanvas(int xStart, int xWidth, int yStart, int yHeight);
+    void noCanvas(void);
     void DOsetPixelColorXY(int x, int y, uint32_t col); // set without mapping
     // outsmart the compiler :) by correctly overloading
     inline void setPixelColor(int n, uint8_t r, uint8_t g, uint8_t b, uint8_t w = 0) { setPixelColor(n, RGBW32(r,g,b,w)); }

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -223,9 +223,13 @@ static uint_fast16_t spinXY(uint_fast16_t x, uint_fast16_t y, uint_fast16_t widt
   float x2 = float(x1) * cosrot - float(y1) * sinrot;
   float y2 = float(x1) * sinrot + float(y1) * cosrot;
   // un-center
+#if defined(SPIN_AROUND_TOP)
+  int x3 = lround(x2) + segWidth/2;
+  int y3 = lround(y2 * 2.0f);
+#else
   int y3 = lround(y2) + segHeight/2;
   int x3 = lround(x2) + segWidth/2;
-
+#endif
   // check bounds
   if ((x3 <0) || (x3 >= segWidth) || (y3 <0) || (y3 >= segHeight)) return UINT16_MAX; // outside of matrix
   // move to segment start

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -213,6 +213,18 @@ static uint_fast16_t spinXY(uint_fast16_t x, uint_fast16_t y, uint_fast16_t widt
   else return (x3%width) + (y3%height) * width;
 }
 
+// WLEDMM: setPixelColorXY without spinXY part.
+void WS2812FX::DOsetPixelColorXY(int x, int y, uint32_t col) {
+  //if (!isMatrix) return; // not a matrix set-up
+  if ((x<0) || (y<0)) return;
+  if (x >= Segment::maxWidth) return;
+  if (y >= Segment::maxHeight) return;
+  uint_fast16_t index = y * Segment::maxWidth + x;
+  if (index < customMappingSize) index = customMappingTable[index];
+  if (index >= _length) return;
+  //if (busses.getPixelColor(index) != col) busses.setPixelColor(index, col);
+  busses.setPixelColor(index, col);
+}
 
 // absolute matrix version of setPixelColor()
 void IRAM_ATTR_YN WS2812FX::setPixelColorXY(int x, int y, uint32_t col) //WLEDMM: IRAM_ATTR conditionally
@@ -236,6 +248,7 @@ void IRAM_ATTR_YN WS2812FX::setPixelColorXY(int x, int y, uint32_t col) //WLEDMM
 // returns RGBW values of pixel
 uint32_t WS2812FX::getPixelColorXY(uint16_t x, uint16_t y) {
 #ifndef WLED_DISABLE_2D
+  if ((x<0) || (y<0)) return 0; // WLEDMM fix array out of bounds access
 #if 1
   // use rotation hack
   uint_fast16_t index = spinXY(x, y,  Segment::maxWidth,  Segment::maxHeight);

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1748,6 +1748,7 @@ void WS2812FX::service() {
 
 void IRAM_ATTR WS2812FX::setPixelColor(int i, uint32_t col)
 {
+  if (i < 0) return; // WLEDMM avoid acessing array out of bounds
   if (i < customMappingSize) i = customMappingTable[i];
   if (i >= _length) return;
   busses.setPixelColor(i, col);


### PR DESCRIPTION
Adding a new dynamic mapping for 2D effects.

The idea is 
* "intercept" pixels on their way from the SEGMENT (with buffer) down to the led driver.
* use a [transformation matrix](https://en.m.wikipedia.org/wiki/Transformation_matrix#Examples_in_2_dimensions) to modify pixel coordinates dynamically
* write out pixels at their new, transformed locations.

As proof of concept, I'm transforming the matrix so its constantly rotating at the same speed.
UI support will come later. Also there is a lot of optimization potential, so performance will be very good finally.

<img width=48% src="https://github.com/MoonModules/WLED/assets/91616163/3cd4149a-ceef-4c83-9fa6-cb0b91c2e75b"> 

<img width=48% src="https://github.com/MoonModules/WLED/assets/91616163/604ad9e8-ae68-489f-bb47-6a0d1e178d5b"> 

<img width=48% src="https://github.com/MoonModules/WLED/assets/91616163/9f027462-856d-46e9-b646-571b6aa6acf6"> 

<img width=48% src="https://github.com/MoonModules/WLED/assets/91616163/b29690c4-b918-4ae3-b2ca-a7f69a15bf97">


https://github.com/MoonModules/WLED/assets/91616163/de8bad22-c74e-4650-8e9a-18b19dfa3e62


https://github.com/MoonModules/WLED/assets/91616163/2f1685f4-fd1e-49ba-8a4c-6a9c2e3c27d3

