### PR TITLE
Adding DSP FFT and supporting integer math functions 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1577,6 +1577,9 @@ build_flags = ${common.build_flags_esp8266} -D WLED_DISABLE_OTA
   -D WLED_DISABLE_HUESYNC
   -D WLED_DISABLE_ESPNOW   ;; exceeds flash size limits
   -D WLED_DISABLE_INFRARED ;; exceeds flash size limits
+  -D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit
+  -D WLED_DISABLE_PARTICLESYSTEM2D ;; exceeds flash size limit
+
 lib_deps = ${esp8266.lib_deps}
 lib_ignore = IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
 ; RAM:   [======    ]  60.6% (used 49616 bytes from 81920 bytes)
@@ -2426,7 +2429,8 @@ build_flags = ${common.build_flags} ${esp32c3.build_flags}
   ;-D HW_PIN_SDA=0 -D HW_PIN_SCL=1 ;; for I2C Qwiic connector
   -D SR_DMTYPE=1 -D I2S_SDPIN=5 -D I2S_WSPIN=6 -D I2S_CKPIN=4 -D MCLK_PIN=7
   ; -D WLED_USE_MY_CONFIG
-
+  -D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit
+  -D WLED_DISABLE_PARTICLESYSTEM2D ;; exceeds flash size limit
 lib_deps = ${esp32c3.lib_deps} ${common_mm.lib_deps_S} ${common_mm.lib_deps_V4_M}
 lib_ignore = 
   ;IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
@@ -2450,6 +2454,8 @@ build_flags = ${env:esp32c3dev_4MB_M.build_flags}
   -D WLED_DISABLE_BROWNOUT_DET    ;; the board only has a 500mA LDO, better to disable brownout detection
   -D WLED_DISABLE_ADALIGHT        ;; to disable serial protocols for boards with CDC USB (Serial RX will receive junk commands, unless its pulled down by resistor)
   -D HW_PIN_SDA=0 -D HW_PIN_SCL=1 ;; avoid pin conflicts
+  -D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit
+  -D WLED_DISABLE_PARTICLESYSTEM2D ;; exceeds flash size limit
 ; RAM:   [==        ]  24.6% (used 80556 bytes from 327680 bytes)
 ; Flash: [==========]  97.3% (used 1530346 bytes from 1572864 bytes)
 
@@ -2476,7 +2482,8 @@ build_flags = ${env:esp32c3dev_4MB_M.build_flags}
   -D WLED_DISABLE_BROWNOUT_DET    ;; the board only has a 500mA LDO, better to disable brownout detection
   -D WLED_DISABLE_ADALIGHT        ;; to disable serial protocols for boards with CDC USB (Serial RX will receive junk commands, unless its pulled down by resistor)
   -D HW_PIN_SDA=0 -D HW_PIN_SCL=1 ;; avoid pin conflicts
-
+  -D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit
+  -D WLED_DISABLE_PARTICLESYSTEM2D ;; exceeds flash size limit
 ; RAM:   [==        ]  24.0% (used 78676 bytes from 327680 bytes)
 ; Flash: [==========]  96.4% (used 1516068 bytes from 1572864 bytes)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1610,6 +1610,7 @@ build_flags = ${esp32_4MB_V4_S_base.esp32_build_flags}
   ; -D SR_DEBUG
   ; -D MIC_LOGGER
   ${common_mm.HUB75_build_flags}
+  -D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit
 lib_deps = ${esp32_4MB_V4_S_base.esp32_lib_deps}
     ${common_mm.HUB75_lib_deps}
 lib_ignore = IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
@@ -2221,6 +2222,8 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   ; -D WLED_DEBUG
   ; -D SR_DEBUG
   ; -D MIC_LOGGER
+  -D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit
+  -D WLED_DISABLE_PARTICLESYSTEM2D ;; exceeds flash size limit
 lib_deps = ${esp32s3.lib_deps} ${common_mm.lib_deps_S}  ${common_mm.lib_deps_V4_M}
 lib_ignore =
   IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation

--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -195,9 +195,8 @@ static uint8_t binNum = 8;           // Used to select the bin for FFT based bea
 #define UM_AUDIOREACTIVE_USE_ARDUINO_FFT // DSP FFT library is not available in ESP-IDF < 4.4
 #endif
 
-//TODO: is the sqrt of any use for DSP FFT?
-#define sqrt(x) sqrtf(x)                // little hack that reduces FFT time by 10-50% on ESP32 (as alternative to FFT_SQRT_APPROXIMATION)
 #ifdef UM_AUDIOREACTIVE_USE_ARDUINO_FFT
+#define sqrt(x) sqrtf(x)                // little hack that reduces FFT time by 10-50% on ESP32 (as alternative to FFT_SQRT_APPROXIMATION)
 #define sqrt_internal sqrtf             // see https://github.com/kosme/arduinoFFT/pull/83
 #include <arduinoFFT.h>                 // ArduinoFFT library for FFT and window functions
 #undef UM_AUDIOREACTIVE_USE_INTEGER_FFT // arduinoFFT has not integer support
