### PR TITLE
ESP32 Dual Booting

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -505,7 +505,7 @@ void WLED::setup()
   #endif
   #ifdef ARDUINO_ARCH_ESP32
   const esp_partition_t *running_partition = esp_ota_get_running_partition();
-  USER_PRINTF("Running from: %s which is %u bytes and type %u subtype %u at address %x\n",boot_partition->label,boot_partition->size,boot_partition->type,boot_partition->subtype,boot_partition->address);
+  USER_PRINTF("Running from: %s which is %u bytes and type %u subtype %u at address %x\n",running_partition->label,running_partition->size,running_partition->type,running_partition->subtype,running_partition->address);
   #endif
 #ifdef ARDUINO_ARCH_ESP32
   DEBUG_PRINT(F("esp32 "));

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -503,8 +503,10 @@ void WLED::setup()
   #ifdef WLED_RELEASE_NAME
   USER_PRINTF(" WLEDMM_%s %s, build %s.\n", versionString, releaseString, TOSTRING(VERSION)); // WLEDMM specific
   #endif
+  #ifdef ARDUINO_ARCH_ESP32
   const esp_partition_t *boot_partition = esp_ota_get_running_partition();
   USER_PRINTF("Booted from: %s which is %u bytes and type %u subtype %u at address %x\n",boot_partition->label,boot_partition->size,boot_partition->type,boot_partition->subtype,boot_partition->address);
+  #endif
 #ifdef ARDUINO_ARCH_ESP32
   DEBUG_PRINT(F("esp32 "));
   DEBUG_PRINTLN(ESP.getSdkVersion());

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -2,7 +2,7 @@
 #include "wled.h"
 #include "wled_ethernet.h"
 #include <Arduino.h>
-
+#include "esp_ota_ops.h"
 #warning WLED-MM GPL-v3. By installing WLED MM you implicitly accept the terms!
 
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)
@@ -501,7 +501,8 @@ void WLED::setup()
   #ifdef WLED_RELEASE_NAME
   USER_PRINTF(" WLEDMM_%s %s, build %s.\n", versionString, releaseString, TOSTRING(VERSION)); // WLEDMM specific
   #endif
-
+  const esp_partition_t *boot_partition = esp_ota_get_running_partition();
+  USER_PRINTF("Booted from: %s which is %u bytes and type %u subtype %u at address %x\n",boot_partition->label,boot_partition->size,boot_partition->type,boot_partition->subtype,boot_partition->address);
 #ifdef ARDUINO_ARCH_ESP32
   DEBUG_PRINT(F("esp32 "));
   DEBUG_PRINTLN(ESP.getSdkVersion());

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -504,8 +504,8 @@ void WLED::setup()
   USER_PRINTF(" WLEDMM_%s %s, build %s.\n", versionString, releaseString, TOSTRING(VERSION)); // WLEDMM specific
   #endif
   #ifdef ARDUINO_ARCH_ESP32
-  const esp_partition_t *boot_partition = esp_ota_get_running_partition();
-  USER_PRINTF("Booted from: %s which is %u bytes and type %u subtype %u at address %x\n",boot_partition->label,boot_partition->size,boot_partition->type,boot_partition->subtype,boot_partition->address);
+  const esp_partition_t *running_partition = esp_ota_get_running_partition();
+  USER_PRINTF("Running from: %s which is %u bytes and type %u subtype %u at address %x\n",boot_partition->label,boot_partition->size,boot_partition->type,boot_partition->subtype,boot_partition->address);
   #endif
 #ifdef ARDUINO_ARCH_ESP32
   DEBUG_PRINT(F("esp32 "));

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -2,7 +2,9 @@
 #include "wled.h"
 #include "wled_ethernet.h"
 #include <Arduino.h>
+#ifdef ARDUINO_ARCH_ESP32
 #include "esp_ota_ops.h"
+#endif
 #warning WLED-MM GPL-v3. By installing WLED MM you implicitly accept the terms!
 
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -1,4 +1,5 @@
 #include "wled.h"
