### PR TITLE
Fix the git commit for GifDecoder

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -253,7 +253,7 @@ lib_deps =
     ;;makuna/NeoPixelBus @ 2.7.5 ;; WLEDMM will be added in board specific sections
     https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.2
     bitbank2/AnimatedGIF@^1.4.7
-    https://github.com/Aircoookie/GifDecoder#bc3af18
+    https://github.com/Aircoookie/GifDecoder#bc3af189b6b1e06946569f6b4287f0b79a860f8e
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI
   #For compatible OLED display uncomment following


### PR DESCRIPTION
I couldn't get the GifDecoder library dependency to work - according to the [PlatformIO documentation](https://docs.platformio.org/en/latest/core/userguide/pkg/cmd_install.html#repository-git-hg-svn) it supports the full commit hash - tried it and it worked.

Before:

```
Resolving esp32S3_8MB_PSRAM_M dependencies...
Library Manager: Installing git+https://github.com/Aircoookie/GifDecoder#bc3af18
git version 2.51.0.windows.2
Initialized empty Git repository in C:/Users/charlie/.platformio/.cache/tmp/pkg-installing-mrxdrs01/.git/
fatal: couldn't find remote ref bc3af18

VCSBaseException: VCS: Could not process command ['git', 'fetch', '--depth=1', 'origin', 'bc3af18']
```

If I'm missing a trick here, please let me know.

It also works without the commit, since that's still the default branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated library dependency for improved stability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->