### PR TITLE
Game of Life Memory Leak Fix + Other Changes

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5234,7 +5234,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
       }
     }
   }
-  if (SEGENV.step > strip.now || strip.now - SEGENV.step < FRAMETIME_FIXED * (uint32_t)map(SEGMENT.speed,0,255,64,2)) {
+  if (SEGENV.step > strip.now || strip.now - SEGENV.step < 1000 / (uint32_t)map(SEGMENT.speed,0,255,1,64)) { // 1 - 64 updates per second
     return FRAMETIME; //skip if not enough time has passed
   }
 
@@ -5336,7 +5336,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
   SEGENV.step = strip.now;
   return FRAMETIME;
 } // mode_2Dgameoflife()
-static const char _data_FX_MODE_2DGAMEOFLIFE[] PROGMEM = "Game Of Life@!,Color Mutation ☾,Blur ☾,,,All Colors ☾,Overlay ☾,Wrap ☾,;!,!;!;2;sx=200,ix=12,c1=8,o3=1"; 
+static const char _data_FX_MODE_2DGAMEOFLIFE[] PROGMEM = "Game Of Life@!,Color Mutation ☾,Blur ☾,,,All Colors ☾,Overlay ☾,Wrap ☾,;!,!;!;2;sx=82,ix=12,c1=8,o3=1"; 
 
 /////////////////////////
 //     2D Hiphotic     //

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5188,23 +5188,22 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
   }
   //start new game of life
   if ((SEGENV.call == 0 || generation == 0) && SEGENV.step < strip.now) {
-    SEGENV.step = strip.now + 1500; // show initial state for 1.5 seconds
+    SEGENV.step = strip.now + 1250; // show initial state for 1.25 seconds
     generation = 1;
     random16_set_seed(strip.now>>2); //seed the random generator
     //Setup Grid
     for (int x = 0; x < cols; x++) for (int y = 0; y < rows; y++) {
-      uint8_t state = (random8() < 82) ? 1 : 0; // ~32% chance of being alive
-      if (state == 0) {
-        setBitValue(cells, y * cols + x, false);
-        setBitValue(futureCells, y * cols + x, false);
-        if (SEGMENT.check2) continue;
-        SEGMENT.setPixelColorXY(x,y, !SEGMENT.check1?bgColor : RGBW32(bgColor.r, bgColor.g, bgColor.b, 0));
-      }
-      else {
+      if (random8() < 82) { // ~32% chance of being alive
         setBitValue(cells, y * cols + x, true);
         setBitValue(futureCells, y * cols + x, true);
         color = SEGMENT.color_from_palette(random8(), false, PALETTE_SOLID_WRAP, 0);
         SEGMENT.setPixelColorXY(x,y,!SEGMENT.check1?color : RGBW32(color.r, color.g, color.b, 0));
+      }
+      else {
+        setBitValue(cells, y * cols + x, false);
+        setBitValue(futureCells, y * cols + x, false);
+        if (SEGMENT.check2) continue; //overlay
+        SEGMENT.setPixelColorXY(x,y, !SEGMENT.check1?bgColor : RGBW32(bgColor.r, bgColor.g, bgColor.b, 0));
       }
     }
 
@@ -5250,7 +5249,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
 
     for (int i = -1; i <= 1; i++) for (int j = -1; j <= 1; j++) { // iterate through 3*3 matrix
       if (i==0 && j==0) continue; // ignore itself
-      if (!SEGMENT.check3 || generation % 1500 == 0) { //no wrap disable wrap every 1500 generations to prevent undetected repeats
+      if (!SEGMENT.check3 || generation % 1500 == 0) { //no wrap, disable wrap every 1500 generations to prevent undetected repeats
         cX = x+i;
         cY = y+j;
         if (cX < 0 || cY < 0 || cX >= cols || cY >= rows) continue; //skip if out of bounds
@@ -5265,7 +5264,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
         if (!getBitValue(futureCells, cIndex)) continue; //parent just died, color lost
         color = SEGMENT.getPixelColorXY(cX, cY);
         if (color == bgColor) continue;
-        nColors[colorCount%3] = color;
+        nColors[colorCount % 3] = color;
         colorCount++;
       }
     }
@@ -5292,8 +5291,8 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
         else dominantColor = nColors[random8()%3];
       }
       else if (colorCount == 2) dominantColor = nColors[random8()%2]; // 1 leading parent died
-      else if (colorCount == 1) dominantColor = nColors[0]; // 2 leading parents died
-      else dominantColor = color; // all parents died last used color
+      else if (colorCount == 1) dominantColor = nColors[0];           // 2 leading parents died
+      else dominantColor = color;                                     // all parents died last used color
       // mutate color chance
       if (random8() < SEGMENT.intensity || dominantColor == bgColor) dominantColor = !SEGMENT.check1?SEGMENT.color_from_palette(random8(), false, PALETTE_SOLID_WRAP, 0): random16()*random16();
       if (SEGMENT.check1) dominantColor = RGBW32(dominantColor.r, dominantColor.g, dominantColor.b, 0); //WLEDMM support all colors
@@ -5312,7 +5311,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
   bool repetition = false;
   if (!cellChanged || crc == *oscillatorCRC || crc == *spaceshipCRC) repetition = true; //check if cell changed this gen and compare previous stored crc values
   if (repetition) {
-    generation = 0; // reset on next call
+    generation = 0;      // reset on next call
     SEGENV.step += 1000; // pause final generation for 1 second
     return FRAMETIME;
   }
@@ -5324,7 +5323,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
   SEGENV.step = strip.now;
   return FRAMETIME;
 } // mode_2Dgameoflife()
-static const char _data_FX_MODE_2DGAMEOFLIFE[] PROGMEM = "Game Of Life@!,Color Mutation ☾,Blur ☾,,,All Colors ☾,Overlay ☾,Wrap ☾,;!,!;!;2;sx=200,ix=12,c1=0,o3=1"; 
+static const char _data_FX_MODE_2DGAMEOFLIFE[] PROGMEM = "Game Of Life@!,Color Mutation ☾,Blur ☾,,,All Colors ☾,Overlay ☾,Wrap ☾,;!,!;!;2;sx=200,ix=12,c1=8,o3=1"; 
 
 /////////////////////////
 //     2D Hiphotic     //

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5172,16 +5172,16 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
   const uint16_t cols = SEGMENT.virtualWidth();
   const uint16_t rows = SEGMENT.virtualHeight();
   const size_t dataSize = ((SEGMENT.length() + 7) / 8); // round up to nearest byte
-  const size_t detectionSize =  sizeof(uint8_t) + sizeof(uint16_t)*2; // 1 uint8_t (gliderLen), 2 uint16_t (2 CRCs)
-  const size_t totalSize = dataSize * 2 + detectionSize + sizeof(uint8_t);
+  const size_t detectionSize =  sizeof(uint16_t) * 3; // 2 CRCs, gliderLength
+  const size_t totalSize = dataSize * 2 + detectionSize + sizeof(uint8_t); // detectionSize + prevPalette
 
   if (!SEGENV.allocateData(totalSize)) return mode_static(); //allocation failed
   byte *cells       = reinterpret_cast<byte*>(SEGENV.data);
   byte *futureCells = reinterpret_cast<byte*>(SEGENV.data + dataSize);
-  uint8_t *gliderLength   = reinterpret_cast<uint8_t*>(SEGENV.data + dataSize*2);
-  uint16_t *oscillatorCRC = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize*2 + sizeof(uint8_t));
-  uint16_t *spaceshipCRC  = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize*2 + sizeof(uint8_t) + sizeof(uint16_t));
-  uint8_t *prevPalette = reinterpret_cast<uint8_t*>(SEGENV.data + dataSize*2 + detectionSize);
+  uint16_t *gliderLength  = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize * 2);
+  uint16_t *oscillatorCRC = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize * 2 + sizeof(uint8_t));
+  uint16_t *spaceshipCRC  = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize * 2 + sizeof(uint8_t) + sizeof(uint16_t));
+  uint8_t  *prevPalette   = reinterpret_cast<uint8_t*>(SEGENV.data + dataSize * 2 + detectionSize);
 
   uint16_t &generation = SEGENV.aux0; //Rename SEGENV/SEGMENT variables for readability
   bool allColors   = SEGMENT.check1;
