### PR TITLE
new mapping mode "Waterfall"

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -347,7 +347,8 @@ typedef enum mapping1D2D {
   M12_jMap = 4, //WLEDMM jMap
   M12_sCircle = 5, //WLEDMM Circle
   M12_sBlock = 6, //WLEDMM Block
-  M12_sPinwheel = 7 //WLEDMM Pinwheel
+  M12_sPinwheel = 7, //WLEDMM Pinwheel
+  M12_sWaterfall = 8 //WLEDMM Waterfall
 } mapping1D2D_t;
 
 // segment, 72 bytes
@@ -424,6 +425,8 @@ typedef struct Segment {
 
     bool _isSimpleSegment = false;      // simple = no grouping or spacing - mirror, transpose or reverse allowed
     bool _isSuperSimpleSegment = false; // superSimple = no grouping or spacing, no mirror - only transpose or reverse allowed
+    bool _is2Deffect = false;           // tells us if the strip is running a real 2D effect
+
 #ifdef WLEDMM_FASTPATH
     // WLEDMM cache some values that won't change while drawing a frame
     bool _isValid2D = false;

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -279,6 +279,7 @@ void Segment::startFrame(void) {
 
   // WLEDMM Waterfall mapping
   if (!_is2Deffect && (map1D2D == M12_pBar) && reverse) { // WLEDMM Waterfall = bar + reverse
+    if (!ledsrgb || (ledsrgbSize == 0)) setUpLeds();      // create segment buffer if not set up already ==> 30% faster, and prevents interference with other segments.
     for (unsigned myRow = _2dHeight-1; myRow > 0; myRow--)
       for (unsigned myCol = 0; myCol < _2dWidth; myCol++) {
         setPixelColorXY(myCol, myRow, getPixelColorXY(int(myCol), int(myRow)-1));

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1503,8 +1503,8 @@ void Segment::fadePixelColor(uint16_t n, uint8_t fade) {
 void __attribute__((hot)) Segment::fade_out(uint8_t rate) {
   if (!isActive()) return; // not active
   bool reallyIs2D = _is2Deffect || (is2D() && !(map1D2D == M12_pBar && reverse));  // WLEDMM switch to "1D" mode for Bar or waterfall
-  const uint_fast16_t cols = reallyIs2D ? virtualWidth() : virtualLength();           // WLEDMM use fast int types
-  const uint_fast16_t rows = virtualHeight(); // will be 1 for 1D
+  const uint_fast16_t cols = reallyIs2D ? virtualWidth() : virtualLength();        // WLEDMM use fast int types
+  const uint_fast16_t rows = reallyIs2D ? virtualHeight() : 1;                     // must be 1 for 1D
 
   uint_fast8_t fadeRate = (255-rate) >> 1;
   float mappedRate_r = 1.0f / (float(fadeRate) +1.1f); // WLEDMM use reciprocal  1/mappedRate -> faster on non-FPU chips
@@ -1547,7 +1547,8 @@ void __attribute__((hot)) Segment::fadeToBlackBy(uint8_t fadeBy) {
   if (!isActive() || fadeBy == 0) return;   // optimization - no scaling to apply
   bool reallyIs2D = _is2Deffect || (is2D() && !(map1D2D == M12_pBar && reverse));  // WLEDMM switch to "1D" mode for Bar or waterfall
   const uint_fast16_t cols = reallyIs2D ? virtualWidth() : virtualLength();        // WLEDMM use fast int types
-  const uint_fast16_t rows = virtualHeight(); // will be 1 for 1D
+  const uint_fast16_t rows = reallyIs2D ? virtualHeight() : 1;                     // must be 1 for 1D
+
   const uint_fast8_t scaledown = 255-fadeBy;  // WLEDMM faster to pre-compute this
 
   // WLEDMM minor optimization

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -165,6 +165,7 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
   uint16_t of  = seg.offset;
   uint8_t  soundSim = elem["si"] | seg.soundSim;
   uint8_t  map1D2D  = elem["m12"] | seg.map1D2D;
+  if (map1D2D > 7) map1D2D = M12_pBar; // WLEDMM fix for "waterfall" mapping which is out of range 0-7
 
   //WLEDMM jMap
   if (map1D2D == M12_jMap && !seg.jMap)
@@ -327,6 +328,8 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
   JsonArray iarr = elem[F("i")]; //set individual LEDs
   if (!iarr.isNull()) {
     uint8_t oldMap1D2D = seg.map1D2D;
+    if (oldMap1D2D > 7) oldMap1D2D = M12_pBar; // WLEDMM fix for "waterfall" mapping which is out of range 0-7
+
     seg.map1D2D = M12_Pixels; // no mapping
     // WLEDMM begin - we need to init segment caches before putting any pixels
     if (strip.isServicing()) {


### PR DESCRIPTION
Waterfall mapping takes a 1D effect on the top row, and copies is down one row in each step.

The code still needs some rework:
* Waterfall = "Bar" + "reverse" due to limitations in m1D2D
* m1D2D is only 3bit wide, but we need a new entry "8". 
* slider to control waterfall speed is needed
* _is2Deffect still looks "not really right". Need to sleep over it.


## examples

"Blurz" looks like comets

![Screenshot 2024-11-24 005517](https://github.com/user-attachments/assets/4424329e-8421-4555-bf66-17b97221850c)

"BPM" creates waves

![Screenshot 2024-11-24 010606](https://github.com/user-attachments/assets/d6b1f618-3e96-4076-b44b-c667b676fa88)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new waterfall mapping option for 2D LED effects, enabling waterfall-like visual patterns on matrix-based LED displays.

* **Improvements**
  * Enhanced 2D effect detection and mode handling for improved compatibility across different LED configurations.
  * Improved validation and fallback handling for LED mapping configurations, increasing system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->