### PR TITLE
Enable builds with DMX Output support

### DIFF
--- a/platformio_override.ini
+++ b/platformio_override.ini
@@ -1,0 +1,7 @@
+; === platformio_override.ini ===
+[env:esp32dev_v4_dmx]
+extends = env:esp32dev
+build_flags =
+  ${common.build_flags}
+  -DWLED_RELEASE_NAME=\"mmwled-dmx\"
+  -D WLED_ENABLE_DMX


### PR DESCRIPTION
DMX in/out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an ESP32 build variant with DMX support. Users can compile a release labeled “mmwled-dmx” that enables DMX functionality.
- Chores
  - Introduced a PlatformIO environment to simplify building the DMX-enabled ESP32 variant, extending the existing configuration with appropriate build flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->