@@ -5234,7 +5234,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
     return FRAMETIME;
   }
 
-  bool blurDead = SEGENV.step > strip.now && blur && !bgBlendMode && !overlayBG;
+  bool blurDead   = SEGENV.step > strip.now && blur && !bgBlendMode && !overlayBG;
   bool palChanged = SEGMENT.palette != *prevPalette && !allColors;
   if (palChanged) *prevPalette = SEGMENT.palette;
 

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5179,8 +5179,8 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
   byte *cells       = reinterpret_cast<byte*>(SEGENV.data);
   byte *futureCells = reinterpret_cast<byte*>(SEGENV.data + dataSize);
   uint16_t *gliderLength  = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize * 2);
-  uint16_t *oscillatorCRC = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize * 2 + sizeof(uint8_t));
-  uint16_t *spaceshipCRC  = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize * 2 + sizeof(uint8_t) + sizeof(uint16_t));
+  uint16_t *oscillatorCRC = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize * 2 + sizeof(uint16_t));
+  uint16_t *spaceshipCRC  = reinterpret_cast<uint16_t*>(SEGENV.data + dataSize * 2 + sizeof(uint16_t) * 2);
   uint8_t  *prevPalette   = reinterpret_cast<uint8_t*>(SEGENV.data + dataSize * 2 + detectionSize);
 
   uint16_t &generation = SEGENV.aux0; //Rename SEGENV/SEGMENT variables for readability
