### PR TITLE
Improved framerate control code - strip.show(), strip.service()

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -43,13 +43,14 @@ bool strip_uses_global_leds(void) __attribute__((pure));  // WLEDMM implemented 
 #endif
 
 /* Not used in all effects yet */
+#define FPS_UNLIMITED    249
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_FASTPATH)   // WLEDMM go faster on ESP32
 #define WLED_FPS         120
 #define FRAMETIME_FIXED  (strip.getFrameTime() < 10 ? 12 : 24)
 #define WLED_FPS_SLOW         60
 #define FRAMETIME_FIXED_SLOW  (15)    // = 66 FPS => 1000/66
-//#define FRAMETIME        _frametime
 #define FRAMETIME        strip.getFrameTime()
+#define MIN_SHOW_DELAY   (max(2, (_frametime*5)/8))    // WLEDMM support higher framerates (up to 250fps) -- 5/8 = 62%
 #else
 #define WLED_FPS         42
 #define FRAMETIME_FIXED  (1000/WLED_FPS)
@@ -57,6 +58,7 @@ bool strip_uses_global_leds(void) __attribute__((pure));  // WLEDMM implemented 
 #define FRAMETIME_FIXED_SLOW  (1000/WLED_FPS_SLOW)
 //#define FRAMETIME        _frametime
 #define FRAMETIME        strip.getFrameTime()
+#define MIN_SHOW_DELAY   (_frametime < 16 ? 8 : 15)
 #endif
 
 /* each segment uses 52 bytes of SRAM memory, so if you're application fails because of
@@ -81,8 +83,6 @@ bool strip_uses_global_leds(void) __attribute__((pure));  // WLEDMM implemented 
 /* How much data bytes each segment should max allocate to leave enough space for other segments,
   assuming each segment uses the same amount of data. 256 for ESP8266, 640 for ESP32. */
 #define FAIR_DATA_PER_SEG (MAX_SEGMENT_DATA / strip.getMaxSegments())
-
-#define MIN_SHOW_DELAY   (_frametime < 16 ? (_frametime <8? (_frametime <7? (_frametime <6 ? 2 :3) :4) : 8) : 15)    // WLEDMM support higher framerates (up to 250fps)
 
 #define NUM_COLORS       3 /* number of colors per segment */
 #define SEGMENT          strip._segments[strip.getCurrSegmentId()]
