### PR TITLE
C6 experiments

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -517,7 +517,7 @@ monitor_filters = esp32_exception_decoder
 ;; ESP32-C6 "devkit M" with 4MB flash
 extends = env:esp32c6dev_8MB
 board = esp32-c6-devkitm-1
-board_build.partitions = ${esp32.default_partitions}
+board_build.partitions = ${esp32.big_partitions}
 build_unflags = ${env:esp32c6dev_8MB.build_unflags} -D WLED_RELEASE_NAME=ESP32-C6_8MB
 build_flags = ${env:esp32c6dev_8MB.build_flags}     -D WLED_RELEASE_NAME=ESP32-C6_4MB 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -242,7 +242,7 @@ upload_speed = 115200
 lib_compat_mode = strict
 lib_deps =
     ;; fastled/FastLED @ 3.6.0
-    https://github.com/netmindz/FastLED.git#ESP32-C6 ;; patched version needed for -C6
+    https://github.com/softhack007/FastLED.git#ESP32-C6 ;; patched version needed for -C6
     IRremoteESP8266 @ 2.8.2
     ;;makuna/NeoPixelBus @ 2.7.5 ;; WLEDMM will be added in board specific sections
     ;;https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.7
@@ -481,9 +481,13 @@ framework = arduino
 board = esp32-c6-devkitc-1
 
 build_unflags = ${common.build_unflags}
+  -D CORE_DEBUG_LEVEL=0
+  -D NDEBUG
 build_flags = ${common.build_flags} ${esp32c6.build_flags} -D WLED_RELEASE_NAME=ESP32-C6_8MB
   -Wno-volatile -Wno-deprecated-declarations ;; silence compiler warnings
   -Wno-cpp                                   ;; silence '#pragma warning' messages
+  -D DEBUG -g3 -ggdb
+  -D CORE_DEBUG_LEVEL=4
   -D WLED_WATCHDOG_TIMEOUT=0
   ;; -DLOLIN_WIFI_FIX ; might be needed on "-C6 mini"
   ;;-DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB

--- a/platformio.ini
+++ b/platformio.ini
@@ -480,6 +480,7 @@ platform = ${esp32c6.platform}
 platform_packages = ${esp32c6.platform_packages}
 framework = arduino
 board = esp32-c6-devkitc-1
+;;build_type = debug
 
 build_unflags = ${common.build_unflags}
   -D CORE_DEBUG_LEVEL=0
@@ -489,6 +490,9 @@ build_flags = ${common.build_flags} ${esp32c6.build_flags} -D WLED_RELEASE_NAME=
   -Wno-cpp                                   ;; silence '#pragma warning' messages
   -D DEBUG -g3 -ggdb
   -D CORE_DEBUG_LEVEL=4
+  -D WLED_DEBUG
+  ;;-D FASTLED_RMT_SERIAL_DEBUG=1
+  -DFASTLED_NO_FASTLED         ;; disables the global "FastLED" object
   -D WLED_WATCHDOG_TIMEOUT=0
   ;; -DLOLIN_WIFI_FIX ; might be needed on "-C6 mini"
   ;;-DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB
@@ -497,6 +501,7 @@ build_flags = ${common.build_flags} ${esp32c6.build_flags} -D WLED_RELEASE_NAME=
   -D WLED_DISABLE_ESPNOW       ;; not sure if this will work
   -D WLED_DISABLE_ALEXA        ;; compile errors
   -D WLED_DISABLE_WEBSOCKETS   ;; not sure if this will work (hacks needed in asyncWebserver)
+  -D LEDPIN=2
 upload_speed = 460800
 lib_deps = ${esp32c6.lib_deps}
 lib_ignore =

--- a/platformio.ini
+++ b/platformio.ini
@@ -463,6 +463,7 @@ build_flags = -g
   -DCONFIG_IDF_TARGET_ESP32C6=1
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -DCO
+  -DFASTLED_NO_FASTLED      ;; disable the global "FastLED" object (avoids crash at startup)
   -DARDUINO_USB_MODE=1 ;; this flag is mandatory for ESP32-C3
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
   ;; ARDUINO_USB_CDC_ON_BOOT
@@ -480,19 +481,17 @@ platform = ${esp32c6.platform}
 platform_packages = ${esp32c6.platform_packages}
 framework = arduino
 board = esp32-c6-devkitc-1
-;; build_type = debug
+;;build_type = debug
 
 build_unflags = ${common.build_unflags}
-  -D CORE_DEBUG_LEVEL=0
-  -D NDEBUG
+  ;; -D CORE_DEBUG_LEVEL=0
+  ;; -D NDEBUG
 build_flags = ${common.build_flags} ${esp32c6.build_flags} -D WLED_RELEASE_NAME=ESP32-C6_8MB
-  ;;-Wno-volatile ;; -Wno-deprecated-declarations ;; silence compiler warnings
-  ;; -Wno-cpp                                   ;; silence '#pragma warning' messages
-  -D DEBUG -g3 -ggdb
-  -D CORE_DEBUG_LEVEL=4
-  -D WLED_DEBUG
-  ;;-D FASTLED_RMT_SERIAL_DEBUG=1
-  -DFASTLED_NO_FASTLED         ;; disables the global "FastLED" object
+  ;; -Wno-volatile ;; -Wno-deprecated-declarations ;; silence compiler warnings
+  ;; -Wno-cpp                                      ;; silence '#pragma warning' messages
+  ;; -D DEBUG -g3 -ggdb
+  ;; -D CORE_DEBUG_LEVEL=4
+  ;; -D WLED_DEBUG
   -D WLED_WATCHDOG_TIMEOUT=0
   ;; -DLOLIN_WIFI_FIX ; might be needed on "-C6 mini"
   ;;-DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB
@@ -500,8 +499,9 @@ build_flags = ${common.build_flags} ${esp32c6.build_flags} -D WLED_RELEASE_NAME=
   -D WLED_DISABLE_INFRARED     ;; library not not compatible with -C6
   -D WLED_DISABLE_ESPNOW       ;; not sure if this will work
   -D WLED_DISABLE_ALEXA        ;; compile errors
-  -D WLED_DISABLE_WEBSOCKETS   ;; not sure if this will work (hacks needed in asyncWebserver)
-  -D LEDPIN=2
+  ;;-D WLED_DISABLE_WEBSOCKETS   ;; not sure if this will work (hacks needed in asyncWebserver)
+  -D BTNPIN=9
+  -D LEDPIN=8
 upload_speed = 460800
 lib_deps = ${esp32c6.lib_deps}
 lib_ignore =

--- a/platformio.ini
+++ b/platformio.ini
@@ -49,6 +49,8 @@
 ; ===================
 
 default_envs = 
