### PR TITLE
Added code to handle Half-step encoders along with a config option

### DIFF
--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.h
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.h
@@ -1094,7 +1094,7 @@ void RotaryEncoderUIUsermod::addToConfig(JsonObject &root) {
   top[FPSTR(_presetLow)]  = presetLow;
   top[FPSTR(_presetHigh)] = presetHigh;
   top[FPSTR(_applyToAll)] = applyToAll;
-  top[FPSTR(_HalfStep)] = HalfStep
+  top[FPSTR(_HalfStep)] = HalfStep;
   DEBUG_PRINTLN(F("Rotary Encoder config saved."));
 }
 


### PR DESCRIPTION
to turn it on/off.  Have a mixture of Quad and Half step encoders and wanted an easy way to use either without recompiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "half step" mode for rotary encoder controls for finer input resolution.
  * Encoder mode selection is now persisted and restored automatically.

* **Bug Fixes**
  * Improved and stabilized rotary encoder edge detection and direction handling for both half-step and full-step modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->