+#include "esp_ota_ops.h"
 
 /*
  * Adalight and TPM2 handler
@@ -119,6 +120,30 @@ void handleSerial()
         } else if (next == 'v') {
           Serial.print("WLED"); Serial.write(' '); Serial.println(VERSION);
 
+        } else if (next == '^') {
+          esp_err_t err;
+          const esp_partition_t *boot_partition = esp_ota_get_boot_partition();
+          const esp_partition_t *running_partition = esp_ota_get_running_partition();
+          USER_PRINTF("Running on %s and we should have booted from %s. This %s\n",running_partition->label,boot_partition->label,(String(running_partition->label) == String(boot_partition->label))?"is what we expect.":"means OTA messed up!");
+          if (String(running_partition->label) == String(boot_partition->label)) {
+            esp_partition_iterator_t new_boot_partition_iterator = NULL;
+            if (boot_partition->subtype == ESP_PARTITION_SUBTYPE_APP_OTA_0) {
+              new_boot_partition_iterator = esp_partition_find(ESP_PARTITION_TYPE_APP,ESP_PARTITION_SUBTYPE_APP_OTA_1,"app1");
+            } else {
+              new_boot_partition_iterator = esp_partition_find(ESP_PARTITION_TYPE_APP,ESP_PARTITION_SUBTYPE_APP_OTA_0,"app0");
+            }
+            const esp_partition_t* new_boot_partition = esp_partition_get(new_boot_partition_iterator);
+            err = esp_ota_set_boot_partition(new_boot_partition);
+            if (err == ESP_OK) {
+              USER_PRINTF("Switching boot partitions from %s to %s in 3 seconds!\n",boot_partition->label,new_boot_partition->label);
+              delay(3000);
+              esp_restart();
+            } else {
+              USER_PRINTF("Looks like the other app partition (%s) is invalid. Ignoring.\n",new_boot_partition->label);
+            }
+          } else {
+            USER_PRINTF("Looks like the other partion is invalid as we exepected %s but we booted failsafe to %s. Ignoring boot change.\n",boot_partition->label,running_partition->label);
+          }
         } else if (next == 'X') {
           forceReconnect = true; // WLEDMM - force reconnect via Serial
         } else if (next == 0xB0) {updateBaudRate( 115200);

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -1,5 +1,7 @@
 #include "wled.h"
+#ifdef ARDUINO_ARCH_ESP32
 #include "esp_ota_ops.h"
+#endif
 
 /*
  * Adalight and TPM2 handler
@@ -121,6 +123,7 @@ void handleSerial()
           Serial.print("WLED"); Serial.write(' '); Serial.println(VERSION);
 
         } else if (next == '^') {
+          #ifdef ARDUINO_ARCH_ESP32
           esp_err_t err;
           const esp_partition_t *boot_partition = esp_ota_get_boot_partition();
           const esp_partition_t *running_partition = esp_ota_get_running_partition();
@@ -144,6 +147,9 @@ void handleSerial()
           } else {
             USER_PRINTF("Looks like the other partion is invalid as we exepected %s but we booted failsafe to %s. Ignoring boot change.\n",boot_partition->label,running_partition->label);
           }
+          #else
+            USER_PRINTLN("This function is only for ESP32 and newer boards.");
+          #endif
         } else if (next == 'X') {
           forceReconnect = true; // WLEDMM - force reconnect via Serial
         } else if (next == 0xB0) {updateBaudRate( 115200);

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -148,7 +148,7 @@ void handleSerial()
             USER_PRINTF("Looks like the other partion is invalid as we exepected %s but we booted failsafe to %s. Ignoring boot change.\n",boot_partition->label,running_partition->label);
           }
           #else
-            USER_PRINTLN("This function is only for ESP32 and newer boards.");
+          USER_PRINTLN("Boot partition switching is only available for ESP32 and newer boards.");
           #endif
         } else if (next == 'X') {
           forceReconnect = true; // WLEDMM - force reconnect via Serial


### PR DESCRIPTION
We have two app partitions... why not use them?

This allows switching between the OTA partitions on the fly.  If you flash via the web interface, this can be used to roll-back to your previous firmware... or to just switch between two firmwares on the same ESP32 for A/B testing without reflashing.

If you only flash a board over serial, app0 is always flashed - but if you use OTA, then app1 is flashed and the board is adjusted to boot from it instead. The next time you OTA update, app0 will be overwritten and you'll boot from it, etc. 

This allows pressing "^" on the serial console to switch boot partitions between app0 and app1, if they both exist and appear to be valid.  Could also be moved into the GUI, etc. 