+  esp32c6dev_8MB    ;; highly experimental.
+  esp32c6dev_4MB    ;; highly experimental.
   esp32_4MB_S       ;; experimental, optimized for speed
   esp32_4MB_M       ;; esp32 recommended default
   esp32_4MB_M_eth

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,6 +43,7 @@
 ; default_envs = esp32c3dev
 ; default_envs = lolin_s2_mini
 ; default_envs = esp32s3dev_16MB_PSRAM_opi
+; default_envs = esp32c6dev_8MB
 
 ; MoonModules entries
 ; ===================
@@ -238,12 +239,14 @@ upload_speed = 115200
 # ------------------------------------------------------------------------------
 lib_compat_mode = strict
 lib_deps =
-    fastled/FastLED @ 3.6.0
+    ;; fastled/FastLED @ 3.6.0
+    https://github.com/netmindz/FastLED.git#ESP32-C6 ;; patched version needed for -C6
     IRremoteESP8266 @ 2.8.2
     ;;makuna/NeoPixelBus @ 2.7.5 ;; WLEDMM will be added in board specific sections
     ;;https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.7
     ;; https://github.com/lost-hope/ESPAsyncWebServer.git#master  ;; WLEDMM to display .log and .wled files in /edit
-    https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1  ;; newer with bugfixes and stability improvements
+    ;; https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1  ;; newer with bugfixes and stability improvements
+    https://github.com/softhack007/ESPAsyncWebServer.git#ESP32-C6  ;; patched version needed for -C6
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI
   #For compatible OLED display uncomment following
@@ -440,6 +443,72 @@ lib_deps =
   makuna/NeoPixelBus @ 2.7.5
   ;; makuna/NeoPixelBus @ 2.7.9 ;; experimental
   ${env.lib_deps}
+
+
+[esp32c6]
+;; generic definitions for all ESP32-C6 boards
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.06.10/platform-espressif32.zip
+platform_packages = 
+;;platform_packages =
+;;  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.1
+;;  framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.1/esp32-arduino-libs-3.0.1.zip
+
+board = esp32-c6-devkitm-1
+build_flags = -g
+  -DARDUINO_ARCH_ESP32
+  -DARDUINO_ARCH_ESP32C6
+  -DCONFIG_IDF_TARGET_ESP32C6=1
+  -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -DCO
+  -DARDUINO_USB_MODE=1 ;; this flag is mandatory for ESP32-C3
+  ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
+  ;; ARDUINO_USB_CDC_ON_BOOT
+lib_deps =
+  ;;https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
+  https://github.com/softhack007/AsyncTCP.git#ESP32-C6 ;; patched version needed for -C6
+  makuna/NeoPixelBus @ 2.8.0                           ;; latest version neeeded for -C6
+  ${env.lib_deps}
+
+
+[env:esp32c6dev_8MB]
+;; ESP32-C6 "devkit C" with 8MB flash
+extends = esp32c6
+platform = ${esp32c6.platform}
+platform_packages = ${esp32c6.platform_packages}
+framework = arduino
+board = esp32-c6-devkitc-1
+
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags} ${esp32c6.build_flags} -D WLED_RELEASE_NAME=ESP32-C6_8MB
+  -Wno-volatile -Wno-deprecated-declarations ;; silence compiler warnings
+  -Wno-cpp                                   ;; silence '#pragma warning' messages
+  -D WLED_WATCHDOG_TIMEOUT=0
+  ;; -DLOLIN_WIFI_FIX ; might be needed on "-C6 mini"
+  ;;-DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB
+  -DARDUINO_USB_CDC_ON_BOOT=0   ;; for serial-to-USB chip
+  -D WLED_DISABLE_INFRARED     ;; library not not compatible with -C6
+  -D WLED_DISABLE_ESPNOW       ;; not sure if this will work
+  -D WLED_DISABLE_ALEXA        ;; compile errors
+  -D WLED_DISABLE_WEBSOCKETS   ;; not sure if this will work (hacks needed in asyncWebserver)
+upload_speed = 460800
+lib_deps = ${esp32c6.lib_deps}
+lib_ignore =
+  IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
+
+board_build.partitions = ${esp32.large_partitions}
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+board_build.arduino.memory_type = qio_qspi
+monitor_filters = esp32_exception_decoder
+
+[env:esp32c6dev_4MB]
+;; ESP32-C6 "devkit M" with 4MB flash
+extends = env:esp32c6dev_8MB
+board = esp32-c6-devkitm-1
+board_build.partitions = ${esp32.default_partitions}
+build_unflags = ${env:esp32c6dev_8MB.build_unflags} -D WLED_RELEASE_NAME=ESP32-C6_8MB
+build_flags = ${env:esp32c6dev_8MB.build_flags}     -D WLED_RELEASE_NAME=ESP32-C6_4MB 
+
 
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards

--- a/platformio.ini
+++ b/platformio.ini
@@ -450,11 +450,12 @@ lib_deps =
 
 [esp32c6]
 ;; generic definitions for all ESP32-C6 boards
-platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.06.10/platform-espressif32.zip
+;;platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.06.10/platform-espressif32.zip
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.07.11/platform-espressif32.zip
 ;;platform_packages = 
 platform_packages =
-  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.1
-  framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.1/esp32-arduino-libs-3.0.1.zip
+  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.3
+  framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.3/esp32-arduino-libs-3.0.3.zip
 
 board = esp32-c6-devkitm-1
 build_flags = -g
@@ -464,10 +465,11 @@ build_flags = -g
   -DCONFIG_IDF_TARGET_ESP32C6=1
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -DCO
-  -DFASTLED_NO_FASTLED      ;; disable the global "FastLED" object (avoids crash at startup)
+  -DESP32_ARDUINO_NO_RGB_BUILTIN ;; avoids RMT driver abort on startup "E (98) rmt(legacy): CONFLICT! driver_ng is not allowed to be used with the legacy driver"
   -DARDUINO_USB_MODE=1 ;; this flag is mandatory for ESP32-C3
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
   ;; ARDUINO_USB_CDC_ON_BOOT
+  -DFASTLED_NO_FASTLED      ;; disable the global "FastLED" object (avoids crash at startup)
 lib_deps =
   ;;https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   https://github.com/softhack007/AsyncTCP.git#ESP32-C6 ;; patched version needed for -C6
@@ -488,7 +490,7 @@ build_unflags = ${common.build_unflags}
   ;; -D CORE_DEBUG_LEVEL=0
   ;; -D NDEBUG
 build_flags = ${common.build_flags} ${esp32c6.build_flags} -D WLED_RELEASE_NAME=ESP32-C6_8MB
