### PR TITLE
Mdev v4 only

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -126,7 +126,6 @@ extra_configs =
 #   arduino core 2.6.3 = platformIO 2.3.2
 #   arduino core 2.7.0 = platformIO 2.5.0
 # ------------------------------------------------------------------------------
-arduino_core_3_2_0 = espressif8266@3.2.0
 arduino_core_3_1_2 = espressif8266@4.2.1
 
 # Development platforms
@@ -141,13 +140,6 @@ platform_packages = platformio/toolchain-xtensa @ ~2.100300.220621 #2.40802.2005
                     platformio/tool-esptool #@ ~1.413.0
                     platformio/tool-esptoolpy #@ ~1.30000.0
 
-## previous platform for 8266, in case of problems with the new one
-## you'll need  makuna/NeoPixelBus@ 2.6.9 for arduino_core_3_2_0, which does not support Ucs890x
-;; platform_wled_default = ${common.arduino_core_3_2_0}
-;; platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
-;;                    platformio/toolchain-xtensa @ ~2.40802.200502
-;;                    platformio/tool-esptool @ ~1.413.0
-;;                    platformio/tool-esptoolpy @ ~1.30000.0
 
 # ------------------------------------------------------------------------------
 # FLAGS: DEBUG
@@ -326,15 +318,6 @@ platform_packages_compat =
                     platformio/tool-esptool #@ ~1.413.0
                     platformio/tool-esptoolpy #@ ~1.30000.0
 
-;; experimental - for using older NeoPixelBus 2.7.9
-lib_deps_compat =
-  ESPAsyncTCP @ 1.2.2
-  ESPAsyncUDP
-  ESP8266PWM
-  fastled/FastLED @ 3.6.0
-  IRremoteESP8266 @ 2.8.2
-  makuna/NeoPixelBus @ 2.7.9
-  https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.0
 
 
 [esp32]

--- a/platformio.ini
+++ b/platformio.ini
@@ -2682,7 +2682,7 @@ build_flags = ${esp32_4MB_S_base.build_flags}
 [env:esp32_pico_4MB_M]
 extends = esp32_4MB_M_base
 board = pico32
