### PR TITLE
(experimental) Peek preview always visible above effects list

### DIFF
--- a/wled00/data/index.css
+++ b/wled00/data/index.css
@@ -402,6 +402,10 @@ button {
     margin: 0 auto auto;
 }
 
+.belowpreview {
+	top: 164px;
+}
+
 .staybot {
 	bottom: 5px;
 }

--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -211,7 +211,7 @@
 	</div>
 
 	<div id="Effects" class="tabcontent">
-		<div id="effectGFX" hidden="true"> <!--WLEDMM-->
+		<div id="effectGFX" style="z-index: 2;" hidden="true"> <!--WLEDMM-->
 			<!-- <p class="labels hd">Peek ☾ <button class="btn infobtn btn-xs" onclick="eandp(this,gId('canvasPeek'));">v</button></p> -->
 			<br>
 			<canvas id="canvasPeek" onclick="bigPeek(true)"></canvas><br>
@@ -219,7 +219,7 @@
 		</div>
 		<div id="fx">
 			<p class="labels hd" id="modeLabel">Effect mode</p>
-			<div class="staytop fnd" id="fxFind">
+			<div class="staytop fnd belowpreview" id="fxFind">  <!--WLEDMM-->
 				<input type="text" placeholder="Search" oninput="search(this,'fxlist')" onfocus="search(this,'fxlist');gId('filters').classList.add('fade');" onblur="gId('filters').classList.remove('fade')"/>
 				<i class="icons clear-icon" onclick="clean(this);">&#xe38f;</i>
 				<i class="icons search-icon" onclick="gId('filters').classList.toggle('hide');" style="cursor:pointer;">&#xe0a1;</i>


### PR DESCRIPTION
A hack that keeps the preview visible when scrolling through the effect list.
Basically works in PC mode but looks strange in phone mode.

Someone with more HTML/CSS experience should take this a starting point and make it work.

![image](https://github.com/user-attachments/assets/6d37c566-e196-410e-8fca-b88cf3e86618)