-  ;; -Wno-volatile ;; -Wno-deprecated-declarations ;; silence compiler warnings
+  -Wno-volatile ;; -Wno-deprecated-declarations ;; silence compiler warnings
   ;; -Wno-cpp                                      ;; silence '#pragma warning' messages
   ;; -D DEBUG -g3 -ggdb
   ;; -D CORE_DEBUG_LEVEL=4

--- a/platformio.ini
+++ b/platformio.ini
@@ -457,6 +457,7 @@ platform_packages =
 
 board = esp32-c6-devkitm-1
 build_flags = -g
+  -DESP32
   -DARDUINO_ARCH_ESP32
   -DARDUINO_ARCH_ESP32C6
   -DCONFIG_IDF_TARGET_ESP32C6=1
@@ -504,7 +505,7 @@ lib_ignore =
 board_build.partitions = ${esp32.large_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-board_build.arduino.memory_type = qio_qspi
+;; board_build.arduino.memory_type = qio_qspi
 monitor_filters = esp32_exception_decoder
 
 [env:esp32c6dev_4MB]

--- a/platformio.ini
+++ b/platformio.ini
@@ -486,8 +486,8 @@ build_unflags = ${common.build_unflags}
   -D CORE_DEBUG_LEVEL=0
   -D NDEBUG
 build_flags = ${common.build_flags} ${esp32c6.build_flags} -D WLED_RELEASE_NAME=ESP32-C6_8MB
-  -Wno-volatile -Wno-deprecated-declarations ;; silence compiler warnings
-  -Wno-cpp                                   ;; silence '#pragma warning' messages
+  ;;-Wno-volatile ;; -Wno-deprecated-declarations ;; silence compiler warnings
+  ;; -Wno-cpp                                   ;; silence '#pragma warning' messages
   -D DEBUG -g3 -ggdb
   -D CORE_DEBUG_LEVEL=4
   -D WLED_DEBUG

--- a/platformio.ini
+++ b/platformio.ini
@@ -450,10 +450,10 @@ lib_deps =
 [esp32c6]
 ;; generic definitions for all ESP32-C6 boards
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.06.10/platform-espressif32.zip
-platform_packages = 
-;;platform_packages =
-;;  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.1
-;;  framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.1/esp32-arduino-libs-3.0.1.zip
+;;platform_packages = 
+platform_packages =
+  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.1
+  framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.1/esp32-arduino-libs-3.0.1.zip
 
 board = esp32-c6-devkitm-1
 build_flags = -g
@@ -480,7 +480,7 @@ platform = ${esp32c6.platform}
 platform_packages = ${esp32c6.platform_packages}
 framework = arduino
 board = esp32-c6-devkitc-1
-;;build_type = debug
+;; build_type = debug
 
 build_unflags = ${common.build_unflags}
   -D CORE_DEBUG_LEVEL=0

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7412,7 +7412,7 @@ uint16_t mode_freqmap(void) {                   // Map FFT_MajorPeak to SEGLEN. 
   uint16_t pixCol = (log10f(FFT_MajorPeak) - 1.78f) * 255.0f/(MAX_FREQ_LOG10 - 1.78f);   // Scale log10 of frequency values to the 255 colour index.
   if (FFT_MajorPeak < 61.0f) pixCol = 0;                                                 // handle underflow
 
-#if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6)
   uint16_t bright = (int) (sqrtf(my_magnitude)*16.0f);  // WLEDMM sqrt scaling, to make peaks more prominent
 #else
   uint16_t bright = (int)my_magnitude;

--- a/wled00/NodeStruct.h
+++ b/wled00/NodeStruct.h
@@ -14,6 +14,7 @@
 #define NODE_TYPE_ID_ESP32S2         33
 #define NODE_TYPE_ID_ESP32S3         34
 #define NODE_TYPE_ID_ESP32C3         35
+#define NODE_TYPE_ID_ESP32C6         36
 
 /*********************************************************************************************\
 * NodeStruct

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -231,7 +231,9 @@ BusPwm::BusPwm(BusConfig &bc) : Bus(bc.type, bc.start, bc.autoWhite) {
   uint8_t numPins = NUM_PWM_PINS(bc.type);
   _frequency = bc.frequency ? bc.frequency : WLED_PWM_FREQ;
 
-  #ifdef ESP8266
+#if !defined(CONFIG_IDF_TARGET_ESP32C6)
+
+  #if defined(ESP8266)
   analogWriteRange(255);  //same range as one RGB channel
   analogWriteFreq(_frequency);
   #else
@@ -254,6 +256,7 @@ BusPwm::BusPwm(BusConfig &bc) : Bus(bc.type, bc.start, bc.autoWhite) {
     ledcAttachPin(_pins[i], _ledcStart + i);
     #endif
   }
+#endif
   reversed = bc.reversed;
   _valid = true;
 }
@@ -368,7 +371,9 @@ void BusPwm::deallocatePins() {
     #ifdef ESP8266
     digitalWrite(_pins[i], LOW); //turn off PWM interrupt
     #else
+#if !defined(CONFIG_IDF_TARGET_ESP32C6)
     if (_ledcStart < 16) ledcDetachPin(_pins[i]);
+#endif
     #endif
   }
   #ifdef ARDUINO_ARCH_ESP32

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -10,12 +10,17 @@
 // https://github.com/Makuna/NeoPixelBus/blob/b32f719e95ef3c35c46da5c99538017ef925c026/src/internal/Esp32_i2s.h#L4
 // https://github.com/Makuna/NeoPixelBus/blob/b32f719e95ef3c35c46da5c99538017ef925c026/src/internal/NeoEsp32RmtMethod.h#L857
 
-#if !defined(WLED_NO_I2S0_PIXELBUS) && (defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3))
+#if !defined(WLED_NO_I2S0_PIXELBUS) && (defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6))
 #define WLED_NO_I2S0_PIXELBUS
 #endif
-#if !defined(WLED_NO_I2S1_PIXELBUS) && (defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2))
+#if !defined(WLED_NO_I2S1_PIXELBUS) && (defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32S2))
 #define WLED_NO_I2S1_PIXELBUS
 #endif
+
+#if !defined(WLED_NO_RMT_PIXELBUS) && defined(CONFIG_IDF_TARGET_ESP32C6)  // NPB only supports BitBang on -C6 at the moment
+#define WLED_NO_RMT_PIXELBUS
+#endif
+
 // temporary end
 
 // WLEDMM TroyHacks support - SLOWPATH has priority over TWOPATH
@@ -186,25 +191,37 @@ bool canUseSerial(void);   // WLEDMM (wled_serial.cpp) returns true if Serial ca
 /*** ESP32 Neopixel methods ***/
 #ifdef ARDUINO_ARCH_ESP32
 //RGB
+#if defined(WLED_NO_RMT_PIXELBUS)
+#define B_32_RN_NEO_3 NeoPixelBusLg<NeoGrbFeature, NeoEsp32BitBangWs2812xMethod, NeoGammaNullMethod>
+#else
 #define B_32_RN_NEO_3 NeoPixelBusLg<NeoGrbFeature, NeoEsp32RmtNWs2812xMethod, NeoGammaNullMethod>
+#endif
 #ifndef WLED_NO_I2S0_PIXELBUS
 #define B_32_I0_NEO_3 NeoPixelBusLg<NeoGrbFeature, NeoEsp32I2s0800KbpsMethod, NeoGammaNullMethod>
 #endif
 #ifndef WLED_NO_I2S1_PIXELBUS
 #define B_32_I1_NEO_3 NeoPixelBusLg<NeoGrbFeature, NeoEsp32I2s1800KbpsMethod, NeoGammaNullMethod>
 #endif
-//#define B_32_BB_NEO_3 NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32BitBang800KbpsMethod> // NeoEsp8266BitBang800KbpsMethod
+//#define B_32_BB_NEO_3 NeoPixelBusLg<NeoGrbFeature, NeoEsp32BitBang800KbpsMethod, NeoGammaNullMethod> // NeoEsp8266BitBang800KbpsMethod
 //RGBW
+#if defined(WLED_NO_RMT_PIXELBUS)
+#define B_32_RN_NEO_4 NeoPixelBusLg<NeoGrbwFeature, NeoEsp32BitBangWs2812xMethod, NeoGammaNullMethod>
+#else
 #define B_32_RN_NEO_4 NeoPixelBusLg<NeoGrbwFeature, NeoEsp32RmtNWs2812xMethod, NeoGammaNullMethod>
+#endif
 #ifndef WLED_NO_I2S0_PIXELBUS
 #define B_32_I0_NEO_4 NeoPixelBusLg<NeoGrbwFeature, NeoEsp32I2s0800KbpsMethod, NeoGammaNullMethod>
 #endif
 #ifndef WLED_NO_I2S1_PIXELBUS
 #define B_32_I1_NEO_4 NeoPixelBusLg<NeoGrbwFeature, NeoEsp32I2s1800KbpsMethod, NeoGammaNullMethod>
 #endif
-//#define B_32_BB_NEO_4 NeoPixelBrightnessBus<NeoGrbwFeature, NeoEsp32BitBang800KbpsMethod> // NeoEsp8266BitBang800KbpsMethod
+//#define B_32_BB_NEO_4 NeoPixelBusLg<NeoGrbwFeature, NeoEsp32BitBang800KbpsMethod, NeoGammaNullMethod> // NeoEsp8266BitBang800KbpsMethod
 //400Kbps
+#if defined(WLED_NO_RMT_PIXELBUS)
+#define B_32_RN_400_3 NeoPixelBusLg<NeoGrbFeature, NeoEsp32BitBang400KbpsMethod, NeoGammaNullMethod>
+#else
 #define B_32_RN_400_3 NeoPixelBusLg<NeoGrbFeature, NeoEsp32RmtN400KbpsMethod, NeoGammaNullMethod>
+#endif
 #ifndef WLED_NO_I2S0_PIXELBUS
 #define B_32_I0_400_3 NeoPixelBusLg<NeoGrbFeature, NeoEsp32I2s0400KbpsMethod, NeoGammaNullMethod>
 #endif
@@ -213,7 +230,11 @@ bool canUseSerial(void);   // WLEDMM (wled_serial.cpp) returns true if Serial ca
 #endif
 //#define B_32_BB_400_3 NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32BitBang400KbpsMethod> // NeoEsp8266BitBang400KbpsMethod
 //TM1814 (RGBW)
+#if defined(WLED_NO_RMT_PIXELBUS)
+#define B_32_RN_TM1_4 NeoPixelBusLg<NeoWrgbTm1814Feature, NeoEsp32BitBangTm1814Method, NeoGammaNullMethod>
+#else
 #define B_32_RN_TM1_4 NeoPixelBusLg<NeoWrgbTm1814Feature, NeoEsp32RmtNTm1814Method, NeoGammaNullMethod>
+#endif
 #ifndef WLED_NO_I2S0_PIXELBUS
 #define B_32_I0_TM1_4 NeoPixelBusLg<NeoWrgbTm1814Feature, NeoEsp32I2s0Tm1814Method, NeoGammaNullMethod>
 #endif
@@ -222,7 +243,11 @@ bool canUseSerial(void);   // WLEDMM (wled_serial.cpp) returns true if Serial ca
 #endif
 //Bit Bang theoratically possible, but very undesirable and not needed (no pin restrictions on RMT and I2S)
 //TM1829 (RGB)
+#if defined(WLED_NO_RMT_PIXELBUS)
+#define B_32_RN_TM2_3 NeoPixelBusLg<NeoBrgFeature, NeoEsp32BitBangTm1829Method, NeoGammaNullMethod>
+#else
 #define B_32_RN_TM2_3 NeoPixelBusLg<NeoBrgFeature, NeoEsp32RmtNTm1829Method, NeoGammaNullMethod>
+#endif
 #ifndef WLED_NO_I2S0_PIXELBUS
 #define B_32_I0_TM2_3 NeoPixelBusLg<NeoBrgFeature, NeoEsp32I2s0Tm1829Method, NeoGammaNullMethod>
 #endif
@@ -231,7 +256,11 @@ bool canUseSerial(void);   // WLEDMM (wled_serial.cpp) returns true if Serial ca
 #endif
 //Bit Bang theoratically possible, but very undesirable and not needed (no pin restrictions on RMT and I2S)
 //UCS8903
+#if defined(WLED_NO_RMT_PIXELBUS)
+#define B_32_RN_UCS_3 NeoPixelBusLg<NeoRgbUcs8903Feature, NeoEsp32BitBangWs2812xMethod, NeoGammaNullMethod>
+#else
 #define B_32_RN_UCS_3 NeoPixelBusLg<NeoRgbUcs8903Feature, NeoEsp32RmtNWs2812xMethod, NeoGammaNullMethod>
+#endif
 #ifndef WLED_NO_I2S0_PIXELBUS
 #define B_32_I0_UCS_3 NeoPixelBusLg<NeoRgbUcs8903Feature, NeoEsp32I2s0800KbpsMethod, NeoGammaNullMethod>
 #endif
@@ -240,7 +269,11 @@ bool canUseSerial(void);   // WLEDMM (wled_serial.cpp) returns true if Serial ca
 #endif
 //Bit Bang theoratically possible, but very undesirable and not needed (no pin restrictions on RMT and I2S)
 //UCS8904
+#if defined(WLED_NO_RMT_PIXELBUS)
+#define B_32_RN_UCS_4 NeoPixelBusLg<NeoRgbwUcs8904Feature, NeoEsp32BitBangWs2812xMethod, NeoGammaNullMethod>
+#else
 #define B_32_RN_UCS_4 NeoPixelBusLg<NeoRgbwUcs8904Feature, NeoEsp32RmtNWs2812xMethod, NeoGammaNullMethod>
+#endif
 #ifndef WLED_NO_I2S0_PIXELBUS
 #define B_32_I0_UCS_4 NeoPixelBusLg<NeoRgbwUcs8904Feature, NeoEsp32I2s0800KbpsMethod, NeoGammaNullMethod>
 #endif
@@ -456,7 +489,11 @@ class PolyBus {
       case I_8266_BB_UCS_4: busPtr = new B_8266_BB_UCS_4(len, pins[0]); break;
     #endif
     #ifdef ARDUINO_ARCH_ESP32
+#if defined(WLED_NO_RMT_PIXELBUS)
+      case I_32_RN_NEO_3: busPtr = new B_32_RN_NEO_3(len, pins[0]); USER_PRINT("(BitBang) "); break;
+#else
       case I_32_RN_NEO_3: busPtr = new B_32_RN_NEO_3(len, pins[0], (NeoBusChannel)channel); USER_PRINTF("(RMT #%u) ", channel); break;
+#endif
       #ifndef WLED_NO_I2S0_PIXELBUS
       case I_32_I0_NEO_3: busPtr = new B_32_I0_NEO_3(len, pins[0]); USER_PRINT("(I2S #0) "); break;
       #endif
@@ -464,7 +501,11 @@ class PolyBus {
       case I_32_I1_NEO_3: busPtr = new B_32_I1_NEO_3(len, pins[0]); USER_PRINT("(I2S #1) "); break;
       #endif
 //      case I_32_BB_NEO_3: busPtr = new B_32_BB_NEO_3(len, pins[0], (NeoBusChannel)channel); break;
+#if defined(WLED_NO_RMT_PIXELBUS)
+      case I_32_RN_NEO_4: busPtr = new B_32_RN_NEO_4(len, pins[0]); USER_PRINT("(RGBW BitBang) "); break;
+#else
       case I_32_RN_NEO_4: busPtr = new B_32_RN_NEO_4(len, pins[0], (NeoBusChannel)channel); USER_PRINTF("(RGBW RMT #%u) ", channel); break;
+#endif
       #ifndef WLED_NO_I2S0_PIXELBUS
       case I_32_I0_NEO_4: busPtr = new B_32_I0_NEO_4(len, pins[0]); USER_PRINT("(RGBW I2S #0) "); break;
       #endif
@@ -472,7 +513,11 @@ class PolyBus {
       case I_32_I1_NEO_4: busPtr = new B_32_I1_NEO_4(len, pins[0]); USER_PRINT("(RGBW I2S #1) "); break;
       #endif
 //      case I_32_BB_NEO_4: busPtr = new B_32_BB_NEO_4(len, pins[0], (NeoBusChannel)channel); break;
+#if defined(WLED_NO_RMT_PIXELBUS)
+      case I_32_RN_400_3: busPtr = new B_32_RN_400_3(len, pins[0]); break;
+#else
       case I_32_RN_400_3: busPtr = new B_32_RN_400_3(len, pins[0], (NeoBusChannel)channel); break;
+#endif
       #ifndef WLED_NO_I2S0_PIXELBUS
       case I_32_I0_400_3: busPtr = new B_32_I0_400_3(len, pins[0]); break;
       #endif
@@ -480,8 +525,13 @@ class PolyBus {
       case I_32_I1_400_3: busPtr = new B_32_I1_400_3(len, pins[0]); break;
       #endif
 //      case I_32_BB_400_3: busPtr = new B_32_BB_400_3(len, pins[0], (NeoBusChannel)channel); break;
+#if defined(WLED_NO_RMT_PIXELBUS)
+      case I_32_RN_TM1_4: busPtr = new B_32_RN_TM1_4(len, pins[0]); break;
+      case I_32_RN_TM2_3: busPtr = new B_32_RN_TM2_3(len, pins[0]); break;
+#else
       case I_32_RN_TM1_4: busPtr = new B_32_RN_TM1_4(len, pins[0], (NeoBusChannel)channel); break;
       case I_32_RN_TM2_3: busPtr = new B_32_RN_TM2_3(len, pins[0], (NeoBusChannel)channel); break;
+#endif
       #ifndef WLED_NO_I2S0_PIXELBUS
       case I_32_I0_TM1_4: busPtr = new B_32_I0_TM1_4(len, pins[0]); break;
       case I_32_I0_TM2_3: busPtr = new B_32_I0_TM2_3(len, pins[0]); break;
@@ -490,7 +540,11 @@ class PolyBus {
       case I_32_I1_TM1_4: busPtr = new B_32_I1_TM1_4(len, pins[0]); break;
       case I_32_I1_TM2_3: busPtr = new B_32_I1_TM2_3(len, pins[0]); break;
       #endif
+#if defined(WLED_NO_RMT_PIXELBUS)
+      case I_32_RN_UCS_3: busPtr = new B_32_RN_UCS_3(len, pins[0]); break;
+#else
       case I_32_RN_UCS_3: busPtr = new B_32_RN_UCS_3(len, pins[0], (NeoBusChannel)channel); break;
+#endif
       #ifndef WLED_NO_I2S0_PIXELBUS
       case I_32_I0_UCS_3: busPtr = new B_32_I0_UCS_3(len, pins[0]); break;
       #endif
@@ -498,7 +552,11 @@ class PolyBus {
       case I_32_I1_UCS_3: busPtr = new B_32_I1_UCS_3(len, pins[0]); break;
       #endif
 //      case I_32_BB_UCS_3: busPtr = new B_32_BB_UCS_3(len, pins[0], (NeoBusChannel)channel); break;
+#if defined(WLED_NO_RMT_PIXELBUS)
+      case I_32_RN_UCS_4: busPtr = new B_32_RN_UCS_4(len, pins[0]); break;
+#else
       case I_32_RN_UCS_4: busPtr = new B_32_RN_UCS_4(len, pins[0], (NeoBusChannel)channel); break;
+#endif
       #ifndef WLED_NO_I2S0_PIXELBUS
       case I_32_I0_UCS_4: busPtr = new B_32_I0_UCS_4(len, pins[0]); break;
       #endif
@@ -1203,6 +1261,11 @@ class PolyBus {
       if (num > 3) offset = 1;  // only one I2S
       #elif defined(CONFIG_IDF_TARGET_ESP32C3)
       // On ESP32-C3 only the first 2 RMT channels are usable for transmitting
+      if (num > 1) return I_NONE;
+      //if (num > 1) offset = 1; // I2S not supported yet (only 1 I2S)
+      #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+      // toDo: double-check everything is the same -C3
+      // On ESP32-C6 only the first 2 RMT channels are usable for transmitting
       if (num > 1) return I_NONE;
       //if (num > 1) offset = 1; // I2S not supported yet (only 1 I2S)
       #elif defined(CONFIG_IDF_TARGET_ESP32S3)

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -97,7 +97,7 @@ bool isButtonPressed(uint8_t i)
       if (digitalRead(pin) == HIGH) return true;
       break;
     case BTN_TYPE_TOUCH:
-      #if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+      #if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6)
       if (touchRead(pin) <= touchThreshold) return true;
       #endif
       break;

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -28,7 +28,8 @@
     #define WLED_MAX_BUSSES 3
     #define WLED_MIN_VIRTUAL_BUSSES 2
   #else
-    #if defined(CONFIG_IDF_TARGET_ESP32C3)    // 2 RMT, 6 LEDC, only has 1 I2S but NPB does not support it ATM
+    #if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)  // C6 is very similar to C3
+                                              // 2 RMT, 6 LEDC, only has 1 I2S but NPB does not support it ATM
       #define WLED_MAX_BUSSES 3               // will allow 2 digital & 1 analog (or the other way around)
       #define WLED_MIN_VIRTUAL_BUSSES 3
     #elif defined(CONFIG_IDF_TARGET_ESP32S2)  // 4 RMT, 8 LEDC, only has 1 I2S bus, supported in NPB
@@ -393,7 +394,7 @@
   #ifdef ESP8266
     #define MAX_LED_MEMORY 4000
   #else
-    #if defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32C3)
+    #if defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32C3) || defined(ARDUINO_ARCH_ESP32C6)
       #define MAX_LED_MEMORY 32000
     #else
       #define MAX_LED_MEMORY 64000
@@ -534,6 +535,10 @@
   #define IRAM_ATTR_YN IRAM_ATTR
 #else
   #define IRAM_ATTR_YN
+#endif
+
+#if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#define pcTaskGetTaskName pcTaskGetName
 #endif
 
 #endif

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -537,8 +537,10 @@
   #define IRAM_ATTR_YN
 #endif
 
+#ifdef ARDUINO_ARCH_ESP32
 #if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #define pcTaskGetTaskName pcTaskGetName
+#endif
 #endif
 
 #endif

--- a/wled00/improv.cpp
+++ b/wled00/improv.cpp
@@ -10,7 +10,7 @@
   #define DIMPROV_PRINTF(x...)
 #endif
 
-#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S3)
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32S3)
 #undef WLED_DISABLE_IMPROV_WIFISCAN
 #define WLED_DISABLE_IMPROV_WIFISCAN
 #endif
@@ -199,6 +199,8 @@ void sendImprovInfoResponse() {
       "esp8266"
     #elif CONFIG_IDF_TARGET_ESP32C3
       "esp32-c3"
+    #elif CONFIG_IDF_TARGET_ESP32C6
+      "esp32-c6"
     #elif CONFIG_IDF_TARGET_ESP32S2
       "esp32-s2"
     #elif CONFIG_IDF_TARGET_ESP32S3

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -131,7 +131,9 @@ String PinManagerClass::getPinSpecialText(int gpio) {  // special purpose PIN in
       // ESP32-C3
       if (gpio > 17 && gpio < 20) return (F("USB (CDC) / JTAG"));
       //if (gpio == 2 || gpio == 8 || gpio == 9) return (F("(strapping pin)"));
-
+    #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+      // ESP32-C6
+      if (gpio > 11 && gpio < 14) return (F("USB (CDC) / JTAG"));
     #else
       // "classic" ESP32, or ESP32 PICO-D4
       //if (gpio == 0 || gpio == 2 || gpio == 5) return (F("(strapping pin)"));
@@ -261,7 +263,7 @@ String PinManagerClass::getPinSpecialText(int gpio) {  // special purpose PIN in
   // ADC PINs - not for 8266
   if (digitalPinToAnalogChannel(gpio) >= 0) {  // ADC pin
   #ifdef SOC_ADC_CHANNEL_NUM
-    if (digitalPinToAnalogChannel(gpio) < SOC_ADC_CHANNEL_NUM(0)) return(F("ADC-1")); // for ESP32-S3, ESP32-S2, ESP32-C3 
+    if (digitalPinToAnalogChannel(gpio) < SOC_ADC_CHANNEL_NUM(0)) return(F("ADC-1")); // for ESP32-S3, ESP32-S2, ESP32-C3 , ESP32-C6
   #else
     if (digitalPinToAnalogChannel(gpio) < 8) return(F("ADC-1"));   // for classic ESP32
   #endif
@@ -654,7 +656,7 @@ bool PinManagerClass::joinWire(int8_t pinSDA, int8_t pinSCL) {
       if (gpio == A0) return true;   // for 8266
     #else                            // for ESP32 variants
       #ifdef SOC_ADC_CHANNEL_NUM
-        if (digitalPinToAnalogChannel(gpio) < SOC_ADC_CHANNEL_NUM(0)) return true; // ADC1 on ESP32-S3, ESP32-S2, ESP32-C3 
+        if (digitalPinToAnalogChannel(gpio) < SOC_ADC_CHANNEL_NUM(0)) return true; // ADC1 on ESP32-S3, ESP32-S2, ESP32-C3, ESP32-C6
       #else
         if (digitalPinToAnalogChannel(gpio) < 8) return true;   // ADC1 on classic ESP32
       #endif
@@ -685,7 +687,7 @@ bool PinManagerClass::joinWire(int8_t pinSDA, int8_t pinSCL) {
     #else                                                   // for ESP32 variants
       if ((adcUnit != ADC1) && (adcUnit != ADC2)) return(PM_NO_PIN); // catch errors
 
-      #if defined(SOC_ADC_MAX_CHANNEL_NUM)                                   // for ESP32-S3, ESP32-S2, ESP32-C3
+      #if defined(SOC_ADC_MAX_CHANNEL_NUM)                                   // for ESP32-S3, ESP32-S2, ESP32-C3, ESP32-C6
       int8_t analogChannel = (adcUnit == ADC1) ? adcPort : (SOC_ADC_MAX_CHANNEL_NUM + adcPort);
       if (adcPort >= SOC_ADC_MAX_CHANNEL_NUM) analogChannel = 255;
       #else                                                                  // for classic ESP32
@@ -731,6 +733,11 @@ bool PinManagerClass::isPinOk(byte gpio, bool output)
     // strapping pins: 2, 8, & 9
     if (gpio > 11 && gpio < 18) return false;     // 11-17 SPI FLASH
     if (gpio > 17 && gpio < 20) return false;     // 18-19 USB-JTAG
+  #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    // https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-reference/peripherals/gpio.html
+    // strapping pins: 4, 5, 8, 9
+    if (gpio > 11 && gpio < 14) return false;     // 12-13 USB-JTAG
+    if (gpio > 23 && gpio < 31) return false;     // 24-30 SPI FLASH
   #elif defined(CONFIG_IDF_TARGET_ESP32S3)
     // 00 to 18 are for general use. Be careful about straping pins GPIO0 and GPIO3 - these may be pulled-up or pulled-down on your board.
     if (gpio > 18 && gpio < 21) return false;     // 19 + 20 = USB-JTAG. Not recommended for other uses.
@@ -764,7 +771,7 @@ PinOwner PinManagerClass::getPinOwner(byte gpio) {
 }
 
 #ifdef ARDUINO_ARCH_ESP32
-#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
   #define MAX_LED_CHANNELS 6
 #else
   #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -3,6 +3,15 @@
 /*
  * Registers pins so there is no attempt for two interfaces to use the same pin
  */
+
+#ifdef ARDUINO_ARCH_ESP32
+// get prototypes for GPIO_IS_VALID_GPIO and GPIO_IS_VALID_OUTPUT_GPIO
+extern "C" {
+#include "esp32-hal.h"
+#include "driver/gpio.h"
+}
+#endif
+
 #include <Arduino.h>
 #include "const.h" // for USERMOD_* values
 

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -17,7 +17,7 @@ Distributed as-is; no warranty is given.
 #if defined(ARDUINO_ARCH_ESP32)
 
 #include <Arduino.h>
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)  && !defined(CONFIG_IDF_TARGET_ESP32S2)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(CONFIG_IDF_TARGET_ESP32S2)
 
 #include "SparkFunDMX.h"
 #include <HardwareSerial.h>

--- a/wled00/src/dependencies/e131/ESPAsyncE131.cpp
+++ b/wled00/src/dependencies/e131/ESPAsyncE131.cpp
@@ -21,6 +21,10 @@
 #include "../network/Network.h"
 #include <string.h>
 
+#if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#define Network WL_Network
+#endif
+
 // E1.17 ACN Packet Identifier
 const byte ESPAsyncE131::ACN_ID[12] = { 0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 0x37, 0x00, 0x00, 0x00 };
 

--- a/wled00/src/dependencies/e131/ESPAsyncE131.cpp
+++ b/wled00/src/dependencies/e131/ESPAsyncE131.cpp
@@ -21,8 +21,10 @@
 #include "../network/Network.h"
 #include <string.h>
 
+#ifdef ARDUINO_ARCH_ESP32
 #if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #define Network WL_Network
+#endif
 #endif
 
 // E1.17 ACN Packet Identifier

--- a/wled00/src/dependencies/network/Network.cpp
+++ b/wled00/src/dependencies/network/Network.cpp
@@ -1,5 +1,9 @@
 #include "Network.h"
 
+#if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+//#define NetworkClass NetworkManager
+#endif
+
 IPAddress NetworkClass::localIP()
 {
   IPAddress localIP;
@@ -88,4 +92,4 @@ bool NetworkClass::isEthernet()
   return false;
 }
 
-NetworkClass Network;
+NetworkClass WL_Network;

--- a/wled00/src/dependencies/network/Network.cpp
+++ b/wled00/src/dependencies/network/Network.cpp
@@ -1,9 +1,5 @@
 #include "Network.h"
 
-#if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-//#define NetworkClass NetworkManager
-#endif
-
 IPAddress NetworkClass::localIP()
 {
   IPAddress localIP;
@@ -92,8 +88,12 @@ bool NetworkClass::isEthernet()
   return false;
 }
 
+#ifdef ARDUINO_ARCH_ESP32
 #if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 NetworkClass WL_Network;
+#else
+NetworkClass Network;
+#endif
 #else
 NetworkClass Network;
 #endif

--- a/wled00/src/dependencies/network/Network.cpp
+++ b/wled00/src/dependencies/network/Network.cpp
@@ -92,4 +92,8 @@ bool NetworkClass::isEthernet()
   return false;
 }
 
+#if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 NetworkClass WL_Network;
+#else
+NetworkClass Network;
+#endif

--- a/wled00/src/dependencies/network/Network.h
+++ b/wled00/src/dependencies/network/Network.h
@@ -19,8 +19,12 @@ public:
   bool isEthernet();
 };
 
+#ifdef ARDUINO_ARCH_ESP32
 #if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 extern NetworkClass WL_Network;
+#else
+extern NetworkClass Network;
+#endif
 #else
 extern NetworkClass Network;
 #endif

--- a/wled00/src/dependencies/network/Network.h
+++ b/wled00/src/dependencies/network/Network.h
@@ -19,6 +19,10 @@ public:
   bool isEthernet();
 };
 
+#if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+extern NetworkClass WL_Network;
+#else
 extern NetworkClass Network;
+#endif
 
 #endif

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -703,6 +703,8 @@ void sendSysInfoUDP()
   data[38] = NODE_TYPE_ID_ESP8266;
   #elif defined(CONFIG_IDF_TARGET_ESP32C3)
   data[38] = NODE_TYPE_ID_ESP32C3;
+  #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+  data[38] = NODE_TYPE_ID_ESP32C6;
   #elif defined(CONFIG_IDF_TARGET_ESP32S3)
   data[38] = NODE_TYPE_ID_ESP32S3;
   #elif defined(CONFIG_IDF_TARGET_ESP32S2)

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -10,7 +10,7 @@
 #include "soc/rtc_cntl_reg.h"
 #endif
 
-#if defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32)
+#if defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C6)
 #include "../tools/ESP32-Chip_info.hpp"
 #endif
 
@@ -542,7 +542,7 @@ void WLED::setup()
   #endif
   USER_PRINT(F(", speed ")); USER_PRINT(ESP.getFlashChipSpeed()/1000000);USER_PRINTLN(F("MHz."));
   
-  #if defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32)
+  #if defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C6)
   showRealSpeed();
   #endif
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -35,7 +35,7 @@
     #error please fix your build environment. only one CONFIG_IDF_TARGET may be defined
   #endif
   // make sure we have a supported CONFIG_IDF_TARGET_
-  #if !defined(CONFIG_IDF_TARGET_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
+  #if !defined(CONFIG_IDF_TARGET_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)  && !defined(CONFIG_IDF_TARGET_ESP32C6)
     #error please fix your build environment. No supported CONFIG_IDF_TARGET was defined
   #endif
   #if CONFIG_IDF_TARGET_ESP32_SOLO || CONFIG_IDF_TARGET_ESP32SOLO
@@ -902,7 +902,7 @@ void WLED::initAP(bool resetAP)
   USER_PRINTLN(apSSID);                    // WLEDMM
   WiFi.softAPConfig(IPAddress(4, 3, 2, 1), IPAddress(4, 3, 2, 1), IPAddress(255, 255, 255, 0));
   WiFi.softAP(apSSID, apPass, apChannel, apHide, 8); // WLED-MM allow up to 8 clients for ad-hoc "in the field" syncing.
-  #if defined(LOLIN_WIFI_FIX) && (defined(ARDUINO_ARCH_ESP32C3) || defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32S3))
+  #if defined(LOLIN_WIFI_FIX) && (defined(ARDUINO_ARCH_ESP32C3) || defined(ARDUINO_ARCH_ESP32C6) || defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32S3))
   WiFi.setTxPower(WIFI_POWER_8_5dBm);
   #endif
 
@@ -1090,7 +1090,7 @@ void WLED::initConnection()
 
   WiFi.begin(clientSSID, clientPass);
 #ifdef ARDUINO_ARCH_ESP32
-  #if defined(LOLIN_WIFI_FIX) && (defined(ARDUINO_ARCH_ESP32C3) || defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32S3))
+  #if defined(LOLIN_WIFI_FIX) && (defined(ARDUINO_ARCH_ESP32C3) || defined(ARDUINO_ARCH_ESP32C6) || defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32S3))
   WiFi.setTxPower(WIFI_POWER_8_5dBm);
   #endif
   WiFi.setSleep(!noWifiSleep);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -13,6 +13,15 @@
 // WLEDMM  - you can check for this define in usermods, to only enabled WLEDMM specific code in the "right" fork. Its not defined in AC WLED.
 #define _MoonModules_WLED_
 
+// a few hacks
+#if !defined(ARDUINO_ARCH_ESP32)
+#undef ESP_IDF_VERSION
+#endif
+#if !defined(ESP_IDF_VERSION) && !defined(ESP_IDF_VERSION_VAL)
+#undef ESP_IDF_VERSION
+#define ESP_IDF_VERSION_VAL(a,b,c) 99999999 // dummy
+#endif
+
 //WLEDMM + Moustachauve/Wled-Native 
 // You can define custom product info from build flags.
 // This is useful to allow API consumer to identify what type of WLED version

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -16,10 +16,9 @@
 // a few hacks
 #if !defined(ARDUINO_ARCH_ESP32)
 #undef ESP_IDF_VERSION
-#endif
-#if !defined(ESP_IDF_VERSION) && !defined(ESP_IDF_VERSION_VAL)
-#undef ESP_IDF_VERSION
+#if !defined(ESP_IDF_VERSION_VAL)
 #define ESP_IDF_VERSION_VAL(a,b,c) 99999999 // dummy
+#endif
 #endif
 
 //WLEDMM + Moustachauve/Wled-Native 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -128,6 +128,9 @@
 #include <SPI.h>
 
 #include "src/dependencies/network/Network.h"
+#if defined(ESP_IDF_VERSION) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#define Network WL_Network
+#endif
 
 #ifdef WLED_USE_MY_CONFIG
   #include "my_config.h"
@@ -327,7 +330,7 @@ WLED_GLOBAL int8_t irPin _INIT(-1);
 WLED_GLOBAL int8_t irPin _INIT(IRPIN);
 #endif
 
-#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2) || (defined(RX) && defined(TX))
+#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) ||  defined(CONFIG_IDF_TARGET_ESP32C6) ||defined(CONFIG_IDF_TARGET_ESP32S2) || (defined(RX) && defined(TX))
   // use RX/TX as set by the framework - these boards do _not_ have RX=3 and TX=1
   constexpr uint8_t hardwareRX = RX;
   constexpr uint8_t hardwareTX = TX;

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -73,8 +73,8 @@ void sendBytes(){
 }
 
 bool canUseSerial(void) {   // WLEDMM returns true if Serial can be used for debug output (i.e. not configured for other purpose)
-  #if defined(CONFIG_IDF_TARGET_ESP32C3) && ARDUINO_USB_CDC_ON_BOOT && !defined(WLED_DEBUG_HOST)
-  //  on -C3, USB CDC blocks if disconnected! so check if Serial is active before printing to it.
+  #if ARDUINO_USB_CDC_ON_BOOT && !defined(WLED_DEBUG_HOST)
+  //  USB CDC blocks if disconnected! so check if Serial is active before printing to it.
   if (!Serial) return false;
   #endif
   if (pinManager.isPinAllocated(hardwareTX) && (pinManager.getPinOwner(hardwareTX) != PinOwner::DebugOut)) 

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -850,6 +850,8 @@ void getSettingsJS(AsyncWebServerRequest* request, byte subPage, char* dest) //W
     oappend(SET_F(".bin<br>("));
     #if defined(CONFIG_IDF_TARGET_ESP32C3)
     oappend(SET_F("ESP32-C3"));
+    #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    oappend(SET_F("ESP32-C6"));
     #elif defined(CONFIG_IDF_TARGET_ESP32S3)
     oappend(SET_F("ESP32-S3"));
     #elif defined(CONFIG_IDF_TARGET_ESP32S2)


### PR DESCRIPTION
This is a first, very experimental support for the ESP32-C6 chip.  It compiles, but nothing tested on the hardware yet.

Its intended for WLED/MM core developers, to understand better where the differences are.
If you don't consider yourself a "core developer", then please ignore this PR and do something meaningful 😛

⚠️  no PWM support yet - so you can't use analog LEDs
⚠️  NeoPixelBus drivers are running in "BitBang" mode, so don't attach more than just a handful of addressable LEDs.
⚠️ Audioreadctive not supported yet, due to massive changes in I2S API

Currently some libraries are not compiling with Arduino Core 3.0.x, so i've forked these and made a few minimal patches to allow compiling. Also I had to make a "no FastLED" version of FastLED, because the clockless RMT driver of fastLED is causing crashes at startup - even when all outputs are managed by NeoPixelBus -> `E (423) rmt(legacy): CONFLICT! driver_ng is not allowed to be used with the legacy driver`.