-board_build.flash_mode = dout ;; (dout = dual out; more compatible than qio = quad i/o)
+board_build.flash_mode = dio ;; (dout = dual out; more compatible than qio = quad i/o)
 upload_speed = 256000 ;; or 115200 ;; or 460800 ; or 921600  (slower speeds are better when flashing without a soldered connection)
 
 build_flags = ${esp32_4MB_M_base.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -126,11 +126,7 @@ extra_configs =
 #   arduino core 2.6.3 = platformIO 2.3.2
 #   arduino core 2.7.0 = platformIO 2.5.0
 # ------------------------------------------------------------------------------
-arduino_core_2_6_3 = espressif8266@2.3.3
-arduino_core_2_7_4 = espressif8266@2.6.2
-arduino_core_3_0_0 = espressif8266@3.0.0
 arduino_core_3_2_0 = espressif8266@3.2.0
-arduino_core_4_1_0 = espressif8266@4.1.0
 arduino_core_3_1_2 = espressif8266@4.2.1
 
 # Development platforms
@@ -212,7 +208,7 @@ build_flags =
 build_unflags =
 
 build_flags_esp8266 = ${common.build_flags}  ${esp8266.build_flags}
-build_flags_esp32   = ${common.build_flags}  ${esp32.build_flags}
+build_flags_esp32   = ${common.build_flags}  ${esp32_idf_V4.build_flags}
 build_flags_esp32_V4= ${common.build_flags}  ${esp32_idf_V4.build_flags}
 
 ldscript_1m128k = eagle.flash.1m128.ld
@@ -342,21 +338,9 @@ lib_deps_compat =
 
 
 [esp32]
-#platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
-platform = espressif32@3.5.0
-
-platform_packages = framework-arduinoespressif32 @ https://github.com/Aircoookie/arduino-esp32.git#1.0.6.4
-
-build_flags = -g
-  -DARDUINO_ARCH_ESP32
-  #-DCONFIG_LITTLEFS_FOR_IDF_3_2
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -D CONFIG_ASYNC_TCP_TASK_STACK_SIZE=9472                ;; WLEDMM increase stack by 1.25Kb, as audioreactive needs bigger SETTINGS_STACK_BUF_SIZE
-  #use LITTLEFS library by lorol in ESP32 core 1.x.x instead of built-in in 2.x.x
-  -D LOROL_LITTLEFS
-  ; -D WLEDMM_TWOPATH    ;; use I2S1 as the second bus --> ~15% faster on "V3" builds - may flicker a bit more
-  ; -D WLEDMM_SLOWPATH ;; don't use I2S for LED bus
-  ; -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
+platform             = ${esp32_idf_V4.platform}
+platform_packages    = ${esp32_idf_V4.platform_packages}
+build_flags          = ${esp32_idf_V4.build_flags}
 
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv      ;; WLED standard for 4MB flash: 1.4MB firmware, 1MB filesystem
 ;default_partitions = tools/WLED_ESP32_4MB_256KB_FS.csv   ;; WLEDMM alternative for 4MB flash:   1.8MB firmware, 256KB filesystem (esptool erase_flash needed before changing)
@@ -367,14 +351,7 @@ big_partitions = tools/WLED_ESP32_4MB_256KB_FS.csv     ;; 1.8MB firmware, 256KB 
 large_partitions = tools/WLED_ESP32_8MB.csv
 extreme_partitions = tools/WLED_ESP32_16MB_9MB_FS.csv
 
-lib_deps =
-  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0 ;; WLEDMM this must be first in the list, otherwise Aircoookie/ESPAsyncWebServer pulls in an older version of AsyncTCP !!
-  ; https://github.com/lorol/LITTLEFS.git
-  ; WLEDMM specific: use patched version of lorol LittleFS
-  https://github.com/softhack007/LITTLEFS-threadsafe.git#master
-  makuna/NeoPixelBus @ 2.7.5
-  ;; makuna/NeoPixelBus @ 2.7.9 ;; experimental
-  ${env.lib_deps}
+lib_deps = ${esp32_idf_V4.lib_deps}
 
 ;; Compatibility with upstream --> you should prefer using ${common_mm.build_flags_S} and ${common_mm.lib_deps_S}
 AR_build_flags = ${common_mm.AR_build_flags}
@@ -417,9 +394,6 @@ lib_depsV4 =
 ;; WLEDMM end
 
 [esp32_idf_V4]
-;; experimental build environment for ESP32 using ESP-IDF 4.4.x / arduino-esp32 v2.0.5
-;; very similar to the normal ESP32 flags, but omitting Lorol LittleFS, as littlefs is included in the new framework already.
-;;
 ;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
 

--- a/usermods/BME280_v2/usermod_bme280.h
+++ b/usermods/BME280_v2/usermod_bme280.h
@@ -245,7 +245,7 @@ public:
         // from the UI and values read from sensor, then publish to broker
         if (temperature != lastTemperature || PublishAlways)
         {
-          publishMqtt("temperature", String(temperature, TemperatureDecimals).c_str());
+          publishMqtt("temperature", String(temperature, (unsigned)TemperatureDecimals).c_str());
         }
 
         lastTemperature = temperature; // Update last sensor temperature for next loop
@@ -258,17 +258,17 @@ public:
 
           if (humidity != lastHumidity || PublishAlways)
           {
-            publishMqtt("humidity", String(humidity, HumidityDecimals).c_str());
+            publishMqtt("humidity", String(humidity, (unsigned)HumidityDecimals).c_str());
           }
 
           if (heatIndex != lastHeatIndex || PublishAlways)
           {
-            publishMqtt("heat_index", String(heatIndex, TemperatureDecimals).c_str());
+            publishMqtt("heat_index", String(heatIndex, (unsigned)TemperatureDecimals).c_str());
           }
 
           if (dewPoint != lastDewPoint || PublishAlways)
           {
-            publishMqtt("dew_point", String(dewPoint, TemperatureDecimals).c_str());
+            publishMqtt("dew_point", String(dewPoint, (unsigned)TemperatureDecimals).c_str());
           }
 
           lastHumidity = humidity;
@@ -285,7 +285,7 @@ public:
 
         if (pressure != lastPressure || PublishAlways)
         {
-          publishMqtt("pressure", String(pressure, PressureDecimals).c_str());
+          publishMqtt("pressure", String(pressure, (unsigned)PressureDecimals).c_str());
         }
 
         lastPressure = pressure;


### PR DESCRIPTION
Update all builds to be using the V4 ESP-IDF, no more V3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Cleaned up and simplified platform configuration options for ESP8266 and ESP32 devices.
  - Updated ESP32 environment to inherit settings from a common configuration, reducing duplication.
  - Changed flash mode for ESP32 Pico 4MB module to improve compatibility.

- **Style**
  - Improved type safety in MQTT message formatting for BME280 sensor readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->