### PR TITLE
gifdecoder bugfixes, up to 30% speedup, and minor improvements

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -4693,9 +4693,11 @@ static const char _data_FX_MODE_WASHING_MACHINE[] PROGMEM = "Washing Machine@!,!
   Draws a .gif image from filesystem on the matrix/strip
 */
 uint16_t mode_image(void) {
+  if (!strip.isMatrix) return mode_oops(); // not a 2D set-up
   #ifndef WLED_ENABLE_GIF
   return mode_oops();
   #else
+  if (max(SEGMENT.virtualWidth(),SEGMENT.virtualHeight()) < 4) return mode_oops(); // too small
   renderImageToSegment(SEGMENT);
   return FRAMETIME;
   #endif
@@ -4704,7 +4706,7 @@ uint16_t mode_image(void) {
   //   Serial.println(status);
   // }
 }
-static const char _data_FX_MODE_IMAGE[] PROGMEM = "Image@!,;;;12;sx=128";
+static const char _data_FX_MODE_IMAGE[] PROGMEM = "Image@!,Blur,;;;12;sx=128,ix=0";
 
 /*
   Blends random colors across palette

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -142,7 +142,8 @@ byte renderImageToSegment(Segment &seg) {
     } catch (...) {  // if we arrive here, the decoder has thrown an OOM exception
       gifDecodeFailed = true;
       errorFlag = ERR_NORAM_PX;
-      USER_PRINTLN("\nGIF decoder out of memory. I'm going to shoot myself now.\n");
+      USER_PRINTLN("\nGIF decoder out of memory. Please try a smaller image file.\n");
+      //USER_PRINTLN("I'm going to shoot myself now.");
       return IMAGE_ERROR_DECODER_ALLOC;
     }
 #endif

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -131,7 +131,18 @@ byte renderImageToSegment(Segment &seg) {
     decoder.setFileReadCallback(fileReadCallback);
     decoder.setFileReadBlockCallback(fileReadBlockCallback);
     decoder.setFileSizeCallback(fileSizeCallback);
+#if __cpp_exceptions // use exception handler if we can (some targets don't support exceptions)
+    try {            
+#endif
     decoder.alloc(); // WLEDMM this function may throw out-of memory and cause a crash
+#if __cpp_exceptions
+    } catch (...) {  // if we arrive here, the decoder has thrown an OOM exception
+      gifDecodeFailed = true;
+      errorFlag = ERR_NORAM_PX;
+      USER_PRINTLN("\nGIF decoder out of memory. I'm going to shoot myself now.\n");
+      return IMAGE_ERROR_DECODER_ALLOC;
+    }
+#endif
 
     DEBUG_PRINTLN(F("Starting decoding"));
     int derr = 0;

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -111,6 +111,7 @@ byte renderImageToSegment(Segment &seg) {
 
   if (strncmp(lastFilename +1, seg.name, 32) != 0) { // segment name changed, load new image
     strncpy(lastFilename +1, seg.name, 32);
+    lastFilename[33] = '\0'; // make sure that lastFilename is always null-terminated
     gifDecodeFailed = false;
     size_t fnameLen = strlen(lastFilename);
     if ((fnameLen < 4) || strcmp(lastFilename + fnameLen - 4, ".gif") != 0) { // empty segment name, name too short, or name not ending in .gif

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -158,6 +158,12 @@ byte renderImageToSegment(Segment &seg) {
   if (millis() - lastFrameDisplayTime < wait) return IMAGE_ERROR_WAITING;
 
   decoder.getSize(&gifWidth, &gifHeight);
+  // bad gif size: prevent division by zero
+  if (gifWidth == 0 || gifHeight == 0) {
+    gifDecodeFailed = true;
+    USER_PRINTF("Invalid GIF dimensions: %dx%d\n", gifWidth, gifHeight);
+    return IMAGE_ERROR_GIF_DECODE;
+  }
   // softhack007: pre-calculate upscaling for speedup
   expandX = (seg_cols+(gifWidth-1)) / gifWidth;
   expandY = (seg_rows+(gifHeight-1)) / gifHeight;

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -111,9 +111,10 @@ byte renderImageToSegment(Segment &seg) {
   if (strncmp(lastFilename +1, seg.name, 32) != 0) { // segment name changed, load new image
     strncpy(lastFilename +1, seg.name, 32);
     gifDecodeFailed = false;
-    if (strcmp(lastFilename + strlen(lastFilename) - 4, ".gif") != 0) {
+    size_t fnameLen = strlen(lastFilename);
+    if ((fnameLen < 4) || strcmp(lastFilename + strlen(lastFilename) - 4, ".gif") != 0) { // empty segment name, name too short, or name not ending in .gif
       gifDecodeFailed = true;
-      USER_PRINTF("Unsupported format: %s\n", lastFilename);
+      USER_PRINTF("GIF decoder unsupported file: %s\n", lastFilename);
       return IMAGE_ERROR_UNSUPPORTED_FORMAT;
     }
     if (file) file.close();

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -9,11 +9,15 @@
  * Functions to render images from filesystem to segments, used by the "Image" effect
  */
 
-File file;
-char lastFilename[34] = "/";
-GifDecoder<320,320,12,true> decoder;
-bool gifDecodeFailed = false;
-unsigned long lastFrameDisplayTime = 0, currentFrameDelay = 0;
+static File file;
+static char lastFilename[34] = "/";
+#if !defined(BOARD_HAS_PSRAM)
+  static GifDecoder<256,256,11,true> decoder;  // WLEDMM use less RAM on boards without PSRAM - avoids crashes due to out-of-memory
+#else
+  static GifDecoder<320,320,12,true> decoder;
+#endif
+static bool gifDecodeFailed = false;
+static unsigned long lastFrameDisplayTime = 0, currentFrameDelay = 0;
 
 bool fileSeekCallback(unsigned long position) {
   return file.seek(position);
@@ -35,29 +39,49 @@ int fileSizeCallback(void) {
   return file.size();
 }
 
-bool openGif(const char *filename) {
+bool openGif(const char *filename) {  // side-effect: updates "file"
   file = WLED_FS.open(filename, "r");
+  DEBUG_PRINTF("opening GIF file %s\n", filename);
 
   if (!file) return false;
   return true;
 }
 
-Segment* activeSeg;
-uint16_t gifWidth, gifHeight;
+static Segment* activeSeg;
+static uint16_t gifWidth, gifHeight;  // these two must stay uint16_t, because they are passed by reference
+static unsigned seg_cols = 1;
+static unsigned seg_rows = 1;
+static int expandX = 1;
+static int expandY = 1;
+static int lastX = -1, lastY = -1;
 
 void screenClearCallback(void) {
   activeSeg->fill(0);
 }
 
-void updateScreenCallback(void) {}
-
+void updateScreenCallback(void) {
+  // this callback runs when the decoder has finished painting all pixels
+  // perfect time for adding blur
+  if (activeSeg->intensity > 1) {
+    uint8_t blurAmount = activeSeg->intensity >> 2;
+    if ((blurAmount < 24) && (activeSeg->is2D())) activeSeg->blurRows(activeSeg->intensity >> 1);  // some blur - fast
+    else activeSeg->blur(blurAmount);                                                              // more blur - slower
+  }
+  lastX = lastY = -1; // invalidate last position
+}
 void drawPixelCallback(int16_t x, int16_t y, uint8_t red, uint8_t green, uint8_t blue) {
-  // simple nearest-neighbor scaling 
-  int16_t outY = y * activeSeg->height() / gifHeight;
-  int16_t outX = x * activeSeg->width()  / gifWidth;
+  // simple nearest-neighbor downscaling
+  int outY = y * seg_rows / gifHeight;
+  int outX = x * seg_cols / gifWidth;
+
+  if ((unsigned(outX) >= seg_cols) || (unsigned(outY) >= seg_rows)) return; // out of range
+  if ((lastX == outX) && (lastY == outY)) return;                           // downscaling optimization: skip re-painting same pixel
+  lastX = outX; lastY = outY;
+
   // set multiple pixels if upscaling
-  for (int16_t i = 0; i < (activeSeg->width()+(gifWidth-1)) / gifWidth; i++) {
-    for (int16_t j = 0; j < (activeSeg->height()+(gifHeight-1)) / gifHeight; j++) {
+  // softhack007: changed loop x/y order -> minor speedup from better cache locality
+  for (int j = 0; j < expandY; j++) {
+    for (int i = 0; i < expandX; i++) {
       activeSeg->setPixelColorXY(outX + i, outY + j, gamma8(red), gamma8(green), gamma8(blue));
     }
   }
@@ -81,17 +105,24 @@ byte renderImageToSegment(Segment &seg) {
   // TODO: if (seg.mode != seg.currentMode()) return IMAGE_ERROR_WAITING;
   if (activeSeg && activeSeg != &seg) return IMAGE_ERROR_SEG_LIMIT; // only one segment at a time
   activeSeg = &seg;
+  seg_cols = activeSeg->virtualWidth();
+  seg_rows = activeSeg->virtualHeight();
 
   if (strncmp(lastFilename +1, seg.name, 32) != 0) { // segment name changed, load new image
     strncpy(lastFilename +1, seg.name, 32);
     gifDecodeFailed = false;
     if (strcmp(lastFilename + strlen(lastFilename) - 4, ".gif") != 0) {
       gifDecodeFailed = true;
+      USER_PRINTF("Unsupported format: %s\n", lastFilename);
       return IMAGE_ERROR_UNSUPPORTED_FORMAT;
     }
     if (file) file.close();
-    openGif(lastFilename);
-    if (!file) { gifDecodeFailed = true; return IMAGE_ERROR_FILE_MISSING; }
+
+    if (!openGif(lastFilename)) {
+      gifDecodeFailed = true; 
+      USER_PRINTF("GIF file not found: %s\n", lastFilename);
+      return IMAGE_ERROR_FILE_MISSING; 
+    }
     decoder.setScreenClearCallback(screenClearCallback);
     decoder.setUpdateScreenCallback(updateScreenCallback);
     decoder.setDrawPixelCallback(drawPixelCallback);
@@ -100,9 +131,18 @@ byte renderImageToSegment(Segment &seg) {
     decoder.setFileReadCallback(fileReadCallback);
     decoder.setFileReadBlockCallback(fileReadBlockCallback);
     decoder.setFileSizeCallback(fileSizeCallback);
-    decoder.alloc();
+    decoder.alloc(); // WLEDMM this function may throw out-of memory and cause a crash
+
     DEBUG_PRINTLN(F("Starting decoding"));
-    if(decoder.startDecoding() < 0) { gifDecodeFailed = true; return IMAGE_ERROR_GIF_DECODE; }
+    int derr = 0;
+    if((derr = decoder.startDecoding()) < 0) { 
+      gifDecodeFailed = true;
+      USER_PRINTF("GIF Decoding error %d\n", derr);
+      if ((derr == ERROR_GIF_TOO_WIDE) || (derr == ERROR_GIF_UNSUPPORTED_FEATURE) || (derr == ERROR_GIF_INVALID_PARAMETER)) 
+        errorFlag = ERR_NORAM_PX;
+      return IMAGE_ERROR_GIF_DECODE; 
+    }
+    if ((errorFlag == ERR_NORAM_PX) || (errorFlag == ERR_NORAM)) errorFlag = ERR_NONE; // success -> reset previous memory error codes
     DEBUG_PRINTLN(F("Decoding started"));
   }
 
@@ -118,9 +158,16 @@ byte renderImageToSegment(Segment &seg) {
   if (millis() - lastFrameDisplayTime < wait) return IMAGE_ERROR_WAITING;
 
   decoder.getSize(&gifWidth, &gifHeight);
+  // softhack007: pre-calculate upscaling for speedup
+  expandX = (seg_cols+(gifWidth-1)) / gifWidth;
+  expandY = (seg_rows+(gifHeight-1)) / gifHeight;
 
   int result = decoder.decodeFrame(false);
-  if (result < 0) { gifDecodeFailed = true; return IMAGE_ERROR_FRAME_DECODE; }
+  if (result < 0) {
+    gifDecodeFailed = true;
+    USER_PRINTF("GIF Frame decode failed %d\n", result);
+    return IMAGE_ERROR_FRAME_DECODE;
+   }
 
   currentFrameDelay = decoder.getFrameDelay_ms();
   unsigned long tooSlowBy = (millis() - lastFrameDisplayTime) - wait; // if last frame was longer than intended, compensate

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -113,7 +113,7 @@ byte renderImageToSegment(Segment &seg) {
     strncpy(lastFilename +1, seg.name, 32);
     gifDecodeFailed = false;
     size_t fnameLen = strlen(lastFilename);
-    if ((fnameLen < 4) || strcmp(lastFilename + strlen(lastFilename) - 4, ".gif") != 0) { // empty segment name, name too short, or name not ending in .gif
+    if ((fnameLen < 4) || strcmp(lastFilename + fnameLen - 4, ".gif") != 0) { // empty segment name, name too short, or name not ending in .gif
       gifDecodeFailed = true;
       USER_PRINTF("GIF decoder unsupported file: %s\n", lastFilename);
       return IMAGE_ERROR_UNSUPPORTED_FORMAT;

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -49,8 +49,9 @@ bool openGif(const char *filename) {  // side-effect: updates "file"
 
 static Segment* activeSeg;
 static uint16_t gifWidth, gifHeight;  // these two must stay uint16_t, because they are passed by reference
-static unsigned seg_cols = 1;
-static unsigned seg_rows = 1;
+static unsigned segCols = 1;
+static unsigned segRows = 1;
+//static unsigned segLen = 1; // for future 1D support
 static int expandX = 1;
 static int expandY = 1;
 static int lastX = -1, lastY = -1;
@@ -69,12 +70,11 @@ void updateScreenCallback(void) {
   }
   lastX = lastY = -1; // invalidate last position
 }
-void drawPixelCallback(int16_t x, int16_t y, uint8_t red, uint8_t green, uint8_t blue) {
+void draw2DPixelCallback(int16_t x, int16_t y, uint8_t red, uint8_t green, uint8_t blue) {
   // simple nearest-neighbor downscaling
-  int outY = y * seg_rows / gifHeight;
-  int outX = x * seg_cols / gifWidth;
-
-  if ((unsigned(outX) >= seg_cols) || (unsigned(outY) >= seg_rows)) return; // out of range
+  int outY = y * segRows / gifHeight;
+  int outX = x * segCols / gifWidth;
+  if ((unsigned(outX) >= segCols) || (unsigned(outY) >= segRows)) return; // out of range
   if ((lastX == outX) && (lastY == outY)) return;                           // downscaling optimization: skip re-painting same pixel
   lastX = outX; lastY = outY;
 
@@ -105,8 +105,9 @@ byte renderImageToSegment(Segment &seg) {
   // TODO: if (seg.mode != seg.currentMode()) return IMAGE_ERROR_WAITING;
   if (activeSeg && activeSeg != &seg) return IMAGE_ERROR_SEG_LIMIT; // only one segment at a time
   activeSeg = &seg;
-  seg_cols = activeSeg->virtualWidth();
-  seg_rows = activeSeg->virtualHeight();
+  segCols = activeSeg->virtualWidth();
+  segRows = activeSeg->virtualHeight();
+  // segLen = activeSeg->virtualLength(); // for future 1D and expand1D support
 
   if (strncmp(lastFilename +1, seg.name, 32) != 0) { // segment name changed, load new image
     strncpy(lastFilename +1, seg.name, 32);
@@ -126,7 +127,7 @@ byte renderImageToSegment(Segment &seg) {
     }
     decoder.setScreenClearCallback(screenClearCallback);
     decoder.setUpdateScreenCallback(updateScreenCallback);
-    decoder.setDrawPixelCallback(drawPixelCallback);
+    decoder.setDrawPixelCallback(draw2DPixelCallback);
     decoder.setFileSeekCallback(fileSeekCallback);
     decoder.setFilePositionCallback(filePositionCallback);
     decoder.setFileReadCallback(fileReadCallback);
@@ -177,8 +178,8 @@ byte renderImageToSegment(Segment &seg) {
     return IMAGE_ERROR_GIF_DECODE;
   }
   // softhack007: pre-calculate upscaling for speedup
-  expandX = (seg_cols+(gifWidth-1)) / gifWidth;
-  expandY = (seg_rows+(gifHeight-1)) / gifHeight;
+  expandX = (segCols+(gifWidth-1)) / gifWidth;
+  expandY = (segRows+(gifHeight-1)) / gifHeight;
 
   int result = decoder.decodeFrame(false);
   if (result < 0) {


### PR DESCRIPTION
* fixed a bug that caused wrong behavior with segment mirroring 
  (effects *must* use virtualHeight() /  virtualWidth() instead of height() / width())
* added image blur as an option (second slider)
* added very basic error reporting for users
*  up to 25% faster, especially with big, animated gifs

* made all local variables "static" (don't pollute global namespace)
* drawPixelCallback: cache calculations that do not depend on x/y position
* reduced memory allocations on boards without PSRAM, to avoid crashes. This may lead to error messages when trying opening GIFs > 64x64 pixels, however boards without PSRAM are not able to handle more pixels any way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image/GIF playback: added an extra image parameter plus a Blur intensity; improved per-segment scaling/upscaling and memory-aware decoder behavior on low-RAM devices.

* **Bug Fixes**
  * Image mode now runs only on 2D/matrix layouts and rejects tiny GIFs.
  * Robust filename validation, graceful failures for missing/unsupported files or low-memory, better decoding error handling and playback cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->