### PR TITLE
Overhaul Art-Net output to be more "professionally" useful

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -303,8 +303,10 @@ void BusPwm::setPixelColor(uint16_t pix, uint32_t c) {
     case TYPE_ANALOG_5CH: //RGB + warm white + cold white
       _data[4] = cw;
       w = ww;
+      // falls through
     case TYPE_ANALOG_4CH: //RGBW
       _data[3] = w;
+      // falls through
     case TYPE_ANALOG_3CH: //standard dumb RGB
       _data[0] = r; _data[1] = g; _data[2] = b;
       break;
@@ -451,38 +453,46 @@ void BusNetwork::setPixelColor(uint16_t pix, uint32_t c) {
   uint16_t offset = pix * _UDPchannels;
   uint8_t co = _colorOrderMap.getPixelColorOrder(pix+_start, _colorOrder);
   if (_colorOrder != co) {
-    if (co == COL_ORDER_GRB) {
+    switch (co) {
+    case COL_ORDER_GRB:
       _data[offset]   = G(c);
       _data[offset+1] = R(c);
       _data[offset+2] = B(c);     
-    } else if (co == COL_ORDER_RGB) {
-      _data[offset]   = R(c);
-      _data[offset+1] = G(c);
-      _data[offset+2] = B(c);
-    } else if (co == COL_ORDER_BRG) {
+      break;
+    case COL_ORDER_BRG:
       _data[offset]   = B(c);
       _data[offset+1] = R(c);
       _data[offset+2] = G(c);
-    } else if (co == COL_ORDER_RBG) {
+      break;
+    case COL_ORDER_RBG:
       _data[offset]   = R(c);
       _data[offset+1] = B(c);
       _data[offset+2] = G(c);
-    } else if (co == COL_ORDER_GBR) {
-      _data[offset]   = G(c);
-      _data[offset+1] = B(c);
-      _data[offset+2] = R(c);
-    } else if (co == COL_ORDER_BGR) {
+      break;
+    case COL_ORDER_BGR:
       _data[offset]   = B(c);
       _data[offset+1] = G(c);
       _data[offset+2] = R(c);
+      break;
+    case COL_ORDER_GBR:
+      _data[offset]   = G(c);
+      _data[offset+1] = B(c);
+      _data[offset+2] = R(c);
+    break;
+    case COL_ORDER_RGB:
+      /* falls through */
+    default:
+      _data[offset]   = R(c);
+      _data[offset+1] = G(c);
+      _data[offset+2] = B(c);
+      break;
     }
-    if (_rgbw) _data[offset+3] = W(c);
   } else {
     _data[offset]   = R(c);
     _data[offset+1] = G(c);
     _data[offset+2] = B(c);
-    if (_rgbw) _data[offset+3] = W(c);
   }
+  if (_rgbw) _data[offset+3] = W(c);
 }
 
 uint32_t BusNetwork::getPixelColor(uint16_t pix) {
@@ -490,18 +500,13 @@ uint32_t BusNetwork::getPixelColor(uint16_t pix) {
   uint16_t offset = pix * _UDPchannels;
   uint8_t co = _colorOrderMap.getPixelColorOrder(pix+_start, _colorOrder);
   if (_colorOrder != co) {
-    if (co == COL_ORDER_GRB) {
-      return RGBW32(_data[offset+1], _data[offset+0], _data[offset+2], _rgbw ? (_data[offset+3] << 24) : 0);
-    } else if (co == COL_ORDER_RGB) {
-      return RGBW32(_data[offset+0], _data[offset+1], _data[offset+2], _rgbw ? (_data[offset+3] << 24) : 0);
-    } else if (co == COL_ORDER_BRG) {
-      return RGBW32(_data[offset+2], _data[offset+0], _data[offset+1], _rgbw ? (_data[offset+3] << 24) : 0);
-    } else if (co == COL_ORDER_RBG) {
-      return RGBW32(_data[offset+0], _data[offset+2], _data[offset+1], _rgbw ? (_data[offset+3] << 24) : 0);
-    } else if (co == COL_ORDER_GBR) {
-      return RGBW32(_data[offset+1], _data[offset+2], _data[offset+0], _rgbw ? (_data[offset+3] << 24) : 0);
-    } else if (co == COL_ORDER_BGR) {
-      return RGBW32(_data[offset+2], _data[offset+1], _data[offset+0], _rgbw ? (_data[offset+3] << 24) : 0);
+    switch (co) {
+    case COL_ORDER_GRB: return RGBW32(_data[offset+1], _data[offset+0], _data[offset+2], _rgbw ? (_data[offset+3] << 24) : 0); break;
+    case COL_ORDER_RGB: return RGBW32(_data[offset+0], _data[offset+1], _data[offset+2], _rgbw ? (_data[offset+3] << 24) : 0); break;
+    case COL_ORDER_BRG: return RGBW32(_data[offset+2], _data[offset+0], _data[offset+1], _rgbw ? (_data[offset+3] << 24) : 0); break;
+    case COL_ORDER_RBG: return RGBW32(_data[offset+0], _data[offset+2], _data[offset+1], _rgbw ? (_data[offset+3] << 24) : 0); break;
+    case COL_ORDER_GBR: return RGBW32(_data[offset+1], _data[offset+2], _data[offset+0], _rgbw ? (_data[offset+3] << 24) : 0); break;
+    case COL_ORDER_BGR: return RGBW32(_data[offset+2], _data[offset+1], _data[offset+0], _rgbw ? (_data[offset+3] << 24) : 0); break;
     }
   }
   return RGBW32(_data[offset+0], _data[offset+1], _data[offset+2], _rgbw ? (_data[offset+3] << 24) : 0);

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -393,7 +393,6 @@ uint8_t BusOnOff::getPins(uint8_t* pinArray) {
   return 1;
 }
 
-
 BusNetwork::BusNetwork(BusConfig &bc, const ColorOrderMap &com) : Bus(bc.type, bc.start, bc.autoWhite), _colorOrderMap(com) {
   _valid = false;
   switch (bc.type) {
@@ -418,7 +417,6 @@ BusNetwork::BusNetwork(BusConfig &bc, const ColorOrderMap &com) : Bus(bc.type, b
   _client = IPAddress(bc.pins[0],bc.pins[1],bc.pins[2],bc.pins[3]);
   _broadcastLock = false;
   _valid = true;
-  _colorOrder = bc.colorOrder;
 }
 
 void BusNetwork::setPixelColor(uint16_t pix, uint32_t c) {
@@ -448,6 +446,10 @@ void BusNetwork::setPixelColor(uint16_t pix, uint32_t c) {
       _data[offset]   = G(c);
       _data[offset+1] = B(c);
       _data[offset+2] = R(c);
+    } else if (co == COL_ORDER_BGR) {
+      _data[offset]   = B(c);
+      _data[offset+1] = G(c);
+      _data[offset+2] = R(c);
     }
     if (_rgbw) _data[offset+3] = W(c);
   } else {
@@ -473,6 +475,8 @@ uint32_t BusNetwork::getPixelColor(uint16_t pix) {
       return RGBW32(_data[offset+0], _data[offset+2], _data[offset+1], _rgbw ? (_data[offset+3] << 24) : 0);
     } else if (co == COL_ORDER_GBR) {
       return RGBW32(_data[offset+1], _data[offset+2], _data[offset+0], _rgbw ? (_data[offset+3] << 24) : 0);
+    } else if (co == COL_ORDER_BGR) {
+      return RGBW32(_data[offset+2], _data[offset+1], _data[offset+0], _rgbw ? (_data[offset+3] << 24) : 0);
     }
   }
   return RGBW32(_data[offset+0], _data[offset+1], _data[offset+2], _rgbw ? (_data[offset+3] << 24) : 0);

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -297,7 +297,7 @@ class BusNetwork : public Bus {
   public:
     BusNetwork(BusConfig &bc, const ColorOrderMap &com);
 
-    uint16_t getMaxPixels() override { return 4096; };
+    uint16_t getMaxPixels() override { return MAX_LEDS_PER_BUS; };
     bool hasRGB() { return true; }
     bool hasWhite() { return _rgbw; }
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -295,7 +295,7 @@ class BusOnOff : public Bus {
 
 class BusNetwork : public Bus {
   public:
-    BusNetwork(BusConfig &bc);
+    BusNetwork(BusConfig &bc, const ColorOrderMap &com);
 
     uint16_t getMaxPixels() override { return 4096; };
     bool hasRGB() { return true; }
@@ -318,6 +318,10 @@ class BusNetwork : public Bus {
       return _len;
     }
 
+    uint8_t getColorOrder() {
+      return _colorOrder;
+    }
+
     void cleanup();
 
     ~BusNetwork() {
@@ -331,6 +335,8 @@ class BusNetwork : public Bus {
     bool      _rgbw;
     bool      _broadcastLock;
     byte     *_data;
+    uint8_t   _colorOrder = COL_ORDER_RGB;
+    const ColorOrderMap &_colorOrderMap;
 };
 
 #ifdef WLED_ENABLE_HUB75MATRIX

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -411,7 +411,7 @@
   #if !defined(USERMOD_AUDIOREACTIVE)
     #define SETTINGS_STACK_BUF_SIZE 3834   // WLEDMM added 696+32 bytes of margin (was 3096)
   #else
-    #define SETTINGS_STACK_BUF_SIZE 4000   // WLEDMM more buffer for audioreactive UI (add '-D CONFIG_ASYNC_TCP_TASK_STACK_SIZE=9216' to your build_flags)
+    #define SETTINGS_STACK_BUF_SIZE 4100   // WLEDMM more buffer for audioreactive UI (add '-D CONFIG_ASYNC_TCP_TASK_STACK_SIZE=9216' to your build_flags)
   #endif
 #endif
 

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -5,7 +5,7 @@
 	<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">
 	<title>LED Settings</title>
 	<script>
-		var d=document,laprev=55,maxB=1,maxV=0,maxM=4000,maxPB=4096,maxL=1333,maxLbquot=0; //maximum bytes for LED allocation: 4kB for 8266, 32kB for 32
+		var d=document,laprev=55,maxB=1,maxV=0,maxM=4000,maxPB=8192,maxL=1333,maxLbquot=0; //maximum bytes for LED allocation: 4kB for 8266, 32kB for 32
 		d.um_p = [];
 		d.rsvd = [];
 		d.ro_gpio = [];

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -860,13 +860,13 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
 
       sequenceNumber++;
 
-      for (size_t hardware_output = 0; hardware_output < hardware_outputs; hardware_output++){
+      if (sequenceNumber > 255) sequenceNumber = 0;
+
+      for (size_t hardware_output = 0; hardware_output < hardware_outputs; hardware_output++) {
 
         size_t channels_remaining = channels_per_hardware_output;
 
         while (channels_remaining > 0) {
-
-          if (sequenceNumber > 255) sequenceNumber = 0;
 
           if (!ddpUdp.beginPacket(client, ARTNET_DEFAULT_PORT)) {
             DEBUG_PRINTLN(F("Art-Net WiFiUDP.beginPacket returned an error"));

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -871,8 +871,8 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
       // You get 170 RGB LEDs per universe (128 RGBW) so the receiving hardware needs to be configured correctly.
       // The H807SA, for example, only allows one global setting of Art-Net universes-per-output.
       //
-      const size_t hardware_outputs[4] = { 256,256,256,256 }; // specified in LED counts
-      const size_t hardware_outputs_universe_start[4] = { 0,2,4,6 }; // universe start # per output
+      const size_t hardware_outputs[] = { 1024,1024,1024,1024,1024,1024,1024,1024 }; // specified in LED counts
+      const size_t hardware_outputs_universe_start[] = { 0,6,12,18,24,30,36,42 }; // universe start # per output
       #endif
       
       size_t bufferOffset = 0;

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -852,7 +852,7 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
       we could consider an Art-Net mapping system to adjust universe starts for weird wiring situations.
       */
       const size_t ARTNET_CHANNELS_PER_PACKET = isRGBW?512:510; // 512/4=128 RGBW LEDs, 510/3=170 RGB LEDs
-      const size_t hardware_outputs = 4; // WLED as an Art-Net renderer would be considered "1 hardware output" with many universes
+      const size_t hardware_outputs = 1; // WLED as an Art-Net renderer would be considered "1 hardware output" with many universes
       const size_t channels_per_hardware_output = length/hardware_outputs * (isRGBW?4:3); 
 
       size_t bufferOffset = 0;

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -893,14 +893,11 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
           ddpUdp.write(0xFF & (packetSize     )); // 16-bit length of channel data, LSB
 
           for (size_t i = 0; i < packetSize; i += (isRGBW?4:3)) {
-            // TODO: TroyHacks - some controllers do not have onboard color order remapping. Add something to do this.
-            // Currently remapped manually for GRB, but WLED rendering Art-Net expects RGB.
-            // Color order override maps would be useful here, but doesn't seem to work for "busNetwork" (yet).
-            ddpUdp.write(scale8(buffer[bufferOffset+0], bri)); // G
-            ddpUdp.write(scale8(buffer[bufferOffset+1], bri)); // R
-            ddpUdp.write(scale8(buffer[bufferOffset+2], bri)); // B
-            if (isRGBW) ddpUdp.write(scale8(buffer[bufferOffset+3], bri)); // W
-            bufferOffset += isRGBW?4:3;
+            // "Color Order Override" works on top of this if you need to change the color order before sending.
+            ddpUdp.write(scale8(buffer[bufferOffset++], bri)); // R
+            ddpUdp.write(scale8(buffer[bufferOffset++], bri)); // G
+            ddpUdp.write(scale8(buffer[bufferOffset++], bri)); // B 
+            if (isRGBW) ddpUdp.write(scale8(buffer[bufferOffset++], bri)); // W
           }
 
           if (!ddpUdp.endPacket()) {

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -770,9 +770,9 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
   switch (type) {
     case 0: // DDP
     {
-      #if defined WLED_USE_ETHERNET && !defined ESP8266
-      ddpUdp.begin(Network.localIP(),ARTNET_DEFAULT_PORT); // in case we have Ethernet on ESP32, this forces that source IP/routing.
-      #endif
+      // #if defined WLED_USE_ETHERNET && !defined ESP8266
+      // ddpUdp.begin(Network.localIP(),DDP_DEFAULT_PORT); // in case we have Ethernet on ESP32, this forces that source IP/routing.
+      // #endif
 
       // calculate the number of UDP packets we need to send
       size_t channelCount = length * (isRGBW? 4:3); // 1 channel for every R,G,B value
@@ -842,9 +842,9 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
 
     case 2: //ArtNet
     {
-      #if defined WLED_USE_ETHERNET && !defined ESP8266
-      ddpUdp.begin(Network.localIP(),ARTNET_DEFAULT_PORT); // in case we have Ethernet on ESP32, this forces that source IP/routing.
-      #endif
+      // #if defined WLED_USE_ETHERNET && !defined ESP8266
+      // ddpUdp.begin(Network.localIP(),ARTNET_DEFAULT_PORT); // in case we have Ethernet on ESP32, this forces that source IP/routing.
+      // #endif
       /* 
       We don't really care about the number of universes - just how many hardware outputs we have.
 

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -769,6 +769,8 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
   switch (type) {
     case 0: // DDP
     {
+      ddpUdp.begin(Network.localIP(), DDP_DEFAULT_PORT); // in case we have Ethernet, this forces that source IP/routing.
+
       // calculate the number of UDP packets we need to send
       size_t channelCount = length * (isRGBW? 4:3); // 1 channel for every R,G,B value
       size_t packetCount = ((channelCount-1) / DDP_CHANNELS_PER_PACKET) +1;
@@ -837,6 +839,8 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
 
     case 2: //ArtNet
     {
+      ddpUdp.begin(Network.localIP(),ARTNET_DEFAULT_PORT); // in case we have Ethernet, this forces that source IP/routing.
+
       /* 
       We don't really care about the number of universes - just how many hardware outputs we have.
 

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -769,7 +769,9 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
   switch (type) {
     case 0: // DDP
     {
-      ddpUdp.begin(Network.localIP(), DDP_DEFAULT_PORT); // in case we have Ethernet, this forces that source IP/routing.
+      #if defined WLED_USE_ETHERNET && !defined ESP8266
+      ddpUdp.begin(Network.localIP(),ARTNET_DEFAULT_PORT); // in case we have Ethernet on ESP32, this forces that source IP/routing.
+      #endif
 
       // calculate the number of UDP packets we need to send
       size_t channelCount = length * (isRGBW? 4:3); // 1 channel for every R,G,B value
@@ -839,8 +841,9 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
 
     case 2: //ArtNet
     {
-      ddpUdp.begin(Network.localIP(),ARTNET_DEFAULT_PORT); // in case we have Ethernet, this forces that source IP/routing.
-
+      #if defined WLED_USE_ETHERNET && !defined ESP8266
+      ddpUdp.begin(Network.localIP(),ARTNET_DEFAULT_PORT); // in case we have Ethernet on ESP32, this forces that source IP/routing.
+      #endif
       /* 
       We don't really care about the number of universes - just how many hardware outputs we have.
 

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -876,6 +876,10 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
       size_t bufferOffset = 0;
       size_t hardware_output_universe = 0;
       
+      sequenceNumber++;
+
+      if (sequenceNumber > 255) sequenceNumber = 1;
+
       for (size_t hardware_output = 0; hardware_output < sizeof(hardware_outputs)/sizeof(size_t); hardware_output++) {
         
         if (bufferOffset > length * (isRGBW?4:3)) return 1; // stop when we hit end of LEDs
@@ -889,16 +893,6 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
           if (!ddpUdp.beginPacket(client, ARTNET_DEFAULT_PORT)) {
             DEBUG_PRINTLN(F("Art-Net WiFiUDP.beginPacket returned an error"));
             return 1; // borked
-          } else {
-            // https://art-net.org.uk/how-it-works/streaming-packets/artnzs-packet-definition/
-            // Art-Net spec says:
-            // "The generating device increments this number for every packet sent to a 
-            // specific Port-Address. The number increments from 1 to 255 and then rolls 
-            // over to 1 and repeats. This is because the value 0 is reserved to show that 
-            // Sequence is not implemented."
-            sequenceNumber++;
-            if (sequenceNumber == 0) sequenceNumber = 1; // 0 is reserved in Art-Net for "we're not using sequence numbers"
-            if (sequenceNumber > 255) sequenceNumber = 1;
           }
 
           size_t packetSize = ARTNET_CHANNELS_PER_PACKET;

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -878,6 +878,7 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
       
       sequenceNumber++;
 
+      if (sequenceNumber == 0) sequenceNumber = 1; // just in case, as 0 is considered "Sequence not in use"
       if (sequenceNumber > 255) sequenceNumber = 1;
 
       for (size_t hardware_output = 0; hardware_output < sizeof(hardware_outputs)/sizeof(size_t); hardware_output++) {

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -861,18 +861,20 @@ uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, uint8
       */
       const size_t ARTNET_CHANNELS_PER_PACKET = isRGBW?512:510; // 512/4=128 RGBW LEDs, 510/3=170 RGB LEDs
 
+      #ifndef ARTNET_TROYHACKS
       // Default WLED-to-WLED Art-Net output
       //
       const size_t hardware_outputs[1] = { length }; // specified in LED counts. "length" = all LEDs
       const size_t hardware_outputs_universe_start[1] = { 0 }; // universe start # per output
-
+      #else
       // Example of more than 1 output, currently you can only hard-code this kind of setup here.
       // You get 170 RGB LEDs per universe (128 RGBW) so the receiving hardware needs to be configured correctly.
       // The H807SA, for example, only allows one global setting of Art-Net universes-per-output.
       //
-      // const size_t hardware_outputs[4] = { 256,256,256,256 }; // specified in LED counts
-      // const size_t hardware_outputs_universe_start[4] = { 0,2,4,6 }; // universe start # per output
-
+      const size_t hardware_outputs[4] = { 256,256,256,256 }; // specified in LED counts
+      const size_t hardware_outputs_universe_start[4] = { 0,2,4,6 }; // universe start # per output
+      #endif
+      
       size_t bufferOffset = 0;
       size_t hardware_output_universe = 0;
       

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -202,7 +202,7 @@ static bool sendLiveLedsWs(uint32_t wsClient)  // WLEDMM added "static"
   #ifdef ESP8266
     constexpr size_t MAX_LIVE_LEDS_WS = 256U;
   #else
-    constexpr size_t MAX_LIVE_LEDS_WS = 4096U;  //WLEDMM use 4096 as max matrix size
+    constexpr size_t MAX_LIVE_LEDS_WS = 8192U;  //WLEDMM use 4096 as max matrix size
   #endif
   size_t used;// = strip.getLengthTotal();
   size_t n;// = ((used -1)/MAX_LIVE_LEDS_WS) +1; //only serve every n'th LED if count over MAX_LIVE_LEDS_WS


### PR DESCRIPTION
Overhauls the Art-Net code to allow outputting to devices which may have multiple outputs and universe mappings, such as the commonly available "H807SA" 8-output Art-Net device.

Also adds support for "Color Order Override" in LED settings to allow the output color order to be changed on the fly within WLED for Art-Net rendering endpoints that don't have native color order remapping functionality. By using the existing color order override functions we can change any or all of the Art-Net output, just like we can with physical LEDs.

When serving as an Art-Net renderer, WLED expects 1 hardware output with as many universes as are needed, in RGB color order. This functionality is maintained with this PR with the default settings.

❓ **_Where help is needed_** is adding a parameter for "Hardware Outputs" to the "Art-Net RGB (network)" which will be mapped to `hardware_outputs` in the overhauled code:

![image](https://github.com/MoonModules/WLED/assets/5659019/bf9d37ae-ace1-487b-9b4f-e7711adfd7d2)

(`hardware_outputs` should default to "1" to maintain compatibility with WLED->WLED Art-Net rendering.)

A big thanks to @softhack007 for pointers on the color order remapping!

