### PR TITLE
Art-Net Improvements and Other Fixes

### DIFF
--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -246,12 +246,12 @@
 							gId("dig"+n+"W").innerHTML = "<br />You need at least 1 output!";
 						}
 						if (outputs > 1 && fps_limit > 33333/leds_per_output) gId("dig"+n+"W").innerHTML += "<br />FPS limit may be too high for WS281x pixels.";
-						if (outputs*leds_per_output != total_leds) gId("dig"+n+"W").innerHTML += "<br />Total LEDs doesn't match outputs * LEDs per output.";
+						if (outputs*leds_per_output != total_leds) gId("dig"+n+"W").innerHTML += "<br />Length ("+total_leds+") doesn't match Number of Outputs * LEDs Per Output ("+outputs*leds_per_output+").";
 						if (last_octet == 255) {
 							if (total_leds <= 1024) gId("dig"+n+"W").innerHTML += "<br />Art-Net is in broadcast mode.";
 							if (total_leds  > 1024) gId("dig"+n+"W").innerHTML += "<br />You are sending a lot of broadcast data. Be cautious.";
 						}
-						gId("dig"+n+"W").innerHTML += "<br />Art-Net starting universe is "+d.e131Universe+".";
+						gId("dig"+n+"W").innerHTML += "<br />Art-Net starting universe is "+d.e131Universe+". Change this in <a href='/settings/sync'>Sync Interfaces</a>.";
 					}
 					if (!(t > 28 && t < 32)) d.getElementsByName("WO"+n)[0].value = 0; // reset swapping
 					gId("dig"+n+"c").style.display = ((t >= 40 && t < 48)||(t >= 100 && t < 110)) ? "none":"inline";  // hide count for analog and HUB75
@@ -423,6 +423,7 @@ ${i+1}:
 <option value="80">DDP RGB (network)</option>
 <!--option value="81">E1.31 RGB (network)</option-->
 <option value="82">Art-Net RGB (network)</option>
+<option value="83">Art-Net RGBW (network)</option>
 <option value="88">DDP RGBW (network)</option>
 <option value="101">Hub75Matrix 32x32</option>
 <option value="102">Hub75Matrix 64x32</option>

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -251,6 +251,7 @@
 							if (total_leds <= 1024) gId("dig"+n+"W").innerHTML += "<br />Art-Net is in broadcast mode.";
 							if (total_leds  > 1024) gId("dig"+n+"W").innerHTML += "<br />You are sending a lot of broadcast data. Be cautious.";
 						}
+						gId("dig"+n+"W").innerHTML += "<br />Art-Net starting universe is "+d.e131Universe+".";
 					}
 					if (!(t > 28 && t < 32)) d.getElementsByName("WO"+n)[0].value = 0; // reset swapping
 					gId("dig"+n+"c").style.display = ((t >= 40 && t < 48)||(t >= 100 && t < 110)) ? "none":"inline";  // hide count for analog and HUB75

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -80,7 +80,7 @@
 <div class="helpB"><button type="button" onclick="H()">?</button></div>
 <button type="button" onclick="B()">Back</button><button type="submit">Save</button><hr>
 </div>
-<h2>Sync setup</h2>
+<h2>Sync Interfaces</h2>
 <h3>WLED Broadcast</h3>
 UDP Port: <input name="UP" type="number" min="1" max="65535" class="d5" required><br>
 2nd Port: <input name="U2" type="number" min="1" max="65535" class="d5" required><br>
@@ -139,7 +139,7 @@ Make this instance discoverable: <input type="checkbox" name="NB">
 <h3>Realtime</h3>
 Receive UDP realtime: <input type="checkbox" name="RD"><br>
 Use main segment only: <input type="checkbox" name="MO"><br><br>
-<i>Network DMX input</i><br>
+<i>Network DMX</i><br>
 Type:
 <select name=DI onchange="SP(); adj();">
 <option value=5568>E1.31 (sACN)</option>
@@ -148,7 +148,7 @@ Type:
 </select><br>
 <div id=xp>Port: <input name="EP" type="number" min="1" max="65535" value="5568" class="d5" required><br></div>
 Multicast: <input type="checkbox" name="EM"><br>
