### PR TITLE
audioreactive comet effect (from WLED-SR)

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -330,7 +330,7 @@ bool strip_uses_global_leds(void) __attribute__((pure));  // WLEDMM implemented 
 // Experimental Audioresponsive modes from WLED-SR
 // #define FX_MODE_3DSphereMove           189 // experimental WLED-SR "cube" mode
 #define FX_MODE_POPCORN_AR             190 // WLED-SR audioreactive popcorn
-// #define FX_MODE_MULTI_COMET_AR         191 // WLED-SR audioreactive multi-comet
+#define FX_MODE_MULTI_COMET_AR         191 // WLED-SR audioreactive multi-comet
 #define FX_MODE_STARBURST_AR           192 // WLED-SR audioreactive fireworks starburst
 // #define FX_MODE_PALETTE_AR             193 // WLED-SR audioreactive palette
 #define FX_MODE_FIREWORKS_AR           194 // WLED-SR audioreactive fireworks


### PR DESCRIPTION
a variant of the "multi-comet" effect where new comets are triggered by audio beat detection.
(audioreactive still uses a very beat detection method, but its good enough for this effect)