@@ -852,6 +852,7 @@ class WS2812FX {  // 96 bytes
       customMappingTableSize(0), //WLEDMM
       customMappingSize(0),
       _lastShow(0),
+      _lastServiceShow(0),
       _segment_index(0),
       _mainSegment(0)
     {
@@ -1097,6 +1098,7 @@ class WS2812FX {  // 96 bytes
     uint16_t  customMappingSize;
 
     /*uint32_t*/ unsigned long _lastShow; // WLEDMM avoid losing precision
+    unsigned long _lastServiceShow;       // WLEDMM last call of strip.show (timestamp)
 
     uint8_t _segment_index;
     uint8_t _mainSegment;

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -58,7 +58,8 @@ bool strip_uses_global_leds(void) __attribute__((pure));  // WLEDMM implemented 
 #define FRAMETIME_FIXED_SLOW  (1000/WLED_FPS_SLOW)
 //#define FRAMETIME        _frametime
 #define FRAMETIME        strip.getFrameTime()
-#define MIN_SHOW_DELAY   (_frametime < 16 ? 8 : 15)
+//#define MIN_SHOW_DELAY   (_frametime < 16 ? 8 : 15)  // Upstream legacy
+#define MIN_SHOW_DELAY   (_frametime < 16 ? (_frametime <8? (_frametime <7? (_frametime <6 ? 2 :3) :4) : 8) : 15)    // WLEDMM support higher framerates (up to 250fps)
 #endif
 
 /* each segment uses 52 bytes of SRAM memory, so if you're application fails because of

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -43,20 +43,21 @@ bool strip_uses_global_leds(void) __attribute__((pure));  // WLEDMM implemented 
 #endif
 
 /* Not used in all effects yet */
-#define FPS_UNLIMITED    249
+#define FPS_UNLIMITED    250
+#define FPS_UNLIMITED_AC 0   // WLEDMM upstream uses "0 fps" for unlimited. We support both ways
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_FASTPATH)   // WLEDMM go faster on ESP32
-#define WLED_FPS         120
-#define FRAMETIME_FIXED  (strip.getFrameTime() < 10 ? 12 : 24)
-#define WLED_FPS_SLOW         60
-#define FRAMETIME_FIXED_SLOW  (15)    // = 66 FPS => 1000/66
 #define FRAMETIME        strip.getFrameTime()
 #define MIN_SHOW_DELAY   (max(2, (_frametime*5)/8))    // WLEDMM support higher framerates (up to 250fps) -- 5/8 = 62%
+#define WLED_FPS         120
+#define WLED_FPS_SLOW    60
+#define FRAMETIME_FIXED  24                                // used in Blurz, Freqmap, Scrolling text 
+//#define FRAMETIME_FIXED  (strip.getFrameTime() < 10 ? 12 : 24)
+#define FRAMETIME_FIXED_SLOW  (15)    // = 66 FPS => 1000/66 // used in Solid, Colortwinkles, Candle
 #else
 #define WLED_FPS         42
 #define FRAMETIME_FIXED  (1000/WLED_FPS)
-#define WLED_FPS_SLOW         42
+#define WLED_FPS_SLOW    42
 #define FRAMETIME_FIXED_SLOW  (1000/WLED_FPS_SLOW)
-//#define FRAMETIME        _frametime
 #define FRAMETIME        strip.getFrameTime()
 //#define MIN_SHOW_DELAY   (_frametime < 16 ? 8 : 15)  // Upstream legacy
 #define MIN_SHOW_DELAY   (_frametime < 16 ? (_frametime <8? (_frametime <7? (_frametime <6 ? 2 :3) :4) : 8) : 15)    // WLEDMM support higher framerates (up to 250fps)

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2062,7 +2062,7 @@ void WS2812FX::show(void) {
   estimateCurrentAndLimitBri();
 
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_FASTPATH)
-  unsigned long nowUp = millis();
+  unsigned long showNow = millis();
   #ifdef ARDUINO_ARCH_ESP32                      // WLEDMM more accurate FPS measurement for ESP32
   uint64_t now500 = esp_timer_get_time() / 2;  // native timer; micros /2 -> millis * 500
   #endif
@@ -2074,18 +2074,18 @@ void WS2812FX::show(void) {
   busses.show();
 
   #if !defined(ARDUINO_ARCH_ESP32) || !defined(WLEDMM_FASTPATH)  // upstream legacy
-  unsigned long nowUp = millis();
+  unsigned long showNow = millis();
   #ifdef ARDUINO_ARCH_ESP32                      // WLEDMM more accurate FPS measurement for ESP32
   uint64_t now500 = esp_timer_get_time() / 2;  // native timer; micros /2 -> millis * 500
   #endif
   #endif
 
-  unsigned long diff = nowUp - _lastShow;
+  unsigned long diff = showNow - _lastShow;
   uint16_t fpsCurr = 200;
   if (diff > 0) fpsCurr = 1000 / diff;
   _cumulativeFps = (3 * _cumulativeFps + fpsCurr +2) >> 2;   // "+2" for proper rounding (2/4 = 0.5)
-  _lastShow = nowUp;
-  _lastServiceShow = nowUp;
+  _lastShow = showNow;
+  _lastServiceShow = showNow;
 
 #ifdef ARDUINO_ARCH_ESP32                      // WLEDMM more accurate FPS measurement for ESP32
   int64_t diff500 = now500 - _lastShow500;

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2061,24 +2061,15 @@ void WS2812FX::show(void) {
 
   estimateCurrentAndLimitBri();
 
-  #if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_FASTPATH)
-  unsigned long showNow = millis();
-  #ifdef ARDUINO_ARCH_ESP32                      // WLEDMM more accurate FPS measurement for ESP32
+  unsigned long showNow = millis();            // include time needed for busses.show()
+  #ifdef ARDUINO_ARCH_ESP32                    // WLEDMM more accurate FPS measurement for ESP32
   uint64_t now500 = esp_timer_get_time() / 2;  // native timer; micros /2 -> millis * 500
-  #endif
   #endif
 
   // some buses send asynchronously and this method will return before
   // all of the data has been sent.
   // See https://github.com/Makuna/NeoPixelBus/wiki/ESP32-NeoMethods#neoesp32rmt-methods
   busses.show();
-
-  #if !defined(ARDUINO_ARCH_ESP32) || !defined(WLEDMM_FASTPATH)  // upstream legacy
-  unsigned long showNow = millis();
-  #ifdef ARDUINO_ARCH_ESP32                      // WLEDMM more accurate FPS measurement for ESP32
-  uint64_t now500 = esp_timer_get_time() / 2;  // native timer; micros /2 -> millis * 500
-  #endif
-  #endif
 
   unsigned long diff = showNow - _lastShow;
   uint16_t fpsCurr = 200;

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2062,7 +2062,7 @@ void WS2812FX::show(void) {
   estimateCurrentAndLimitBri();
 
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_FASTPATH)
-  unsigned long now = millis();
+  unsigned long nowUp = millis();
   #ifdef ARDUINO_ARCH_ESP32                      // WLEDMM more accurate FPS measurement for ESP32
   uint64_t now500 = esp_timer_get_time() / 2;  // native timer; micros /2 -> millis * 500
   #endif
@@ -2072,18 +2072,20 @@ void WS2812FX::show(void) {
   // all of the data has been sent.
   // See https://github.com/Makuna/NeoPixelBus/wiki/ESP32-NeoMethods#neoesp32rmt-methods
   busses.show();
-  unsigned long now = millis();
+
+  #if !defined(ARDUINO_ARCH_ESP32) || !defined(WLEDMM_FASTPATH)  // upstream legacy
+  unsigned long nowUp = millis();
   #ifdef ARDUINO_ARCH_ESP32                      // WLEDMM more accurate FPS measurement for ESP32
   uint64_t now500 = esp_timer_get_time() / 2;  // native timer; micros /2 -> millis * 500
   #endif
   #endif
 
-  unsigned long diff = now - _lastShow;
+  unsigned long diff = nowUp - _lastShow;
   uint16_t fpsCurr = 200;
   if (diff > 0) fpsCurr = 1000 / diff;
   _cumulativeFps = (3 * _cumulativeFps + fpsCurr +2) >> 2;   // "+2" for proper rounding (2/4 = 0.5)
-  _lastShow = now;
-  _lastServiceShow = now;
+  _lastShow = nowUp;
+  _lastServiceShow = nowUp;
 
 #ifdef ARDUINO_ARCH_ESP32                      // WLEDMM more accurate FPS measurement for ESP32
   int64_t diff500 = now500 - _lastShow500;

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -166,7 +166,8 @@
 
 			gId('ampwarning').style.display = (d.Sf.MA.value > 7200) ? 'inline':'none';
 
-			gId('fpswarning').style.display = (d.Sf.FR.value > 69) ? 'block':'none'; // WLEDMM
+			gId('fpsNone').style.display = ((d.Sf.FR.value == 0) || (d.Sf.FR.value > 249))? 'block':'none'; // WLEDMM
+			gId('fpswarning').style.display = (d.Sf.FR.value > 69) || (d.Sf.FR.value == 0) ? 'block':'none'; // WLEDMM
 			gId('fpshelp1').style.display = ((d.Sf.FR.value > 80) && (d.Sf.FR.value < 132)) ? 'block':'none'; // WLEDMM
 			gId('fpshelp2').style.display = ((d.Sf.FR.value > 132) && (d.Sf.FR.value < 196)) ? 'block':'none'; // WLEDMM
 			gId('fpshelp3').style.display = (d.Sf.FR.value > 196) ? 'block':'none'; // WLEDMM
@@ -732,7 +733,8 @@ Length: <input type="number" name="XC${i}" id="xc${i}" class="l" min="1" max="65
 			<option value="2">Linear (never wrap)</option>
 			<option value="3">None (not recommended)</option>
 		</select><br>
-		Target refresh rate: <input type="number" class="s" min="1" max="250" name="FR" oninput="UI()" required> FPS
+		Target refresh rate: <input type="number" class="s" min="0" max="250" name="FR" oninput="UI()" required> FPS
+		<div id="fpsNone" style="color:green; display: none;"><b>unlimited FPS mode.</b><br></div>
 		<div id="fpswarning" style="color:GoldenRod; display: none;">
 			&#9888; WLED may become unstable above 70 fps.<br>
 			To protect your setup,


### PR DESCRIPTION
The old code was having lots of minor errors in calculation of "time passed" since last frame. Additionally, the value for MIN_SHOW_DELAY (`_frametime < 16 ? 8 : 15`) seems very random and it's effectively limiting the max framerates to 60-80fps.

#### This change implements a better solution:
* Separates framerate control in strip.service() from FPS calculation in strip.show()
* framerate calcutation considers all steps of rendering (drawing + brightness limiter + busses.show). The old code was only using the time after last "show" until beginning of next render cycle - so it artificially created too low framerates and random "stuttering" of effects.
* Add an "unlimited" mode where all effects will render as fast as possible (limited to 333 fps to keep WiFi alive)

#### From user perspective:
* smoothly running effects at all framerates
* The "Target FPS" (LED settings) will be achieved (and not exceeded much) if effects can render fast enough.
* setting Target FPS to 250 means "unlimited" (good for testing render performance)
* `-D WLEDMM_FASTPATH` is needed for the new code
* 8266 and non-fastpath builds are using the improved code, however with the old MIN_SHOW_DELAY that causes too many idle cycles