-Start universe: <input name="EU" type="number" min="0" max="63999" required><br>
+Start universe: <input name="EU" type="number" min="0" max="63999" required> (Also used for sending Art-Net)<br>
 <i>Reboot required.</i> Check out <a href="https://github.com/LedFx/LedFx" target="_blank">LedFx</a>!<br>
 Skip out-of-sequence packets: <input type="checkbox" name="ES"><br>
 DMX start address: <input name="DA" type="number" min="1" max="510" required><br>

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -66,6 +66,7 @@ static bool bufferedFind(const char *target, bool fromStart = true) {
 
   size_t index = 0;
   byte buf[FS_BUFSIZE];
+  f.setBufferSize(FS_BUFSIZE);
   if (fromStart) f.seek(0);
 
   while (f.position() < f.size() -1) {
@@ -107,6 +108,7 @@ static bool bufferedFindSpace(size_t targetLen, bool fromStart = true) {
 
   size_t index = 0; // better to use size_t instead if uint16_t
   byte buf[FS_BUFSIZE];
+  f.setBufferSize(FS_BUFSIZE);
   if (fromStart) f.seek(0);
 
   while (f.position() < f.size() -1) {
@@ -150,6 +152,7 @@ static bool bufferedFindObjectEnd() {
   uint16_t objDepth = 0; //num of '{' minus num of '}'. return once 0
   //size_t start = f.position();
   byte buf[FS_BUFSIZE];
+  f.setBufferSize(FS_BUFSIZE);
 
   while (f.position() < f.size() -1) {
     size_t bufsize = f.read(buf, FS_BUFSIZE); // better to use size_t instead of uint16_t
@@ -175,7 +178,7 @@ static void writeSpace(size_t l)
 {
   byte buf[FS_BUFSIZE];
   memset(buf, ' ', FS_BUFSIZE);
-
+  f.setBufferSize(FS_BUFSIZE);
   while (l > 0) {
     size_t block = (l>FS_BUFSIZE) ? FS_BUFSIZE : l;
     f.write(buf, block);

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -66,7 +66,9 @@ static bool bufferedFind(const char *target, bool fromStart = true) {
 
   size_t index = 0;
   byte buf[FS_BUFSIZE];
+  #if ESP_IDF_VERSION_MAJOR >= 4
   f.setBufferSize(FS_BUFSIZE);
+  #endif
   if (fromStart) f.seek(0);
 
   while (f.position() < f.size() -1) {
@@ -108,7 +110,9 @@ static bool bufferedFindSpace(size_t targetLen, bool fromStart = true) {
 
   size_t index = 0; // better to use size_t instead if uint16_t
   byte buf[FS_BUFSIZE];
+  #if ESP_IDF_VERSION_MAJOR >= 4
   f.setBufferSize(FS_BUFSIZE);
+  #endif
   if (fromStart) f.seek(0);
 
   while (f.position() < f.size() -1) {
@@ -152,8 +156,9 @@ static bool bufferedFindObjectEnd() {
   uint16_t objDepth = 0; //num of '{' minus num of '}'. return once 0
   //size_t start = f.position();
   byte buf[FS_BUFSIZE];
+  #if ESP_IDF_VERSION_MAJOR >= 4
   f.setBufferSize(FS_BUFSIZE);
-
+  #endif
   while (f.position() < f.size() -1) {
     size_t bufsize = f.read(buf, FS_BUFSIZE); // better to use size_t instead of uint16_t
     size_t count = 0;
@@ -178,7 +183,9 @@ static void writeSpace(size_t l)
 {
   byte buf[FS_BUFSIZE];
   memset(buf, ' ', FS_BUFSIZE);
+  #if ESP_IDF_VERSION_MAJOR >= 4
   f.setBufferSize(FS_BUFSIZE);
+  #endif
   while (l > 0) {
     size_t block = (l>FS_BUFSIZE) ? FS_BUFSIZE : l;
     f.write(buf, block);

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -161,6 +161,12 @@ int getSignalQuality(int rssi)
     return quality;
 }
 
+#if ESP_IDF_VERSION_MAJOR >= 4
+  #define SYSTEM_EVENT_ETH_CONNECTED ARDUINO_EVENT_ETH_CONNECTED
+  #define SYSTEM_EVENT_ETH_DISCONNECTED ARDUINO_EVENT_ETH_DISCONNECTED
+  #define SYSTEM_EVENT_ETH_START ARDUINO_EVENT_ETH_START
+  #define SYSTEM_EVENT_ETH_GOT_IP ARDUINO_EVENT_ETH_GOT_IP
+#endif
 
 //handle Ethernet connection event
 void WiFiEvent(WiFiEvent_t event)
@@ -170,12 +176,21 @@ void WiFiEvent(WiFiEvent_t event)
     case SYSTEM_EVENT_ETH_START:
       DEBUG_PRINTLN(F("ETH Started"));
       break;
+    case SYSTEM_EVENT_ETH_GOT_IP:
+      if (Network.isEthernet()) {
+        if (!apActive) {
+          DEBUG_PRINTLN(F("WiFi Connected *and* ETH Connected. Disabling WIFi"));
+          WiFi.disconnect(true);
+        } else {
+          DEBUG_PRINTLN(F("WiFi Connected *and* ETH Connected. Leaving AP WiFi active"));
+        }
+      } else {
+        DEBUG_PRINTLN(F("WiFi Connected. No ETH"));
+      }
+      break;
     case SYSTEM_EVENT_ETH_CONNECTED:
       {
       DEBUG_PRINTLN(F("ETH Connected"));
-      if (!apActive) {
-        WiFi.disconnect(true);
-      }
       if (staticIP != (uint32_t)0x00000000 && staticGateway != (uint32_t)0x00000000) {
         ETH.config(staticIP, staticGateway, staticSubnet, IPAddress(8, 8, 8, 8));
       } else {

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -911,7 +911,7 @@ uint8_t IRAM_ATTR_YN realtimeBroadcast(uint8_t type, IPAddress client, uint16_t 
       const uint_fast16_t ARTNET_CHANNELS_PER_PACKET = isRGBW?512:510; // 512/4=128 RGBW LEDs, 510/3=170 RGB LEDs
       
       uint_fast16_t bufferOffset = 0;
-      uint_fast16_t hardware_output_universe = 0;
+      uint_fast16_t hardware_output_universe = e131Universe; // start at the universe defined in Sync Setup
       
       sequenceNumber++;
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -1370,16 +1370,15 @@ void WLED::handleConnection()
   } else if (!interfacesInited) { //newly connected
     USER_PRINTLN("");
     USER_PRINT(F("Connected! IP address: http://"));
-    USER_PRINTLN(Network.localIP());
-    //if (Network.isEthernet()) {
-    //  #if ESP32
-    //  USER_PRINT(ETH.localIP());
-    //  USER_PRINTLN(" via Ethernet");
-    //  #endif
-    //} else {
-    //  USER_PRINT(Network.localIP());
-    //  USER_PRINTLN(" via WiFi");
-    //}
+    USER_PRINT(Network.localIP());
+    if (Network.isEthernet()) {
+     #if ESP32
+     USER_PRINTLN(" via Ethernet (disabling WiFi)");
+     WiFi.disconnect(true);
+     #endif
+    } else {
+     USER_PRINTLN(" via WiFi");
+    }
 
     if (improvActive) {
       if (improvError == 3) sendImprovStateResponse(0x00, true);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -487,6 +487,11 @@ void getSettingsJS(AsyncWebServerRequest* request, byte subPage, char* dest) //W
       oappendi(bus->getMaxPixels()); oappend(SET_F(");"));
 
     }
+    
+    oappend(SET_F("d.e131Universe="));
+    oappendi(e131Universe); // Art-Net start universe
+    oappend(SET_F(";"));
+  
     sappend('v',SET_F("MA"),strip.ablMilliampsMax);
     sappend('v',SET_F("LA"),strip.milliampsPerLed);
     if (strip.currentMilliamps)


### PR DESCRIPTION
I really should clean my personal mdev, ha.

Improved Art-Net to have a starting universe and also improved some of the guidance in the Art-Net confg:

![chrome_6SXvJRkLd1](https://github.com/user-attachments/assets/2bf96e73-a5fa-46ad-bcf6-6ed50e6f453b)

Summary of other things in this PR: 

* Art-Net RGBW is now selectable as an LED output type. Needs testing as I don't have any RGBW pixels. 
* Small issue fixed for IDFv4 causing a huge allocation of RAM that fails during buffered file reads. Generally cosmetic as it didn't crash.
* Fix for Ethernet on IDFv4 so it works properly now.
* receiveAudioData() only process the latest packet in buffer now to account for slower refreshes and removes any "buffer effect" from incoming audio packets if there's an FPS mismatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Art-Net RGBW (network) LED type in the LED settings, including updated UI options and validation logic.
  - Art-Net output now starts at the configured universe number as set in Sync Interfaces.

- **Improvements**
  - Enhanced robustness and performance of audio data reception, with improved handling of UDP packets and error conditions.
  - Ethernet connection handling improved: WiFi is now automatically disabled when Ethernet is used.
  - UI updates: clearer labels and additional info in Sync Interfaces and LED settings pages.
  - The current Art-Net starting universe is now displayed in the LED settings with a direct link to Sync Interfaces.

- **Other Changes**
  - File operations now explicitly set buffer size for improved performance on supported platforms.
  - Internal JavaScript variables are updated to reflect current Art-Net universe settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->