### PR TITLE
Full audio fastpath (part2)

### DIFF
--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -704,6 +704,10 @@ void FFTcode(void * parameter)
             FFT.windowing( FFTWindow::Nuttall, FFTDirection::Forward);
             wc = 0.9916873881f;     // 2.8163172034 * 2.0
           break;
+          case 5:
+            FFT.windowing( FFTWindow::Blackman, FFTDirection::Forward);
+            wc = 0.84762867875f;     // 2.3673474360 * 2.0
+          break;
           case 3:
             FFT.windowing( FFTWindow::Hamming, FFTDirection::Forward);
             wc = 0.664159180663f;   // 1.8549343278 * 2.0
@@ -2975,6 +2979,7 @@ class AudioReactive : public Usermod {
       oappend(SET_F("addOption(dd,'Blackman-Harris (MM standard)',0);"));
       oappend(SET_F("addOption(dd,'Hann (balanced)',1);"));
       oappend(SET_F("addOption(dd,'Nuttall (more accurate)',2);"));
+      oappend(SET_F("addOption(dd,'Blackman',5);"));
       oappend(SET_F("addOption(dd,'Hamming',3);"));
       oappend(SET_F("addOption(dd,'Flat-Top (AC WLED, inaccurate)',4);"));
 

--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -861,7 +861,11 @@ void FFTcode(void * parameter)
     // post-processing of frequency channels (pink noise adjustment, AGC, smoothing, scaling)
     if (pinkIndex > MAX_PINK) pinkIndex = MAX_PINK;
 
+#ifdef FFT_USE_SLIDING_WINDOW
     postProcessFFTResults((fabsf(volumeSmth) > 0.25f)? true : false, NUM_GEQ_CHANNELS, usingOldSamples);    // this function modifies fftCalc, fftAvg and fftResult
+#else
+    postProcessFFTResults((fabsf(volumeSmth) > 0.25f)? true : false, NUM_GEQ_CHANNELS, false);    // this function modifies fftCalc, fftAvg and fftResult
+#endif
 
 #if defined(WLED_DEBUG) || defined(SR_DEBUG)|| defined(SR_STATS)
     // timing


### PR DESCRIPTION
This PR allows the audio core to deliver sound data and FFT results 2x faster (43 sps --> 87 sps).

The concept behind this PR is called "sliding window FFT" (aka [50% overlapping FFT](https://en.m.wikipedia.org/w/index.php?title=Welch%27s_method#Definition_and_procedure )). In normal FFT a full batch of samples is first read then analyzed. With sliding window, 50% old samples and 50% new samples are put into each FFT run. This leads to faster responses (new samples arrive twice as fast) and improved accuracy of FFT ([samples suppressed by windowing](https://en.m.wikipedia.org/wiki/Window_function) get a second chance in the next run). It also requires twice the number of FFT runs, so you'll need a fast MCU.

* Frequency reactive effects (GEQ, FreqMap, DJLight) will have improved "on-spot" reactions, and will typically react to audio changes within 10-20 milliseconds.
* Volume reactive effect will react a bit better (but still lagging behind, due to legacy filtering design that was created when only low-quality analog mics were available).


## Limitations
* only works on esp32-S3 and classic esp32, due to higher CPU load for FFT
* Will not work well with analog microphone
* UDP sound sync clients might get "flooded" (twice the number of audio updates need to be handled) 

## how to configure

![image](https://github.com/MoonModules/WLED/assets/91616163/571ba2a9-d3a1-403a-9893-4fbc8adef01e)


### Info Page (with SR_STATS enabled)

Normal mode 
![image](https://github.com/MoonModules/WLED/assets/91616163/eb4507ca-c31f-4be2-bb14-c936dc05828f)


== > Fastpath Mode ==> 
![image](https://github.com/MoonModules/WLED/assets/91616163/aa88252b-a01f-4da8-b57a-18659d3badbd)


