### PR TITLE
f.setBufferSize(FS_BUFSIZE); for buffered file functions

### DIFF
--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -66,6 +66,7 @@ static bool bufferedFind(const char *target, bool fromStart = true) {
 
   size_t index = 0;
   byte buf[FS_BUFSIZE];
+  f.setBufferSize(FS_BUFSIZE);
   if (fromStart) f.seek(0);
 
   while (f.position() < f.size() -1) {
@@ -107,6 +108,7 @@ static bool bufferedFindSpace(size_t targetLen, bool fromStart = true) {
 
   size_t index = 0; // better to use size_t instead if uint16_t
   byte buf[FS_BUFSIZE];
+  f.setBufferSize(FS_BUFSIZE);
   if (fromStart) f.seek(0);
 
   while (f.position() < f.size() -1) {
@@ -150,6 +152,7 @@ static bool bufferedFindObjectEnd() {
   uint16_t objDepth = 0; //num of '{' minus num of '}'. return once 0
   //size_t start = f.position();
   byte buf[FS_BUFSIZE];
+  f.setBufferSize(FS_BUFSIZE);
 
   while (f.position() < f.size() -1) {
     size_t bufsize = f.read(buf, FS_BUFSIZE); // better to use size_t instead of uint16_t
@@ -175,7 +178,7 @@ static void writeSpace(size_t l)
 {
   byte buf[FS_BUFSIZE];
   memset(buf, ' ', FS_BUFSIZE);
-
+  f.setBufferSize(FS_BUFSIZE);
   while (l > 0) {
     size_t block = (l>FS_BUFSIZE) ? FS_BUFSIZE : l;
     f.write(buf, block);

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -66,7 +66,9 @@ static bool bufferedFind(const char *target, bool fromStart = true) {
 
   size_t index = 0;
   byte buf[FS_BUFSIZE];
+  #if ESP_IDF_VERSION_MAJOR >= 4
   f.setBufferSize(FS_BUFSIZE);
+  #endif
   if (fromStart) f.seek(0);
 
   while (f.position() < f.size() -1) {
@@ -108,7 +110,9 @@ static bool bufferedFindSpace(size_t targetLen, bool fromStart = true) {
 
   size_t index = 0; // better to use size_t instead if uint16_t
   byte buf[FS_BUFSIZE];
+  #if ESP_IDF_VERSION_MAJOR >= 4
   f.setBufferSize(FS_BUFSIZE);
+  #endif
   if (fromStart) f.seek(0);
 
   while (f.position() < f.size() -1) {
@@ -152,8 +156,9 @@ static bool bufferedFindObjectEnd() {
   uint16_t objDepth = 0; //num of '{' minus num of '}'. return once 0
   //size_t start = f.position();
   byte buf[FS_BUFSIZE];
+  #if ESP_IDF_VERSION_MAJOR >= 4
   f.setBufferSize(FS_BUFSIZE);
-
+  #endif
   while (f.position() < f.size() -1) {
     size_t bufsize = f.read(buf, FS_BUFSIZE); // better to use size_t instead of uint16_t
     size_t count = 0;
@@ -178,7 +183,9 @@ static void writeSpace(size_t l)
 {
   byte buf[FS_BUFSIZE];
   memset(buf, ' ', FS_BUFSIZE);
+  #if ESP_IDF_VERSION_MAJOR >= 4
   f.setBufferSize(FS_BUFSIZE);
+  #endif
   while (l > 0) {
     size_t block = (l>FS_BUFSIZE) ? FS_BUFSIZE : l;
     f.write(buf, block);

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -161,6 +161,12 @@ int getSignalQuality(int rssi)
     return quality;
 }
 
+#if ESP_IDF_VERSION_MAJOR >= 4
+  #define SYSTEM_EVENT_ETH_CONNECTED ARDUINO_EVENT_ETH_CONNECTED
+  #define SYSTEM_EVENT_ETH_DISCONNECTED ARDUINO_EVENT_ETH_DISCONNECTED
+  #define SYSTEM_EVENT_ETH_START ARDUINO_EVENT_ETH_START
+  #define SYSTEM_EVENT_ETH_GOT_IP ARDUINO_EVENT_ETH_GOT_IP
+#endif
 
 //handle Ethernet connection event
 void WiFiEvent(WiFiEvent_t event)
@@ -170,12 +176,21 @@ void WiFiEvent(WiFiEvent_t event)
     case SYSTEM_EVENT_ETH_START:
       DEBUG_PRINTLN(F("ETH Started"));
       break;
+    case SYSTEM_EVENT_ETH_GOT_IP:
+      if (Network.isEthernet()) {
+        if (!apActive) {
+          DEBUG_PRINTLN(F("WiFi Connected *and* ETH Connected. Disabling WIFi"));
+          WiFi.disconnect(true);
+        } else {
+          DEBUG_PRINTLN(F("WiFi Connected *and* ETH Connected. Leaving AP WiFi active"));
+        }
+      } else {
+        DEBUG_PRINTLN(F("WiFi Connected. No ETH"));
+      }
+      break;
     case SYSTEM_EVENT_ETH_CONNECTED:
       {
       DEBUG_PRINTLN(F("ETH Connected"));
-      if (!apActive) {
-        WiFi.disconnect(true);
-      }
       if (staticIP != (uint32_t)0x00000000 && staticGateway != (uint32_t)0x00000000) {
         ETH.config(staticIP, staticGateway, staticSubnet, IPAddress(8, 8, 8, 8));
       } else {

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -1370,16 +1370,15 @@ void WLED::handleConnection()
   } else if (!interfacesInited) { //newly connected
     USER_PRINTLN("");
     USER_PRINT(F("Connected! IP address: http://"));
-    USER_PRINTLN(Network.localIP());
-    //if (Network.isEthernet()) {
-    //  #if ESP32
-    //  USER_PRINT(ETH.localIP());
-    //  USER_PRINTLN(" via Ethernet");
-    //  #endif
-    //} else {
-    //  USER_PRINT(Network.localIP());
-    //  USER_PRINTLN(" via WiFi");
-    //}
+    USER_PRINT(Network.localIP());
+    if (Network.isEthernet()) {
+     #if ESP32
+     USER_PRINTLN(" via Ethernet (disabling WiFi)");
+     WiFi.disconnect(true);
+     #endif
+    } else {
+     USER_PRINTLN(" via WiFi");
+    }
 
     if (improvActive) {
       if (improvError == 3) sendImprovStateResponse(0x00, true);


### PR DESCRIPTION
Fixes some buffered file operations which were throwing a non-fatal error like this:

`heap_caps_malloc_default failed to allocate 1073421768 bytes with Default capabilities`

Numbers differed, but some undefined value was being tried without `f.setBufferSize(FS_BUFSIZE)` being set.