@@ -630,7 +629,6 @@ void FFTcode(void * parameter)
   float *windowFloat = (float*) calloc(sizeof(float), samplesFFT); // temporary buffer for window function
   if ((windowFloat == nullptr)) return; // something went wrong
     switch(fftWindow) {                             // apply FFT window. note: DSPS windows use ~2k of flash
-    /*
     case 1:
       dsps_wind_hann_f32(windowFloat, samplesFFT);  // recommended for 50% overlap
       wc = 0.66415918066;     // 1.8554726898 * 2.0
@@ -650,7 +648,7 @@ void FFTcode(void * parameter)
     case 4:
         dsps_wind_flat_top_f32(windowFloat, samplesFFT);      // Weigh data using "Flat Top" function - better amplitude preservation, low frequency accuracy
       wc = 1.276771793156f;   // 3.5659039231 * 2.0
-    break;*/
+    break;
     case 0: // falls through
     default:
       dsps_wind_blackman_harris_f32(windowFloat, samplesFFT); // Weigh data using "Blackman- Harris" window - sharp peaks due to excellent sideband rejection

--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -795,7 +795,7 @@ void FFTcode(void * parameter)
 #endif
 
     #ifdef FFT_USE_SLIDING_WINDOW
-    memcpy(oldSamples, valFFT+samplesFFT_2, sizeof(float) * samplesFFT_2);  // copy last 50% to buffer (for sliding window FFT)
+    memcpy(oldSamples, valFFT+samplesFFT_2, sizeof(FFTsampleType) * samplesFFT_2);  // copy last 50% to buffer (for sliding window FFT)
     haveOldSamples = true;
     #endif
 
@@ -824,7 +824,7 @@ void FFTcode(void * parameter)
 #endif
       }
     }
-    newZeroCrossingCount = (newZeroCrossingCount*341)>>9; // multiply by 1/3 to reduce value so it typically stays below 256
+    newZeroCrossingCount = (newZeroCrossingCount*341)>>9; // multiply by 2/3 to reduce value so it typically stays below 256
     zeroCrossingCount = newZeroCrossingCount; // update only once, to avoid that effects pick up an intermediate value
 
     // release highest sample to volume reactive effects early - not strictly necessary here - could also be done at the end of the function

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -470,6 +470,7 @@ uint8_t cos8_t(uint8_t theta);
 float sin_approx(float theta); // uses integer math (converted to float), accuracy +/-0.0015 (compared to sinf())
 float cos_approx(float theta);
 float tan_approx(float x);
+uint32_t sqrt32_bw(uint32_t x);
 //float atan2_t(float y, float x);
 //float acos_t(float x);
 //float asin_t(float x);

--- a/wled00/wled_math.cpp
+++ b/wled00/wled_math.cpp
@@ -110,6 +110,30 @@ float tan_approx(float x) {
   return res;
 }
 
+// bit-wise integer square root calculation (exact) by @dedehai
+uint32_t sqrt32_bw(uint32_t x) {
+  uint32_t res = 0;
+  uint32_t bit;
+  uint32_t num = x; // use 32bit for faster calculation
+
+  if(num < 1 << 10)  bit = 1 << 10; // speed optimization for small numbers < 32^2
+  else if (num < 1 << 20) bit = 1 << 20; // speed optimization for medium numbers < 1024^2
+  else bit = 1 << 30; // start with highest power of 4 <= 2^32
+
+  while (bit > num) bit >>= 2; // reduce iterations
+
+  while (bit != 0) {
+    if (num >= res + bit) {
+      num -= res + bit;
+      res = (res >> 1) + bit;
+    } else {
+      res >>= 1;
+    }
+    bit >>= 2;
+  }
+  return res;
+}
+
 #if 0  // WLEDMM we prefer libm functions that are accurate and fast.
 #define ATAN2_CONST_A 0.1963f
 #define ATAN2_CONST_B 0.9817f


### PR DESCRIPTION
Ported from AC PR: https://github.com/wled/WLED/pull/4750

- Added ESP DSP FFT option for all ESP32 variants
- ESP32 and S3 still use ArduinoFFT by default (DSP FFT uses ~15k of extra flash but it is about twice as fast)
- S2 and C3 use DSP FFT with integer math by default
- Added integer math for handling sample filter and FFT bin post-processing
- Added bit-wise square root function I implemented in AC for fast integer square root calculation
- Removed now unused FFT_PREFER_EXACT_PAKS
- Removed skipping of every other "frame" as its no longer needed for C3


Questions/Comments for @softhack007 
- `runDCBlocker()` has an AC gain > 1 which can be a problem in integer math samples. I found that using `runMicFilter()` with a low-cutoff of 100Hz followed by a simple DC removal (by subtracting the mean value from all samples) gives quite good results on an INMP441. In what circumstances is the runDCBlocker() function useful? Can it be dropped for simple setups that use integer samples i.e. on  C3/S2?
- `runMicFilter()` cutoff frequency comments for high frequencies are wrong for a sample rate of 22kHz (none of the cutoffs can be any higher than 11kHz as that is the Nyquist-frequency)
- There are several scaling factors in the code, with the new DSP FFT any scaling of raw samples could be pre-computed into the windowing function. It makes the code a bit less clean but faster.
- I moved the scaling of the raw FFT samples to the `fftAddAvg()` function as for integer samples it is faster and more accurate, so I did the same for the float version.
- Having all windowing options is great but all the windows use up flash. Are all the alternatives to Blackman-Harris really needed at runtime?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple FFT backends and data types in audio reactive features, enabling improved compatibility and performance across different devices.
  * Introduced a new bit-wise integer square root calculation for 32-bit values, enhancing mathematical operations.

* **Refactor**
  * Unified and generalized audio FFT processing to seamlessly handle both floating-point and integer data types.
  * Updated audio sample handling to support the new FFT abstraction, improving flexibility and efficiency.

* **Bug Fixes**
  * Improved accuracy and performance of FFT and peak detection logic for both integer and float data paths.

* **Chores**
  * Disabled particle system features in multiple build environments to reduce firmware size and fit flash constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->