@@ -5216,7 +5216,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
       else if (!overlayBG) SEGMENT.setPixelColorXY(x,y, allColors ? RGBW32(bgColor.r, bgColor.g, bgColor.b, 0) : bgColor); // set background color if not overlaying
     }
     memcpy(futureCells, cells, dataSize); 
-    
+
     //Set CRCs
     uint16_t crc = crc16((const unsigned char*)cells, dataSize);
     *oscillatorCRC = crc;
@@ -5334,7 +5334,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
   }
   // Update CRC values
   if (generation % 16 == 0) *oscillatorCRC = crc;
-  if (generation % *gliderLength == 0) *spaceshipCRC = crc;
+  if (*gliderLength && generation % *gliderLength == 0) *spaceshipCRC = crc;
 
   generation++;
   SEGENV.step = strip.now;

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5316,7 +5316,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
       SEGMENT.setPixelColorXY(x,y, dominantColor);
     }
     else { // blur dead cells 
-      if (!cellValue && !overlayBG && !bgBlendMode) SEGMENT.setPixelColorXY(x,y, color_blend(SEGMENT.getPixelColorXY(x,y), bgColor, bgBlendMode ? bgBlur : blur)); 
+      if (!cellValue && !overlayBG && !bgBlendMode) SEGMENT.setPixelColorXY(x,y, color_blend(SEGMENT.getPixelColorXY(x,y), bgColor, blur)); 
     }
   }
   //update cell values


### PR DESCRIPTION
Fixed memory leak using new. Removed gameoflife struct and reverted back to using pointers to segenv.data (similar to starLeds version). 

Added Blur slider. Blurs dead cells slowly to bgColor depending on slider instead of immediately dying. Doesn't effect game logic.

Removed confusing pauseFrames, uses .step to pause now.

Keeps track of last palette used and immediately recolors cells if new palette/color selected. Can be improved.

Changes gameSpeed slider to be more consistent. Speed = updates/second now in increments of 4.  