### PR TITLE
Pixelforge backport, UI stability improvements, speedup for UDP real-time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "wled",
   "version": "14.7.0-mdev",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -9,74 +9,99 @@
       "version": "14.7.0-mdev",
       "license": "EUPL-1.2",
       "dependencies": {
-        "clean-css": "^4.2.3",
-        "html-minifier-terser": "^5.1.1",
-        "inliner": "^1.13.1",
-        "nodemon": "^2.0.20",
-        "zlib": "^1.0.5"
-      }
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dependencies": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "clean-css": "^5.3.3",
+        "html-minifier-terser": "^7.2.0",
+        "nodemon": "^3.1.9",
+        "web-resource-inliner": "^7.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6.0.0"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6.0.0"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -85,177 +110,67 @@
         "node": ">= 8"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-    },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
-    "node_modules/camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "node_modules/center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "license": "MIT",
       "dependencies": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/charset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
-      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/cheerio": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
-      "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
-      "dependencies": {
-        "css-select": "~1.0.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "~3.8.1",
-        "lodash": "^3.2.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -268,369 +183,190 @@
       "engines": {
         "node": ">= 8.10.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/clap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-      "dependencies": {
-        "chalk": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "license": "MIT",
       "dependencies": {
         "source-map": "~0.6.0"
       },
       "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/clean-css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dependencies": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      }
-    },
-    "node_modules/coa": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-      "dependencies": {
-        "q": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
+        "node": ">= 10.0"
       }
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/configstore": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-      "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.1",
-        "os-tmpdir": "^1.0.0",
-        "osenv": "^0.1.0",
-        "uuid": "^2.0.1",
-        "write-file-atomic": "^1.1.2",
-        "xdg-basedir": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/configstore/node_modules/uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details."
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "node_modules/css-select": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
-      "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
-      "dependencies": {
-        "boolbase": "~1.0.0",
-        "css-what": "1.0",
-        "domutils": "1.4",
-        "nth-check": "~1.0.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
-      "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/csso": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
-      "integrity": "sha1-F4tDpEYhIhwndWCG9THgL0KQDug=",
-      "dependencies": {
-        "clap": "^1.0.9",
-        "source-map": "^0.5.3"
-      },
-      "bin": {
-        "csso": "bin/csso"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+        "ms": "^2.1.3"
+      },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "engines": {
-        "node": ">=0.4.0"
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "license": "MIT",
       "dependencies": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "domelementtype": "1"
+        "domelementtype": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/domutils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "domelementtype": "1"
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/domutils/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/dot-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
-      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
       "dependencies": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/dot-case/node_modules/lower-case": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/dot-case/node_modules/no-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-      "dependencies": {
-        "lower-case": "^2.0.1",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/duplexify": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "dependencies": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "node_modules/duplexify/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "node_modules/duplexify/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/duplexify/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/duplexify/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dependencies": {
-        "once": "^1.4.0"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-    },
-    "node_modules/es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
+        "node": ">=0.12"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    "node_modules/escape-goat": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+      "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -638,32 +374,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -672,18 +388,11 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -691,245 +400,71 @@
         "node": ">= 6"
       }
     },
-    "node_modules/got": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
-      "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
-      "dependencies": {
-        "duplexify": "^3.2.0",
-        "infinity-agent": "^2.0.0",
-        "is-redirect": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "nested-error-stacks": "^1.0.0",
-        "object-assign": "^3.0.0",
-        "prepend-http": "^1.0.0",
-        "read-all-stream": "^3.0.0",
-        "timed-out": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/got/node_modules/object-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/html-minifier-terser": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-      "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+      "license": "MIT",
       "dependencies": {
-        "camel-case": "^4.1.1",
-        "clean-css": "^4.2.3",
-        "commander": "^4.1.1",
-        "he": "^1.2.0",
-        "param-case": "^3.0.3",
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
         "relateurl": "^0.2.7",
-        "terser": "^4.6.3"
+        "terser": "^5.15.1"
       },
       "bin": {
         "html-minifier-terser": "cli.js"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/camel-case": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
-      "dependencies": {
-        "pascal-case": "^3.1.1",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/param-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
-      "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
-      "dependencies": {
-        "dot-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/htmlparser2": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
+      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+      "license": "MIT",
       "dependencies": {
-        "domelementtype": "1",
-        "domhandler": "2.3",
-        "domutils": "1.5",
-        "entities": "1.0",
-        "readable-stream": "1.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "domelementtype": "^2.0.1",
+        "domhandler": "^3.3.0",
+        "domutils": "^2.4.2",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/htmlparser2?sponsor=1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/infinity-agent": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
-      "integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY="
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
-    "node_modules/inliner": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/inliner/-/inliner-1.13.1.tgz",
-      "integrity": "sha1-5QApgev1Dp2fMTcRSBz/Ei1PP8s=",
-      "dependencies": {
-        "ansi-escapes": "^1.4.0",
-        "ansi-styles": "^2.2.1",
-        "chalk": "^1.1.3",
-        "charset": "^1.0.0",
-        "cheerio": "^0.19.0",
-        "debug": "^2.2.0",
-        "es6-promise": "^2.3.0",
-        "iconv-lite": "^0.4.11",
-        "jschardet": "^1.3.0",
-        "lodash.assign": "^3.2.0",
-        "lodash.defaults": "^3.1.2",
-        "lodash.foreach": "^3.0.3",
-        "mime": "^1.3.4",
-        "minimist": "^1.1.3",
-        "request": "^2.74.0",
-        "svgo": "^0.6.6",
-        "then-fs": "^2.0.0",
-        "uglify-js": "^2.8.0",
-        "update-notifier": "^0.5.0"
-      },
-      "bin": {
-        "inliner": "cli/index.js"
-      }
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "license": "ISC"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -937,45 +472,23 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -984,290 +497,37 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "node_modules/js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "node_modules/jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/latest-version": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
-      "integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
-      "dependencies": {
-        "package-json": "^1.0.0"
-      },
-      "bin": {
-        "latest-version": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-    },
-    "node_modules/lodash._arrayeach": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
-    },
-    "node_modules/lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dependencies": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "node_modules/lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-    },
-    "node_modules/lodash._baseeach": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
-      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
-      "dependencies": {
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "node_modules/lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-    },
-    "node_modules/lodash._createassigner": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dependencies": {
-        "lodash._bindcallback": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash.restparam": "^3.0.0"
-      }
-    },
-    "node_modules/lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
-    "node_modules/lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-    },
-    "node_modules/lodash.assign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-      "dependencies": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._createassigner": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "node_modules/lodash.defaults": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-      "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
-      "dependencies": {
-        "lodash.assign": "^3.0.0",
-        "lodash.restparam": "^3.0.0"
-      }
-    },
-    "node_modules/lodash.foreach": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
-      "integrity": "sha1-b9fvt5aRrs1n/erCdhyY5wHWw5o=",
-      "dependencies": {
-        "lodash._arrayeach": "^3.0.0",
-        "lodash._baseeach": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "node_modules/lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "node_modules/lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dependencies": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
-    "node_modules/lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-    },
-    "node_modules/longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "engines": {
-        "node": ">=0.10.0"
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dependencies": {
-        "mime-db": "1.44.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
+        "node": ">=4.0.0"
       }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1275,47 +535,35 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
-    "node_modules/nested-error-stacks": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
-      "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
       "dependencies": {
-        "inherits": "~2.0.1"
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-      "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
+        "debug": "^4",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.1.2",
         "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
         "undefsafe": "^2.0.5"
@@ -1324,163 +572,47 @@
         "nodemon": "bin/nodemon.js"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=10"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nodemon"
       }
     },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "license": "MIT",
       "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dependencies": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
-    "node_modules/package-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
-      "integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
-      "dependencies": {
-        "got": "^3.2.0",
-        "registry-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/pascal-case": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
-      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "license": "MIT",
       "dependencies": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
-    },
-    "node_modules/pascal-case/node_modules/lower-case": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-      "dependencies": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/pascal-case/node_modules/no-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-      "dependencies": {
-        "lower-case": "^2.0.1",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1488,154 +620,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
-    },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dependencies": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-all-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "node_modules/read-all-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/read-all-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/read-all-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -1643,331 +638,99 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dependencies": {
-        "rc": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
     },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/repeating": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-      "dependencies": {
-        "is-finite": "^1.0.0"
-      },
-      "bin": {
-        "repeating": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dependencies": {
-        "align-text": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dependencies": {
-        "semver": "^5.0.3"
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/simple-update-notifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "license": "MIT",
       "dependencies": {
-        "semver": "~7.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "node_modules/string-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
-      "dependencies": {
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/svgo": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
-      "integrity": "sha1-s0CIkDbyD5tEdUMHfQ9Vc+0ETAg=",
-      "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
       "dependencies": {
-        "coa": "~1.0.1",
-        "colors": "~1.1.2",
-        "csso": "~2.0.0",
-        "js-yaml": "~3.6.0",
-        "mkdirp": "~0.5.1",
-        "sax": "~1.2.1",
-        "whet.extend": "~0.9.9"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
+        "has-flag": "^3.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
     },
     "node_modules/terser": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "license": "BSD-2-Clause",
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=10"
       }
     },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/then-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
-      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
-      "dependencies": {
-        "promise": ">=3.2 <8"
-      }
-    },
-    "node_modules/timed-out": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-      "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1976,1920 +739,50 @@
       }
     },
     "node_modules/touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "node_modules/uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dependencies": {
-        "source-map": "~0.5.1",
-        "yargs": "~3.10.0"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      },
-      "optionalDependencies": {
-        "uglify-to-browserify": "~1.0.0"
-      }
-    },
-    "node_modules/uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "license": "MIT"
     },
-    "node_modules/update-notifier": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
-      "integrity": "sha1-B7XcIGazYnqztPUwEw9+3doHpMw=",
-      "dependencies": {
-        "chalk": "^1.0.0",
-        "configstore": "^1.0.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^1.0.0",
-        "repeating": "^1.1.2",
-        "semver-diff": "^2.0.0",
-        "string-length": "^1.0.0"
-      },
+    "node_modules/valid-data-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
+      "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/whet.extend": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "node_modules/write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
-      }
-    },
-    "node_modules/xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "dependencies": {
-        "os-homedir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dependencies": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
-    },
-    "node_modules/zlib": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
-      "integrity": "sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA=",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    }
-  },
-  "dependencies": {
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
-    "anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-    },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-    },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      }
-    },
-    "charset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
-      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg=="
-    },
-    "cheerio": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
-      "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
-      "requires": {
-        "css-select": "~1.0.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "~3.8.1",
-        "lodash": "^3.2.0"
-      }
-    },
-    "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      }
-    },
-    "clap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-      "requires": {
-        "chalk": "^1.1.3"
-      }
-    },
-    "clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
-      "requires": {
-        "source-map": "~0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      }
-    },
-    "coa": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-      "requires": {
-        "q": "^1.1.2"
-      }
-    },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "configstore": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-      "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.1",
-        "os-tmpdir": "^1.0.0",
-        "osenv": "^0.1.0",
-        "uuid": "^2.0.1",
-        "write-file-atomic": "^1.1.2",
-        "xdg-basedir": "^2.0.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "css-select": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
-      "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
-      "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "1.0",
-        "domutils": "1.4",
-        "nth-check": "~1.0.0"
-      }
-    },
-    "css-what": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
-      "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w="
-    },
-    "csso": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
-      "integrity": "sha1-F4tDpEYhIhwndWCG9THgL0KQDug=",
-      "requires": {
-        "clap": "^1.0.9",
-        "source-map": "^0.5.3"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-    },
-    "domhandler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "domutils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "dot-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
-      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
-      "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-          "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
-          }
-        }
-      }
-    },
-    "duplexify": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
-    "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-    },
-    "es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
-    },
-    "got": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
-      "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
-      "requires": {
-        "duplexify": "^3.2.0",
-        "infinity-agent": "^2.0.0",
-        "is-redirect": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "nested-error-stacks": "^1.0.0",
-        "object-assign": "^3.0.0",
-        "prepend-http": "^1.0.0",
-        "read-all-stream": "^3.0.0",
-        "timed-out": "^2.0.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        }
-      }
-    },
-    "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-    },
-    "html-minifier-terser": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-      "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
-      "requires": {
-        "camel-case": "^4.1.1",
-        "clean-css": "^4.2.3",
-        "commander": "^4.1.1",
-        "he": "^1.2.0",
-        "param-case": "^3.0.3",
-        "relateurl": "^0.2.7",
-        "terser": "^4.6.3"
-      },
-      "dependencies": {
-        "camel-case": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
-          "requires": {
-            "pascal-case": "^3.1.1",
-            "tslib": "^1.10.0"
-          }
-        },
-        "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
-        },
-        "param-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
-          "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
-          "requires": {
-            "dot-case": "^3.0.3",
-            "tslib": "^1.10.0"
-          }
-        }
-      }
-    },
-    "htmlparser2": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-      "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.3",
-        "domutils": "1.5",
-        "entities": "1.0",
-        "readable-stream": "1.1"
-      },
-      "dependencies": {
-        "domutils": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "entities": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
-        }
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "infinity-agent": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
-      "integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY="
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
-    "inliner": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/inliner/-/inliner-1.13.1.tgz",
-      "integrity": "sha1-5QApgev1Dp2fMTcRSBz/Ei1PP8s=",
-      "requires": {
-        "ansi-escapes": "^1.4.0",
-        "ansi-styles": "^2.2.1",
-        "chalk": "^1.1.3",
-        "charset": "^1.0.0",
-        "cheerio": "^0.19.0",
-        "debug": "^2.2.0",
-        "es6-promise": "^2.3.0",
-        "iconv-lite": "^0.4.11",
-        "jschardet": "^1.3.0",
-        "lodash.assign": "^3.2.0",
-        "lodash.defaults": "^3.1.2",
-        "lodash.foreach": "^3.0.3",
-        "mime": "^1.3.4",
-        "minimist": "^1.1.3",
-        "request": "^2.74.0",
-        "svgo": "^0.6.6",
-        "then-fs": "^2.0.0",
-        "uglify-js": "^2.8.0",
-        "update-notifier": "^0.5.0"
-      }
-    },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
-    },
-    "is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-    },
-    "is-number": {
+    "node_modules/web-resource-inliner": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
-      }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "latest-version": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
-      "integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
-      "requires": {
-        "package-json": "^1.0.0"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-    },
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-    },
-    "lodash._arrayeach": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-    },
-    "lodash._baseeach": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
-      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
-      "requires": {
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-    },
-    "lodash._createassigner": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "requires": {
-        "lodash._bindcallback": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash.restparam": "^3.0.0"
-      }
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-    },
-    "lodash.assign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-      "requires": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._createassigner": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash.defaults": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-      "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
-      "requires": {
-        "lodash.assign": "^3.0.0",
-        "lodash.restparam": "^3.0.0"
-      }
-    },
-    "lodash.foreach": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
-      "integrity": "sha1-b9fvt5aRrs1n/erCdhyY5wHWw5o=",
-      "requires": {
-        "lodash._arrayeach": "^3.0.0",
-        "lodash._baseeach": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-    },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-    },
-    "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
-    },
-    "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "requires": {
-        "mime-db": "1.44.0"
-      }
-    },
-    "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "nested-error-stacks": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
-      "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
-      "requires": {
-        "inherits": "~2.0.1"
-      }
-    },
-    "nodemon": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-      "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
-      "requires": {
-        "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
+      "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-7.0.0.tgz",
+      "integrity": "sha512-NlfnGF8MY9ZUwFjyq3vOUBx7KwF8bmE+ywR781SB0nWB6MoMxN4BA8gtgP1KGTZo/O/AyWJz7HZpR704eaj4mg==",
+      "license": "MIT",
       "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "requires": {
-        "abbrev": "1"
-      }
-    },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-    },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "requires": {
-        "boolbase": "~1.0.0"
-      }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
-    "package-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
-      "integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
-      "requires": {
-        "got": "^3.2.0",
-        "registry-url": "^3.0.0"
-      }
-    },
-    "pascal-case": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
-      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
-      "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
+        "ansi-colors": "^4.1.1",
+        "escape-goat": "^3.0.0",
+        "htmlparser2": "^5.0.0",
+        "mime": "^2.4.6",
+        "valid-data-url": "^3.0.0"
       },
-      "dependencies": {
-        "lower-case": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
-        "no-case": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-          "requires": {
-            "lower-case": "^2.0.1",
-            "tslib": "^1.10.0"
-          }
-        }
+      "engines": {
+        "node": ">=10.0.0"
       }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
-    "pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      }
-    },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "requires": {
-        "rc": "^1.0.1"
-      }
-    },
-    "relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "repeating": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "requires": {
-        "semver": "^5.0.3"
-      }
-    },
-    "simple-update-notifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
-      "requires": {
-        "semver": "~7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
-        }
-      }
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
-    "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "string-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
-      "requires": {
-        "strip-ansi": "^3.0.0"
-      }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
-    "svgo": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
-      "integrity": "sha1-s0CIkDbyD5tEdUMHfQ9Vc+0ETAg=",
-      "requires": {
-        "coa": "~1.0.1",
-        "colors": "~1.1.2",
-        "csso": "~2.0.0",
-        "js-yaml": "~3.6.0",
-        "mkdirp": "~0.5.1",
-        "sax": "~1.2.1",
-        "whet.extend": "~0.9.9"
-      }
-    },
-    "terser": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
-      "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "then-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
-      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
-      "requires": {
-        "promise": ">=3.2 <8"
-      }
-    },
-    "timed-out": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-      "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
-    "touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "requires": {
-        "nopt": "~1.0.10"
-      }
-    },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
-    "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
-    },
-    "undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
-    },
-    "update-notifier": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
-      "integrity": "sha1-B7XcIGazYnqztPUwEw9+3doHpMw=",
-      "requires": {
-        "chalk": "^1.0.0",
-        "configstore": "^1.0.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^1.0.0",
-        "repeating": "^1.1.2",
-        "semver-diff": "^2.0.0",
-        "string-length": "^1.0.0"
-      }
-    },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "whet.extend": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
-    },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-    },
-    "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
-      }
-    },
-    "xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "requires": {
-        "os-homedir": "^1.0.0"
-      }
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
-    },
-    "zlib": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
-      "integrity": "sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wled",
   "version": "14.7.0-mdev",
-  "description": "Tools for WLED project",
+  "description": "Tools for WLED-MM project",
   "main": "tools/cdata.js",
   "directories": {
     "lib": "lib",
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "node tools/cdata.js",
+    "test": "node --test",
     "dev": "nodemon -e js,html,htm,css,png,jpg,gif,ico,js -w tools/ -w wled00/data/ -x node tools/cdata.js"
   },
   "repository": {
@@ -22,10 +23,12 @@
   },
   "homepage": "https://github.com/MoonModules/WLED-MM#readme",
   "dependencies": {
-    "clean-css": "^4.2.3",
-    "html-minifier-terser": "^5.1.1",
-    "inliner": "^1.13.1",
-    "nodemon": "^2.0.20",
-    "zlib": "^1.0.5"
+    "clean-css": "^5.3.3",
+    "html-minifier-terser": "^7.2.0",
+    "web-resource-inliner": "^7.0.0",
+    "nodemon": "^3.1.9"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/pio-scripts/build_ui.py
+++ b/pio-scripts/build_ui.py
@@ -1,0 +1,21 @@
+Import("env")
+import shutil
+
+node_ex = shutil.which("node")
+# Check if Node.js is installed and present in PATH if it failed, abort the build
+if node_ex is None:
+    print('\x1b[0;31;43m' + 'Node.js is not installed or missing from PATH html css js will not be processed check https://kno.wled.ge/advanced/compiling-wled/' + '\x1b[0m')
+    exitCode = env.Execute("null")
+    exit(exitCode)
+else:
+    # Install the necessary node packages for the pre-build asset bundling script
+    print('\x1b[6;33;42m' + 'Installing node packages' + '\x1b[0m')
+    env.Execute("npm ci")
+
+    # Call the bundling script
+    exitCode = env.Execute("npm run build")
+
+    # If it failed, abort the build
+    if (exitCode):
+      print('\x1b[0;31;43m' + 'npm run build fails check https://kno.wled.ge/advanced/compiling-wled/' + '\x1b[0m')
+      exit(exitCode)

--- a/pio-scripts/set_metadata.py
+++ b/pio-scripts/set_metadata.py
@@ -1,0 +1,116 @@
+Import('env')
+import subprocess
+import json
+import re
+
+def get_github_repo():
+    """Extract GitHub repository name from git remote URL.
+    
+    Uses the remote that the current branch tracks, falling back to 'origin'.
+    This handles cases where repositories have multiple remotes or where the
+    main remote is not named 'origin'.
+    
+    Returns:
+        str: Repository name in 'owner/repo' format for GitHub repos,
+             'unknown' for non-GitHub repos, missing git CLI, or any errors.
+    """
+    try:
+        remote_name = 'origin'  # Default fallback
+        
+        # Try to get the remote for the current branch
+        try:
+            # Get current branch name
+            branch_result = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], 
+                                         capture_output=True, text=True, check=True)
+            current_branch = branch_result.stdout.strip()
+            
+            # Get the remote for the current branch
+            remote_result = subprocess.run(['git', 'config', f'branch.{current_branch}.remote'], 
+                                         capture_output=True, text=True, check=True)
+            tracked_remote = remote_result.stdout.strip()
+            
+            # Use the tracked remote if we found one
+            if tracked_remote:
+                remote_name = tracked_remote
+        except subprocess.CalledProcessError:
+            # If branch config lookup fails, continue with 'origin' as fallback
+            pass
+        
+        # Get the remote URL for the determined remote
+        result = subprocess.run(['git', 'remote', 'get-url', remote_name], 
+                              capture_output=True, text=True, check=True)
+        remote_url = result.stdout.strip()
+        
+        # Check if it's a GitHub URL
+        if 'github.com' not in remote_url.lower():
+            return None
+        
+        # Parse GitHub URL patterns:
+        # https://github.com/owner/repo.git
+        # git@github.com:owner/repo.git
+        # https://github.com/owner/repo
+        
+        # Remove .git suffix if present
+        if remote_url.endswith('.git'):
+            remote_url = remote_url[:-4]
+        
+        # Handle HTTPS URLs
+        https_match = re.search(r'github\.com/([^/]+/[^/]+)', remote_url, re.IGNORECASE)
+        if https_match:
+            return https_match.group(1)
+        
+        # Handle SSH URLs
+        ssh_match = re.search(r'github\.com:([^/]+/[^/]+)', remote_url, re.IGNORECASE)
+        if ssh_match:
+            return ssh_match.group(1)
+        
+        return None
+        
+    except FileNotFoundError:
+        # Git CLI is not installed or not in PATH
+        return None
+    except subprocess.CalledProcessError:
+        # Git command failed (e.g., not a git repo, no remote, etc.)
+        return None
+    except Exception:
+        # Any other unexpected error
+        return None
+
+# WLED version is managed by package.json; this is picked up in several places
+# - It's integrated in to the UI code
+# - Here, for wled_metadata.cpp
+# - The output_bins script
+# We always take it from package.json to ensure consistency
+with open("package.json", "r") as package:
+    WLED_VERSION = json.load(package)["version"]
+
+def has_def(cppdefs, name):
+    """ Returns true if a given name is set in a CPPDEFINES collection """
+    for f in cppdefs:
+        if isinstance(f, tuple):
+            f = f[0]
+        if f == name:
+            return True
+    return False
+
+
+def add_wled_metadata_flags(env, node):    
+    cdefs = env["CPPDEFINES"].copy()
+
+    if not has_def(cdefs, "WLED_REPO"):
+        repo = get_github_repo()
+        if repo:
+            cdefs.append(("WLED_REPO", f"\\\"{repo}\\\""))
+
+    cdefs.append(("WLED_VERSION", WLED_VERSION))
+
+    # This transforms the node in to a Builder; it cannot be modified again
+    return env.Object(
+        node,
+        CPPDEFINES=cdefs
+    )
+   
+env.AddBuildMiddleware(
+    add_wled_metadata_flags,
+    "*/wled_metadata.cpp"
+)

--- a/pio-scripts/validate_modules.py
+++ b/pio-scripts/validate_modules.py
@@ -1,0 +1,80 @@
+import re
+from pathlib import Path   # For OS-agnostic path manipulation
+from typing import Iterable
+from click import secho
+from SCons.Script import Action, Exit
+from platformio.builder.tools.piolib import LibBuilderBase
+
+
+def is_wled_module(env, dep: LibBuilderBase) -> bool:
+  """Returns true if the specified library is a wled module
+  """
+  usermod_dir = Path(env["PROJECT_DIR"]).resolve() / "usermods"
+  return usermod_dir in Path(dep.src_dir).parents or str(dep.name).startswith("wled-")
+
+
+def read_lines(p: Path):
+    """ Read in the contents of a file for analysis """
+    with p.open("r", encoding="utf-8", errors="ignore") as f:
+        return f.readlines()
+
+
+def check_map_file_objects(map_file: list[str], dirs: Iterable[str]) -> set[str]:
+    """ Identify which dirs contributed to the final build
+
+        Returns the (sub)set of dirs that are found in the output ELF
+    """
+    # Pattern to match symbols in object directories
+    # Join directories into alternation
+    usermod_dir_regex = "|".join([re.escape(dir) for dir in dirs])
+    # Matches nonzero address, any size, and any path in a matching directory
+    object_path_regex = re.compile(r"0x0*[1-9a-f][0-9a-f]*\s+0x[0-9a-f]+\s+\S+[/\\](" + usermod_dir_regex + r")[/\\]\S+\.o")
+
+    found = set()
+    for line in map_file:
+        matches = object_path_regex.findall(line)
+        for m in matches:
+            found.add(m)
+    return found
+
+
+def count_usermod_objects(map_file: list[str]) -> int:
+    """ Returns the number of usermod objects in the usermod list """
+    # Count the number of entries in the usermods table section
+    return len([x for x in map_file if ".dtors.tbl.usermods.1" in x])
+
+
+def validate_map_file(source, target, env):
+    """ Validate that all modules appear in the output build """
+    build_dir = Path(env.subst("$BUILD_DIR"))
+    map_file_path = build_dir /  env.subst("${PROGNAME}.map")
+
+    if not map_file_path.exists():
+        secho(f"ERROR: Map file not found: {map_file_path}", fg="red", err=True)
+        Exit(1)
+
+    # Identify the WLED module builders, set by load_usermods.py
+    module_lib_builders = env['WLED_MODULES']
+
+    # Extract the values we care about
+    modules = {Path(builder.build_dir).name: builder.name for builder in module_lib_builders}
+    secho(f"INFO: {len(modules)} libraries linked as WLED optional/user modules")
+
+    # Now parse the map file
+    map_file_contents = read_lines(map_file_path)
+    usermod_object_count = count_usermod_objects(map_file_contents)
+    secho(f"INFO: {usermod_object_count} usermod object entries")
+
+    confirmed_modules = check_map_file_objects(map_file_contents, modules.keys())
+    missing_modules = [modname for mdir, modname in modules.items() if mdir not in confirmed_modules]
+    if missing_modules:
+        secho(
+            f"ERROR: No object files from {missing_modules} found in linked output!",
+            fg="red",
+            err=True)
+        Exit(1)
+    return None
+
+Import("env")
+env.Append(LINKFLAGS=[env.subst("-Wl,--Map=${BUILD_DIR}/${PROGNAME}.map")])
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.elf", Action(validate_map_file, cmdstr='Checking linked optional modules (usermods) in map file'))

--- a/platformio.ini
+++ b/platformio.ini
@@ -299,6 +299,7 @@ build_flags =
   -D USERMOD_AUDIOREACTIVE
   -D NON32XFER_HANDLER ;; ask forgiveness for PROGMEM misuse
   -D WLED_DISABLE_PARTICLESYSTEM2D
+  -D WLED_DISABLE_PIXELFORGE ;; not enought space in flash
 
 ;; special library dependencies for 8266 (workaround for upsteam #5136) - replaces env.lib_deps
 lib8266_deps =
@@ -367,6 +368,8 @@ default_partitions = ${esp32.default_partitions}          ;; backwards compatibi
 board_build.f_flash = 80000000L
 board_build.flash_mode = dout                             ;; avoid dio/quot/qio - these are broken in arduino-esp32 1.0.6.x
 ;;board_build.flash_mode = dio
+; RAM:   [==        ]  24.2% (used 79284 bytes from 327680 bytes)
+; Flash: [========= ]  93.1% (used 1464961 bytes from 1572864 bytes)
 
 ;; standard platform for esp32
 [esp32]
@@ -669,6 +672,9 @@ platform_packages = ${esp32_legacy.platform_packages}
 build_unflags = ${esp32_legacy.build_unflags}
 build_flags =   ${common.build_flags} ${esp32_legacy.build_flags} -D WLED_RELEASE_NAME=ESP32_compat #-D WLED_DISABLE_BROWNOUT_DET
     ${esp32.AR_build_flags}
+    ;;-D WLED_ENABLE_PIXART                     ;; 8KB Flash
+    -D WLED_ENABLE_PIXELFORGE -DWLED_ENABLE_GIF ;; 30KB flash
+    ;;-D WLED_ENABLE_FULL_FONTS                 ;; 10KB flash
 lib_deps = ${esp32_legacy.lib_deps}
     ${esp32.AR_lib_deps}
 board_build.partitions = ${esp32_legacy.default_partitions}
@@ -720,8 +726,12 @@ platform_packages = ${esp32_legacy.platform_packages}
 upload_speed = 921600
 build_unflags = ${esp32_legacy.build_unflags}
 build_flags =   ${common.build_flags} ${esp32_legacy.build_flags} -D WLED_RELEASE_NAME=ESP32_Ethernet_compat -D RLYPIN=-1 
-  -D WLED_USE_ETHERNET -D BTNPIN=-1
+  -D WLED_USE_ETHERNET -D BTNPIN=-1 -D RLYPIN=-1 -D IRPIN=-1 
+  -D LEDPIN=4
   -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
+    ;;-D WLED_ENABLE_PIXART                     ;; 8KB Flash
+    -D WLED_ENABLE_PIXELFORGE -DWLED_ENABLE_GIF ;; 30KB flash
+    ;;-D WLED_ENABLE_FULL_FONTS                 ;; 10KB flash
   ${esp32.AR_build_flags}
 lib_deps = ${esp32_legacy.lib_deps}
   ${esp32.AR_lib_deps}
@@ -1216,6 +1226,9 @@ build_flags_M =
   -D USERMOD_ROTARY_ENCODER_UI
   -D USERMOD_AUTO_SAVE
   -D WLED_ENABLE_FULL_FONTS  ;; enables (limited) unicode support in scrolling text - warning: increases firmware size by 6848 bytes
+  ;;-D WLED_ENABLE_PIXART    ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
+
   ${common_mm.animartrix_build_flags}
   ${common_mm.NetDebug_build_flags}
 
@@ -1437,7 +1450,8 @@ board_build.partitions = ${esp32.extended_partitions}  ;; 1.65MB firmware, 700KB
 build_flags = ${esp32_4MB_M_base.build_flags}
   -D WLED_RELEASE_NAME=esp32_4MB_M_eth
   -D WLED_USE_ETHERNET
-  -D RLYPIN=-1 -D BTNPIN=-1 ;; Prevent clash
+  -D RLYPIN=-1 -D BTNPIN=-1 -D IRPIN=-1 ;; Prevent clash
+  -D LEDPIN=4 ;; safe default
   -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
   -D WLEDMM_SAVE_FLASH
   ;-D WLED_DISABLE_ALEXA
@@ -1478,6 +1492,9 @@ build_flags = ${esp32_4MB_S_base.build_flags}
   ${Speed_Flags.build_flags}  ;; optimize for speed instead of size
   -D WLEDMM_FASTPATH ;; WLEDMM experimental option. Reduces audio lag (latency), and allows for faster LED framerates. May break compatibility with previous versions.
   ${common_mm.animartrix_build_flags}
+  -D WLED_ENABLE_GIF         ;; 28KB Flash
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
 lib_deps = ${esp32_4MB_S_base.lib_deps}
   ${common_mm.animartrix_lib_deps}
 ; lib_ignore = IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
@@ -1489,6 +1506,8 @@ lib_deps = ${esp32_4MB_S_base.lib_deps}
 extends = esp32_4MB_M_base
 build_flags = ${esp32_4MB_M_base.build_flags}
   -D WLED_RELEASE_NAME=esp32_16MB_M
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
 board = esp32_16MB
 ;board_build.partitions = tools/WLED_ESP32_16MB.csv         ;; WLED standard for 16MB flash:   2MB firmware, 12 MB filesystem
 board_build.partitions = ${esp32.extreme_partitions} ;; WLED extended for 16MB flash: 3.2MB firmware,  9 MB filesystem
@@ -1545,8 +1564,12 @@ board_build.partitions = ${esp32.extreme_partitions} ;; WLED extended for 16MB f
 board = esp32_16MB-poe       ;; needed for ethernet boards (selects "esp32-poe" as variant)
 build_flags = ${esp32_4MB_M_base.build_flags}
   -D WLED_RELEASE_NAME=esp32_16MB_M_eth ; This will be included in the firmware.bin filename
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   -D WLED_USE_ETHERNET
   -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
+  -D BTNPIN=-1 -D RLYPIN=-1 -D IRPIN=-1 
+  -D LEDPIN=4
 ; RAM:   [==        ]  24.2% (used 79388 bytes from 327680 bytes)
 ; Flash: [=======   ]  73.8% (used 1548525 bytes from 2097152 bytes)
 
@@ -1827,6 +1850,8 @@ build_flags = ${esp32_4MB_V4_S_base.esp32_build_flags}
   -D SR_DMTYPE=254 ;; HUB75 driver needs the I2S unit - set AR default mode to 'Network Receive Only' to prevent driver conflicts.
   -D WLED_USE_ETHERNET
   -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
+  -D BTNPIN=-1 -D RLYPIN=-1 -D IRPIN=-1 
+  -D LEDPIN=4
 lib_deps = ${esp32_4MB_V4_S_base.esp32_lib_deps}
     ${common_mm.HUB75_lib_deps}
 lib_ignore = IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
@@ -1938,6 +1963,9 @@ build_flags = ${esp32_4MB_V4_S_base.esp32_build_flags}
   ${common_mm.HUB75_build_flags}
   -D SR_DMTYPE=254 ;; HUB75 driver needs the I2S unit - set AR default mode to 'Network Receive Only' to prevent driver conflicts.
   ${common_mm.animartrix_build_flags}
+  -D WLED_ENABLE_GIF         ;; 28KB Flash
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
 lib_deps = ${esp32_4MB_V4_S_base.esp32_lib_deps}
     ${common_mm.HUB75_lib_deps}
     ${common_mm.animartrix_lib_deps}
@@ -1965,6 +1993,9 @@ build_flags = ${esp32_4MB_V4_M_base.esp32_build_flags}
   ${common_mm.HUB75_build_flags}
   -D SR_DMTYPE=254 ;; HUB75 driver needs the I2S unit - set AR default mode to 'Network Receive Only' to prevent driver conflicts.
   ${common_mm.animartrix_build_flags}
+  -D WLED_ENABLE_GIF         ;; 28KB Flash
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
 lib_deps = ${esp32_4MB_V4_M_base.esp32_lib_deps}
     ${common_mm.HUB75_lib_deps}
     ${common_mm.animartrix_lib_deps}
@@ -2163,6 +2194,8 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   ; -D WLED_DISABLE_MQTT ;   RAM 216 bytes; FLASH 16496 bytes
   ; -D WLED_DISABLE_HUESYNC ;RAM 122 bytes; FLASH 6308 bytes
   ; -D WLED_DISABLE_INFRARED ;RAM 136 bytes; FLASH 24492 bytes
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   ;;-D WLEDMM_FASTPATH ; WLEDMM experimental option. Reduces audio lag (latency), and allows for faster LED framerates. May break compatibility with previous versions.
   -D LEDPIN=4
   ;-D STATUSLED=39
@@ -2217,6 +2250,8 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   ; -D WLED_DISABLE_MQTT ;   RAM 216 bytes; FLASH 16496 bytes
   ; -D WLED_DISABLE_HUESYNC ;RAM 122 bytes; FLASH 6308 bytes
   ; -D WLED_DISABLE_INFRARED ;RAM 136 bytes; FLASH 24492 bytes
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   -D LEDPIN=21
   ;;-D DATA_PINS=21,48,3 -D PIXEL_COUNTS=30,1,144  ;; just an example: my board has a builtin neopixel on gpio48
   ; -D STATUSLED=2
@@ -2256,6 +2291,9 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   -D WLEDMM_FASTPATH ; WLEDMM experimental option. Reduces audio lag (latency), and allows for faster LED framerates. May break compatibility with previous versions.
   ${common_mm.HUB75_build_flags}
   ${common_mm.animartrix_build_flags}
+  -D WLED_ENABLE_GIF         ;; 28KB Flash
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   -D WLED_WATCHDOG_TIMEOUT=0 -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D WLED_DISABLE_LOXONE ; FLASH 1272 bytes
   -D WLED_DISABLE_ALEXA ;  RAM 116 bytes; FLASH 13524 bytes
@@ -2307,6 +2345,9 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   ${common_mm.HUB75_build_flags}
   -D MOONHUB_S3_PINOUT ;; HUB75 pinout
   ${common_mm.animartrix_build_flags}
+  -D WLED_ENABLE_GIF         ;; 28KB Flash
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   -D WLED_RELEASE_NAME=esp32S3_16MB_PSRAM_M_HUB75
   -D WLEDMM_FASTPATH
   -D WLED_DISABLE_BROWNOUT_DET
@@ -2361,6 +2402,8 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   ${Speed_Flags.build_flags_V4}  ;; optimize for speed
   ${common_mm.HUB75_build_flags}
   ${common_mm.animartrix_build_flags}
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   -D WLED_RELEASE_NAME=esp32S3_WROOM-2_M
   -D WLEDMM_FASTPATH
   -DBOARD_HAS_PSRAM ;; -D WLED_USE_PSRAM ;; your board supports PSRAM
@@ -2413,6 +2456,8 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   -D WLEDMM_FASTPATH          ;; WLEDMM experimental option. Reduces audio lag (latency), and allows for faster LED framerates. May break compatibility with previous versions.
   ;; -D WLEDMM_SAVE_FLASH
   ${common_mm.animartrix_build_flags}
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   -D WLED_WATCHDOG_TIMEOUT=0 -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D WLED_DISABLE_LOXONE ; FLASH 1272 bytes
   ;; -D WLED_DISABLE_ALEXA ;  RAM 116 bytes; FLASH 13524 bytes
@@ -2445,7 +2490,7 @@ board = lolin_s3_mini ;; -S3 mini: 4MB flash 2MB PSRAM
 board_build.partitions = ${esp32.extended_partitions} ;; 1.65MB firmware, 700KB filesystem
 build_unflags = ${common.build_unflags}
   -D WLED_ENABLE_HUB75MATRIX ;; board does not have enough pins for HUB75
-  -D USERMOD_ANIMARTRIX ;; not enough flash
+  ;;-D USERMOD_ANIMARTRIX ;; not enough flash
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-indentation -Wno-format-truncation
   ${common_mm.build_flags_S} ${common_mm.build_flags_M}
   -D WLED_RELEASE_NAME=esp32S3_4MB_PSRAM_M
@@ -2461,12 +2506,14 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   -D BTNPIN=-1 -D RLYPIN=-1 -D IRPIN=-1 -D AUDIOPIN=-1
   -D HW_PIN_SDA=12 -D HW_PIN_SCL=13
   -D SR_DMTYPE=1 -D I2S_SDPIN=5 -D I2S_WSPIN=6 -D I2S_CKPIN=4 -D MCLK_PIN=7
-  -D WLED_DISABLE_LOXONE   ; FLASH 1272 bytes - disabled to stay below 100%
-  -D WLED_DISABLE_HUESYNC  ; RAM 122 bytes; FLASH  6308 bytes - disabled to stay below 100%
-  -D WLED_DISABLE_INFRARED ; RAM 136 bytes; FLASH 24492 bytes - disabled to stay below 100%
+  ;;-D WLED_DISABLE_LOXONE   ; FLASH 1272 bytes - disabled to stay below 100%
+  ;;-D WLED_DISABLE_HUESYNC  ; RAM 122 bytes; FLASH  6308 bytes - disabled to stay below 100%
+  ;;-D WLED_DISABLE_INFRARED ; RAM 136 bytes; FLASH 24492 bytes - disabled to stay below 100%
   ;; -D WLED_DISABLE_ALEXA ; RAM 116 bytes; FLASH 13524 bytes
   ;; -D WLED_DISABLE_MQTT  ; RAM 216 bytes; FLASH 16496 bytes
   ;; -D WLEDMM_SAVE_FLASH
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   ; -D WLED_DEBUG
   ; -D SR_DEBUG
   ; -D MIC_LOGGER
@@ -2474,12 +2521,12 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   ;; -D WLED_DISABLE_PARTICLESYSTEM2D ;; exceeds flash size limit
 lib_deps = ${esp32s3.lib_deps} ${common_mm.lib_deps_S}  ${common_mm.lib_deps_V4_M}
 lib_ignore =
-  IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
+  ;; IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
   ${common_mm.HUB75_lib_ignore}
   ${common_mm.DMXin_lib_ignore}
-  ${common_mm.animartrix_lib_ignore}
-; RAM:   [==        ]  16.1% (used 52744 bytes from 327680 bytes)
-; Flash: [========  ]  83.5% (used 1312937 bytes from 1572864 bytes)
+  ;; ${common_mm.animartrix_lib_ignore}
+; RAM:   [==        ]  16.7% (used 54676 bytes from 327680 bytes)
+; Flash: [========  ]  83.2% (used 1416997 bytes from 1703936 bytes)
 
 # ------------------------------------------------------------------------------
 # esp32-S2 environments
@@ -2580,10 +2627,12 @@ build_flags = ${common.build_flags} ${esp32s2.build_flags}
   -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=1
   -D WLED_DISABLE_ADALIGHT     ;; disables serial protocols, as the board only has CDC USB
   -D WLED_DISABLE_INFRARED ;; save flash space
-  -D WLED_DISABLE_ALEXA    ;; save flash space
-  -D WLED_DISABLE_HUESYNC  ;; save flash space
-  -D WLED_DISABLE_LOXONE   ;; save flash space
-  -D WLEDMM_SAVE_FLASH
+  ;;-D WLED_DISABLE_ALEXA    ;; save flash space
+  ;;-D WLED_DISABLE_HUESYNC  ;; save flash space
+  ;;-D WLED_DISABLE_LOXONE   ;; save flash space
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
+  ;;-D WLEDMM_SAVE_FLASH
   -D AUDIOPIN=-1
   -D BTNPIN=-1 -D IRPIN=-1
   -D LEDPIN=16  ;; second led pin = 18
@@ -2601,8 +2650,8 @@ lib_ignore =
   ${common_mm.HUB75_lib_ignore}
   ${common_mm.DMXin_lib_ignore}
 monitor_filters = esp32_exception_decoder
-; RAM:   [==        ]  18.2% (used 59640 bytes from 327680 bytes)
-; Flash: [========  ]  80.3% (used 1368130 bytes from 1703936 bytes)
+; RAM:   [==        ]  18.5% (used 60660 bytes from 327680 bytes)
+; Flash: [========  ]  83.6% (used 1424518 bytes from 1703936 bytes)
 
 [env:esp32s2_PSRAM_S]
 extends = env:esp32s2_PSRAM_M
@@ -2677,6 +2726,8 @@ build_flags = ${common.build_flags} ${esp32c3.build_flags}
   ; -D WLED_USE_MY_CONFIG
   ;; -D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit
   ;; -D WLED_DISABLE_PARTICLESYSTEM2D ;; exceeds flash size limit
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
 lib_deps = ${esp32c3.lib_deps} ${common_mm.lib_deps_S} ${common_mm.lib_deps_V4_M}
 lib_ignore = 
   ;IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
@@ -2944,7 +2995,9 @@ build_flags = ${esp32_4MB_M_base.build_flags}
   ; -D PIR_SENSOR_PIN=-1
   ; -D PWM_PIN=-1
   ; -D WLED_USE_MY_CONFIG
-  -D WLEDMM_SAVE_FLASH
+  ; -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
+
 lib_ignore = ${esp32_4MB_M_base.lib_ignore}
   ${common_mm.DMXin_lib_ignore}
 ; RAM:   [===       ]  26.3% (used 86204 bytes from 327680 bytes)
@@ -2962,6 +3015,8 @@ build_flags = ${esp32_4MB_S_base.build_flags}
   -D WLED_ETH_DEFAULT=9 ; ABC! WLED V43 & compatible
   -D RLYPIN=-1 -D BTNPIN=-1 ;; Prevent clash
   -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   -D AUDIOPIN=-1 
   -D FLD_PIN_SCL=-1 -D FLD_PIN_SDA=-1 ; use global!
   ; -D WLED_USE_MY_CONFIG
@@ -3006,6 +3061,8 @@ build_flags = ${esp32_4MB_M_base.build_flags}
   -D WLEDMM_SAVE_FLASH
   -D WLED_DISABLE_ESPNOW  ;; might help in case of WiFi connectivity problems
   -D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit
+  ; -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  ; -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   ;; -D WLED_DISABLE_PARTICLESYSTEM2D
 ; RAM:   [==        ]  24.2% (used 79424 bytes from 327680 bytes)
 ; Flash: [==========]  99.9% (used 1571177 bytes from 1572864 bytes)
@@ -3042,6 +3099,8 @@ build_flags = ${esp32_4MB_V4_S_base.esp32_build_flags}
   -D WLED_DISABLE_ESPNOW  ;; might help in case of WiFi connectivity problems
   ;;-D WLED_DISABLE_PARTICLESYSTEM1D ;; exceeds flash size limit (default_partitions only)
   ;;-D WLED_DISABLE_PARTICLESYSTEM2D ;; exceeds flash size limit (default_partitions only)
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
 lib_deps = ${esp32_4MB_V4_S_base.esp32_lib_deps}
 lib_ignore = 
   IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation
@@ -3072,8 +3131,10 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   ; Serial debug enabled  -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=1 ;; for Hardware-CDC USB mode
   -D ARDUINO_USB_CDC_ON_BOOT=0
   -D WLED_DISABLE_ADALIGHT     ;; disables serial protocols - recommended for Hardware-CDC USB (Serial RX will receive junk commands when RX pin is unconnected, unless its pulled down by resistor)
-  ; ${common_mm.animartrix_build_flags}
+  ${common_mm.animartrix_build_flags}
   ${common_mm.build_disable_sync_interfaces}
+  -D WLED_ENABLE_PIXART      ;; 8KB Flash
+  -D WLED_ENABLE_PIXELFORGE  ;; 12KB Flash
   -D LOLIN_WIFI_FIX ;; try this in case Wifi does not work
   -D WLED_WATCHDOG_TIMEOUT=0 -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D WLED_USE_PSRAM -DBOARD_HAS_PSRAM ; tells WLED that PSRAM shall be used
@@ -3082,7 +3143,7 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -Wno-misleading-inden
   ${common_mm.HUB75_build_flags}
   -D DEFAULT_LED_TYPE=101
 lib_deps = ${esp32s3.lib_deps} ${common_mm.lib_deps_S} ;; ;;  do not include ${esp32.lib_depsV4} !!!!
-  ; ${common_mm.animartrix_lib_deps}
+  ${common_mm.animartrix_lib_deps}
   ${common_mm.HUB75_lib_deps}
 
 lib_ignore = IRremoteESP8266 ; use with WLED_DISABLE_INFRARED for faster compilation

--- a/platformio.ini
+++ b/platformio.ini
@@ -220,7 +220,7 @@ ldscript_16m14m = eagle.flash.16m14m.ld
 [scripts_defaults]
 extra_scripts =
   pre:pio-scripts/set_version.py
-  pre:pio-scripts/build-html.py
+  pre:pio-scripts/build_ui.py
   pre:pio-scripts/conditional_usb_mode.py
   post:pio-scripts/output_bins.py
   post:pio-scripts/strip-floats.py

--- a/tools/cdata-test.js
+++ b/tools/cdata-test.js
@@ -1,0 +1,212 @@
+'use strict';
+
+const assert = require('node:assert');
+const { describe, it, before, after } = require('node:test');
+const fs = require('fs');
+const path = require('path');
+const child_process = require('child_process');
+const util = require('util');
+const execPromise = util.promisify(child_process.exec);
+
+process.env.NODE_ENV = 'test'; // Set the environment to testing
+const cdata = require('./cdata.js');
+
+describe('Function', () => {
+  const testFolderPath = path.join(__dirname, 'testFolder');
+  const oldFilePath = path.join(testFolderPath, 'oldFile.txt');
+  const newFilePath = path.join(testFolderPath, 'newFile.txt');
+
+  // Create a temporary file before the test
+  before(() => {
+    // Create test folder
+    if (!fs.existsSync(testFolderPath)) {
+      fs.mkdirSync(testFolderPath);
+    }
+
+    // Create an old file
+    fs.writeFileSync(oldFilePath, 'This is an old file.');
+    // Modify the 'mtime' to simulate an old file
+    const oldTime = new Date();
+    oldTime.setFullYear(oldTime.getFullYear() - 1);
+    fs.utimesSync(oldFilePath, oldTime, oldTime);
+
+    // Create a new file
+    fs.writeFileSync(newFilePath, 'This is a new file.');
+  });
+
+  // delete the temporary files after the test
+  after(() => {
+    fs.rmSync(testFolderPath, { recursive: true });
+  });
+
+  describe('isFileNewerThan', async () => {
+    it('should return true if the file is newer than the provided time', async () => {
+      const pastTime = Date.now() - 10000; // 10 seconds ago
+      assert.strictEqual(cdata.isFileNewerThan(newFilePath, pastTime), true);
+    });
+
+    it('should return false if the file is older than the provided time', async () => {
+      assert.strictEqual(cdata.isFileNewerThan(oldFilePath, Date.now()), false);
+    });
+
+    it('should throw an exception if the file does not exist', async () => {
+      assert.throws(() => {
+        cdata.isFileNewerThan('nonexistent.txt', Date.now());
+      });
+    });
+  });
+
+  describe('isAnyFileInFolderNewerThan', async () => {
+    it('should return true if a file in the folder is newer than the given time', async () => {
+      const time = fs.statSync(path.join(testFolderPath, 'oldFile.txt')).mtime;
+      assert.strictEqual(cdata.isAnyFileInFolderNewerThan(testFolderPath, time), true);
+    });
+
+    it('should return false if no files in the folder are newer than the given time', async () => {
+      assert.strictEqual(cdata.isAnyFileInFolderNewerThan(testFolderPath, new Date()), false);
+    });
+
+    it('should throw an exception if the folder does not exist', async () => {
+      assert.throws(() => {
+        cdata.isAnyFileInFolderNewerThan('nonexistent', new Date());
+      });
+    });
+  });
+});
+
+describe('Script', () => {
+  const folderPath = 'wled00';
+  const dataPath = path.join(folderPath, 'data');
+
+  before(() => {
+    process.env.NODE_ENV = 'production';
+    // Backup files
+    fs.cpSync("wled00/data", "wled00Backup", { recursive: true });
+    fs.cpSync("tools/cdata.js", "cdata.bak.js");
+    fs.cpSync("package.json", "package.bak.json");
+  });
+  after(() => {
+    // Restore backup
+    fs.rmSync("wled00/data", { recursive: true });
+    fs.renameSync("wled00Backup", "wled00/data");
+    fs.rmSync("tools/cdata.js");
+    fs.renameSync("cdata.bak.js", "tools/cdata.js");
+    fs.rmSync("package.json");
+    fs.renameSync("package.bak.json", "package.json");
+  });
+
+  // delete all html_*.h files
+  async function deleteBuiltFiles() {
+    const files = await fs.promises.readdir(folderPath);
+    await Promise.all(files.map(file => {
+      if (file.startsWith('html_') && path.extname(file) === '.h') {
+        return fs.promises.unlink(path.join(folderPath, file));
+      }
+    }));
+  }
+
+  // check if html_*.h files were created
+  async function checkIfBuiltFilesExist() {
+    const files = await fs.promises.readdir(folderPath);
+    const htmlFiles = files.filter(file => file.startsWith('html_') && path.extname(file) === '.h');
+    assert(htmlFiles.length > 0, 'html_*.h files were not created');
+  }
+
+  async function runAndCheckIfBuiltFilesExist() {
+    await execPromise('node tools/cdata.js');
+    await checkIfBuiltFilesExist();
+  }
+
+  async function checkIfFileWasNewlyCreated(file) {
+    const modifiedTime = fs.statSync(file).mtimeMs;
+    assert(Date.now() - modifiedTime < 500, file + ' was not modified');
+  }
+
+  async function testFileModification(sourceFilePath, resultFile) {
+    // run cdata.js to ensure html_*.h files are created
+    await execPromise('node tools/cdata.js');
+
+    // modify file
+    fs.appendFileSync(sourceFilePath, ' ');
+    // delay for 1 second to ensure the modified time is different
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // run script cdata.js again and wait for it to finish
+    await execPromise('node tools/cdata.js');
+
+    await checkIfFileWasNewlyCreated(path.join(folderPath, resultFile));
+  }
+
+  describe('should build if', () => {
+    it('html_*.h files are missing', async () => {
+      await deleteBuiltFiles();
+      await runAndCheckIfBuiltFilesExist();
+    });
+
+    it('only one html_*.h file is missing', async () => {
+      // run script cdata.js and wait for it to finish
+      await execPromise('node tools/cdata.js');
+
+      // delete a random html_*.h file
+      let files = await fs.promises.readdir(folderPath);
+      let htmlFiles = files.filter(file => file.startsWith('html_') && path.extname(file) === '.h');
+      const randomFile = htmlFiles[Math.floor(Math.random() * htmlFiles.length)];
+      await fs.promises.unlink(path.join(folderPath, randomFile));
+
+      await runAndCheckIfBuiltFilesExist();
+    });
+
+    it('script was executed with -f or --force', async () => {
+      await execPromise('node tools/cdata.js');
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      await execPromise('node tools/cdata.js --force');
+      await checkIfFileWasNewlyCreated(path.join(folderPath, 'html_ui.h'));
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      await execPromise('node tools/cdata.js -f');
+      await checkIfFileWasNewlyCreated(path.join(folderPath, 'html_ui.h'));
+    });
+
+    it('a file changes', async () => {
+      await testFileModification(path.join(dataPath, 'index.htm'), 'html_ui.h');
+    });
+
+    it('a inlined file changes', async () => {
+      await testFileModification(path.join(dataPath, 'index.js'), 'html_ui.h');
+    });
+
+    it('a settings file changes', async () => {
+      await testFileModification(path.join(dataPath, 'settings_leds.htm'), 'html_ui.h');
+    });
+
+    it('the favicon changes', async () => {
+      await testFileModification(path.join(dataPath, 'favicon.ico'), 'html_ui.h');
+    });
+
+    it('cdata.js changes', async () => {
+      await testFileModification('tools/cdata.js', 'html_ui.h');
+    });
+
+    it('package.json changes', async () => {
+      await testFileModification('package.json', 'html_ui.h');
+    });
+  });
+
+  describe('should not build if', () => {
+    it('the files are already built', async () => {
+      await deleteBuiltFiles();
+
+      // run script cdata.js and wait for it to finish
+      let startTime = Date.now();
+      await execPromise('node tools/cdata.js');
+      const firstRunTime = Date.now() - startTime;
+
+      // run script cdata.js and wait for it to finish
+      startTime = Date.now();
+      await execPromise('node tools/cdata.js');
+      const secondRunTime = Date.now() - startTime;
+
+      // check if second run was faster than the first (must be at least 2x faster)
+      assert(secondRunTime < firstRunTime / 2, 'html_*.h files were rebuilt');
+    });
+  });
+});

--- a/tools/cdata.js
+++ b/tools/cdata.js
@@ -2,7 +2,7 @@
  * Writes compressed C arrays of data files (web interface)
  * How to use it?
  *
- * 1) Install Node 11+ and npm
+ * 1) Install Node 20+ and npm
  * 2) npm install
  * 3) npm run build
  *
@@ -15,26 +15,70 @@
  * It uses NodeJS packages to inline, minify and GZIP files. See writeHtmlGzipped and writeChunks invocations at the bottom of the page.
  */
 
-const fs = require("fs");
-const inliner = require("inliner");
-const zlib = require("zlib");
+const fs = require("node:fs");
+const path = require("path");
+const inline = require("web-resource-inliner");
+const zlib = require("node:zlib");
 const CleanCSS = require("clean-css");
-const MinifyHTML = require("html-minifier-terser").minify;
+const minifyHtml = require("html-minifier-terser").minify;
 const packageJson = require("../package.json");
 
-/**
- *
+// Export functions for testing
+module.exports = { isFileNewerThan, isAnyFileInFolderNewerThan };
+
+//const output = ["wled00/html_ui.h", "wled00/html_pixart.h", "wled00/html_cpal.h", "wled00/html_edit.h", "wled00/html_pxmagic.h", "wled00/html_pixelforge.h", "wled00/html_settings.h", "wled00/html_other.h"]
+const output = ["wled00/html_ui.h", "wled00/html_pixart.h", "wled00/html_cpal.h", "wled00/html_edit.h", "wled00/html_pxmagic.h", "wled00/html_settings.h", "wled00/html_other.h"]
+
+// \x1b[34m is blue, \x1b[36m is cyan, \x1b[0m is reset
+const wledBanner = `
+\t\x1b[34m  ##  ##      ##        ######    ######
+\t\x1b[34m##      ##    ##      ##        ##  ##  ##
+\t\x1b[34m##  ##  ##  ##        ######        ##  ##
+\t\x1b[34m##  ##  ##  ##        ##            ##  ##
+\t\x1b[34m  ##  ##      ######    ######    ######
+\t\t\x1b[36m build script for web UI
+\x1b[0m`;
+
+// Generate build timestamp as UNIX timestamp (seconds since epoch)
+function generateBuildTime() {
+  return Math.floor(Date.now() / 1000);
+}
+
+const singleHeader = `/*
+ * Binary array for the Web UI.
+ * gzip is used for smaller size and improved speeds.
+ * 
+ * Please see https://mm.kno.wled.ge/advanced/custom-features/#changing-web-ui
+ * to find out how to easily modify the web UI source!
  */
-function hexdump(buffer,isHex=false) {
+
+// Automatically generated build time for cache busting (UNIX timestamp)
+#ifdef WEB_BUILD_TIME
+#undef WEB_BUILD_TIME
+#endif
+#define WEB_BUILD_TIME ${generateBuildTime()}
+
+`;
+
+const multiHeader = `/*
+ * More web UI HTML source arrays.
+ * This file is auto generated, please don't make any changes manually.
+ *
+ * Instead, see https://mm.kno.wled.ge/advanced/custom-features/#changing-web-ui
+ * to find out how to easily modify the web UI source!
+ */
+`;
+
+function hexdump(buffer, isHex = false) {
   let lines = [];
 
-  for (let i = 0; i < buffer.length; i +=(isHex?32:16)) {
+  for (let i = 0; i < buffer.length; i += (isHex ? 32 : 16)) {
     var block;
     let hexArray = [];
     if (isHex) {
       block = buffer.slice(i, i + 32)
-      for (let j = 0; j < block.length; j +=2 ) {
-        hexArray.push("0x" + block.slice(j,j+2))
+      for (let j = 0; j < block.length; j += 2) {
+        hexArray.push("0x" + block.slice(j, j + 2))
       }
     } else {
       block = buffer.slice(i, i + 16); // cut buffer into blocks of 16
@@ -51,219 +95,203 @@ function hexdump(buffer,isHex=false) {
   return lines.join(",\n");
 }
 
-function strReplace(str, search, replacement) {
-  return str.split(search).join(replacement);
-}
-
 function adoptVersionAndRepo(html) {
   let repoUrl = packageJson.repository ? packageJson.repository.url : undefined;
   if (repoUrl) {
     repoUrl = repoUrl.replace(/^git\+/, "");
     repoUrl = repoUrl.replace(/\.git$/, "");
-    // Replace we
-    html = strReplace(html, "https://github.com/atuline/WLED", repoUrl);
-    html = strReplace(html, "https://github.com/Aircoookie/WLED", repoUrl);
-    // html = strReplace(html, "https://github.com/wled-dev/WLED", repoUrl); // replacing upstream break "credits"
-    // html = strReplace(html, "https://github.com/wled/WLED", repoUrl);
-    // html = strReplace(html, "https://github.com/MoonModules/WLED", repoUrl); //WLEDMM
-    // html = strReplace(html, "https://github.com/MoonModules/WLED-MM", repoUrl); //WLEDMM - not necessary to replace ourselves ;-)
+    // html = html.replaceAll("https://github.com/wled-dev/WLED", repoUrl); // WLEDMM replacing upstream break "credits"
+    html = html.replaceAll("https://github.com/atuline/WLED", repoUrl);
+    html = html.replaceAll("https://github.com/Aircoookie/WLED", repoUrl);
   }
   let version = packageJson.version;
   if (version) {
-    html = strReplace(html, "##VERSION##", version);
+    html = html.replaceAll("##VERSION##", version);
   }
   return html;
 }
 
-function filter(str, type) {
-  str = adoptVersionAndRepo(str);
-  if (type === undefined) {
+async function minify(str, type = "plain") {
+  const options = {
+    collapseWhitespace: true,
+    conservativeCollapse: true, // preserve spaces in text
+    collapseBooleanAttributes: true,
+    collapseInlineTagWhitespace: true,
+    minifyCSS: true,
+    minifyJS: true,
+    removeAttributeQuotes: true,
+    removeComments: true,
+    sortAttributes: true,
+    sortClassName: true,
+  };
+
+  if (type == "plain") {
     return str;
   } else if (type == "css-minify") {
     return new CleanCSS({}).minify(str).styles;
   } else if (type == "js-minify") {
-    return MinifyHTML('<script>' + str + '</script>', {
-      collapseWhitespace: true,
-      minifyJS: true, 
-      continueOnParseError: false,
-      removeComments: true,
-    }).replace(/<[\/]*script>/g,'');
+    let js = await minifyHtml('<script>' + str + '</script>', options);
+    return js.replace(/<[\/]*script>/g, '');
   } else if (type == "html-minify") {
-    return MinifyHTML(str, {
-      collapseWhitespace: true,
-      maxLineLength: 80,
-      minifyCSS: true,
-      minifyJS: true, 
-      continueOnParseError: false,
-      removeComments: true,
-    });
-  } else if (type == "html-minify-ui") {
-    return MinifyHTML(str, {
-      collapseWhitespace: true,
-      conservativeCollapse: true,
-      maxLineLength: 80,
-      minifyCSS: true,
-      minifyJS: true, 
-      continueOnParseError: false,
-      removeComments: true,
-    });
-  } else {
-    console.warn("Unknown filter: " + type);
-    return str;
+    return await minifyHtml(str, options);
   }
+
+  throw new Error("Unknown filter: " + type);
 }
 
-// Generate build timestamp as UNIX timestamp (seconds since epoch)
-function generateBuildTime() {
-  return Math.floor(Date.now() / 1000);
-}
-
-function writeHtmlGzipped(sourceFile, resultFile, page) {
+async function writeHtmlGzipped(sourceFile, resultFile, page, inlineCss = true) {
   console.info("Reading " + sourceFile);
-  new inliner(sourceFile, function (error, html) {
-    console.info("Inlined " + html.length + " characters");
-    html = filter(html, "html-minify-ui");
-    console.info("Minified to " + html.length + " characters");
+  inline.html({
+    fileContent: fs.readFileSync(sourceFile, "utf8"),
+    relativeTo: path.dirname(sourceFile),
+    strict: inlineCss,     // when not inlining css, ignore errors (enables linking style.css from subfolder htm files)
+    stylesheets: inlineCss // when true (default), css is inlined
+  },
+    async function (error, html) {
+      if (error) throw error;
 
-    if (error) {
-      console.warn(error);
-      throw error;
-    }
-
-    html = adoptVersionAndRepo(html);
-    zlib.gzip(html, { level: zlib.constants.Z_BEST_COMPRESSION }, function (error, result) {
-      if (error) {
-        console.warn(error);
-        throw error;
-      }
-
-      console.info("Compressed " + result.length + " bytes");
+      html = adoptVersionAndRepo(html);
+      const originalLength = html.length;
+      html = await minify(html, "html-minify");
+      const result = zlib.gzipSync(html, { level: zlib.constants.Z_BEST_COMPRESSION });
+      console.info("Minified and compressed " + sourceFile + " from " + originalLength + " to " + result.length + " bytes");
       const array = hexdump(result);
-      const src = `/*
- * Binary array for the Web UI.
- * gzip is used for smaller size and improved speeds.
- * 
- * Please see https://mm.kno.wled.ge/advanced/custom-features/#changing-web-ui
- * to find out how to easily modify the web UI source!
- */
-
-// Automatically generated build time for cache busting (UNIX timestamp)
-#ifdef WEB_BUILD_TIME // avoid duplicate defintions
-#undef WEB_BUILD_TIME
-#endif
-#define WEB_BUILD_TIME ${generateBuildTime()}
-
-// Autogenerated from ${sourceFile}, do not edit!!
-const uint16_t PAGE_${page}_L = ${result.length};
-const uint8_t PAGE_${page}[] PROGMEM = {
-${array}
-};
-`;
+      let src = singleHeader;
+      src += `const uint16_t PAGE_${page}_L = ${result.length};\n`;
+      src += `const uint8_t PAGE_${page}[] PROGMEM = {\n${array}\n};\n\n`;
       console.info("Writing " + resultFile);
       fs.writeFileSync(resultFile, src);
     });
-  });
 }
 
-function specToChunk(srcDir, s) {
-  if (s.method == "plaintext") {
-    const buf = fs.readFileSync(srcDir + "/" + s.file);
-    const str = buf.toString("utf-8");
-    const chunk = `
-// Autogenerated from ${srcDir}/${s.file}, do not edit!!
-const char ${s.name}[] PROGMEM = R"${s.prepend || ""}${filter(str, s.filter)}${
-      s.append || ""
-    }";
+async function specToChunk(srcDir, s) {
+  const buf = fs.readFileSync(srcDir + "/" + s.file);
+  let chunk = `\n// Autogenerated from ${srcDir}/${s.file}, do not edit!!\n`
 
-`;
-    return s.mangle ? s.mangle(chunk) : chunk;
-  } else if (s.method == "gzip") {
-    const buf = fs.readFileSync(srcDir + "/" + s.file);
-    var str = buf.toString('utf-8');
-    if (s.mangle) str = s.mangle(str);
-    const zip = zlib.gzipSync(filter(str, s.filter), { level: zlib.constants.Z_BEST_COMPRESSION });
-    const result = hexdump(zip.toString('hex'), true);
-    const chunk = `
-// Autogenerated from ${srcDir}/${s.file}, do not edit!!
-const uint16_t ${s.name}_length = ${zip.length};
-const uint8_t ${s.name}[] PROGMEM = {
-${result}
-};
-
-`;
-    return chunk;
-  } else if (s.method == "binary") {
-    const buf = fs.readFileSync(srcDir + "/" + s.file);
-    const result = hexdump(buf);
-    const chunk = `
-// Autogenerated from ${srcDir}/${s.file}, do not edit!!
-const uint16_t ${s.name}_length = ${result.length};
-const uint8_t ${s.name}[] PROGMEM = {
-${result}
-};
-
-`;
-    return chunk;
-  } else {
-    console.warn("Unknown method: " + s.method);
-    return undefined;
-  }
-}
-
-function writeChunks(srcDir, specs, resultFile) {
-  let src = `/*
- * More web UI HTML source arrays.
- * This file is auto generated, please don't make any changes manually.
- * Instead, see https://mm.kno.wled.ge/advanced/custom-features/#changing-web-ui
- * to find out how to easily modify the web UI source!
- */ 
-`;
-  specs.forEach((s) => {
-    try {
-      console.info("Reading " + srcDir + "/" + s.file + " as " + s.name);
-      src += specToChunk(srcDir, s);
-    } catch (e) {
-      console.warn(
-        "Failed " + s.name + " from " + srcDir + "/" + s.file,
-        e.message.length > 60 ? e.message.substring(0, 60) : e.message
-      );
+  if (s.method == "plaintext" || s.method == "gzip") {
+    let str = buf.toString("utf-8");
+    str = adoptVersionAndRepo(str);
+    const originalLength = str.length;
+    if (s.method == "gzip") {
+      if (s.mangle) str = s.mangle(str);
+      const zip = zlib.gzipSync(await minify(str, s.filter), { level: zlib.constants.Z_BEST_COMPRESSION });
+      console.info("Minified and compressed " + s.file + " from " + originalLength + " to " + zip.length + " bytes");
+      const result = hexdump(zip);
+      chunk += `const uint16_t ${s.name}_length = ${zip.length};\n`;
+      chunk += `const uint8_t ${s.name}[] PROGMEM = {\n${result}\n};\n\n`;
+      return chunk;
+    } else {
+      const minified = await minify(str, s.filter);
+      console.info("Minified " + s.file + " from " + originalLength + " to " + minified.length + " bytes");
+      chunk += `const char ${s.name}[] PROGMEM = R"${s.prepend || ""}${minified}${s.append || ""}";\n\n`;
+      return s.mangle ? s.mangle(chunk) : chunk;
     }
-  });
+  } else if (s.method == "binary") {
+    const result = hexdump(buf);
+    chunk += `const uint16_t ${s.name}_length = ${buf.length};\n`;
+    chunk += `const uint8_t ${s.name}[] PROGMEM = {\n${result}\n};\n\n`;
+    return chunk;
+  }
+
+  throw new Error("Unknown method: " + s.method);
+}
+
+async function writeChunks(srcDir, specs, resultFile) {
+  let src = multiHeader;
+  for (const s of specs) {
+    console.info("Reading " + srcDir + "/" + s.file + " as " + s.name);
+    src += await specToChunk(srcDir, s);
+  }
   console.info("Writing " + src.length + " characters into " + resultFile);
   fs.writeFileSync(resultFile, src);
 }
 
-writeHtmlGzipped("wled00/data/index.htm", "wled00/html_ui.h", 'index');
+// Check if a file is newer than a given time
+function isFileNewerThan(filePath, time) {
+  const stats = fs.statSync(filePath);
+  return stats.mtimeMs > time;
+}
+
+// Check if any file in a folder (or its subfolders) is newer than a given time
+function isAnyFileInFolderNewerThan(folderPath, time) {
+  const files = fs.readdirSync(folderPath, { withFileTypes: true });
+  for (const file of files) {
+    const filePath = path.join(folderPath, file.name);
+    if (isFileNewerThan(filePath, time)) {
+      return true;
+    }
+    if (file.isDirectory() && isAnyFileInFolderNewerThan(filePath, time)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Check if the web UI is already built
+function isAlreadyBuilt(webUIPath, packageJsonPath = "package.json") {
+  let lastBuildTime = Infinity;
+
+  for (const file of output) {
+    try {
+      lastBuildTime = Math.min(lastBuildTime, fs.statSync(file).mtimeMs);
+    } catch (e) {
+      if (e.code !== 'ENOENT') throw e;
+      console.info("File " + file + " does not exist. Rebuilding...");
+      return false;
+    }
+  }
+
+  return !isAnyFileInFolderNewerThan(webUIPath, lastBuildTime) && !isFileNewerThan(packageJsonPath, lastBuildTime) && !isFileNewerThan(__filename, lastBuildTime);
+}
+
+// Don't run this script if we're in a test environment
+if (process.env.NODE_ENV === 'test') {
+  return;
+}
+
+console.info(wledBanner);
+
+if (isAlreadyBuilt("wled00/data") && process.argv[2] !== '--force' && process.argv[2] !== '-f') {
+  console.info("Web UI is already built");
+  return;
+}
+
+writeHtmlGzipped("wled00/data/index.htm", "wled00/html_ui.h", 'index', false);
 writeHtmlGzipped("wled00/data/simple.htm", "wled00/html_simple.h", 'simple');
 writeHtmlGzipped("wled00/data/pixart/pixart.htm", "wled00/html_pixart.h", 'pixart');
+//writeHtmlGzipped("wled00/data/pxmagic/pxmagic.htm", "wled00/html_pxmagic.h", 'pxmagic');
+//writeHtmlGzipped("wled00/data/pixelforge/pixelforge.htm", "wled00/html_pixelforge.h", 'pixelforge', false); // do not inline css
 writeHtmlGzipped("wled00/data/cpal/cpal.htm", "wled00/html_cpal.h", 'cpal');
-writeHtmlGzipped("wled00/data/pxmagic/pxmagic.htm", "wled00/html_pxmagic.h", 'pxmagic');
-/*
+//writeHtmlGzipped("wled00/data/edit.htm", "wled00/html_edit.h", 'edit');
+
 writeChunks(
   "wled00/data",
   [
     {
-      file: "simple.css",
-      name: "PAGE_simpleCss",
+      file: "edit.htm",
+      name: "PAGE_edit",
       method: "gzip",
-      filter: "css-minify",
-    },
-    {
-      file: "simple.js",
-      name: "PAGE_simpleJs",
-      method: "gzip",
-      filter: "js-minify",
-    },
-    {
-      file: "simple.htm",
-      name: "PAGE_simple",
-      method: "gzip",
-      filter: "html-minify-ui",
+      filter: "html-minify"
     }
   ],
-  "wled00/html_simplex.h"
+  "wled00/html_edit.h"
+);
+
+/*
+writeChunks(
+  "wled00/data/cpal",
+  [
+    {
+      file: "cpal.htm",
+      name: "PAGE_cpal",
+      method: "gzip",
+      filter: "html-minify"
+    }
+  ],
+  "wled00/html_cpal.h"
 );
 */
+
 writeChunks(
   "wled00/data",
   [
@@ -274,8 +302,16 @@ writeChunks(
       filter: "css-minify",
       mangle: (str) =>
         str
-          .replace("%%","%")
+          .replace("%%", "%")
     },
+	/*
+    {
+      file: "common.js",
+      name: "JS_common",
+      method: "gzip",
+      filter: "js-minify",
+    },
+	*/
     {
       file: "settings.htm",
       name: "PAGE_settings",
@@ -430,6 +466,7 @@ const char PAGE_dmxmap[] PROGMEM = R"=====()=====";
       method: "gzip",
       filter: "html-minify",
     },
+    //WLEDMM
     {
       file: "404mini.htm",
       name: "PAGE_404_mini",
@@ -444,12 +481,14 @@ const char PAGE_dmxmap[] PROGMEM = R"=====()=====";
     {
       file: "iro.js",
       name: "iroJs",
-      method: "gzip"
+      method: "gzip",
+      filter: "js-minify",
     },
     {
       file: "rangetouch.js",
       name: "rangetouchJs",
-      method: "gzip"
+      method: "gzip",
+      filter: "js-minify"
     }
   ],
   "wled00/html_other.h"

--- a/tools/cdata.js
+++ b/tools/cdata.js
@@ -304,14 +304,12 @@ writeChunks(
         str
           .replace("%%", "%")
     },
-	/*
     {
       file: "common.js",
       name: "JS_common",
       method: "gzip",
       filter: "js-minify",
     },
-	*/
     {
       file: "settings.htm",
       name: "PAGE_settings",

--- a/tools/cdata.js
+++ b/tools/cdata.js
@@ -100,7 +100,7 @@ function adoptVersionAndRepo(html) {
   if (repoUrl) {
     repoUrl = repoUrl.replace(/^git\+/, "");
     repoUrl = repoUrl.replace(/\.git$/, "");
-    // html = strReplace(html, "https://github.com/wled-dev/WLED", repoUrl); // replacing upstream break "credits"
+    // html = html.replaceAll("https://github.com/wled-dev/WLED", repoUrl); // WLEDMM replacing upstream break "credits"
     html = html.replaceAll("https://github.com/atuline/WLED", repoUrl);
     html = html.replaceAll("https://github.com/Aircoookie/WLED", repoUrl);
   }

--- a/tools/cdata.js
+++ b/tools/cdata.js
@@ -100,7 +100,7 @@ function adoptVersionAndRepo(html) {
   if (repoUrl) {
     repoUrl = repoUrl.replace(/^git\+/, "");
     repoUrl = repoUrl.replace(/\.git$/, "");
-    // html = html.replaceAll("https://github.com/wled-dev/WLED", repoUrl); // WLEDMM replacing upstream break "credits"
+    // html = strReplace(html, "https://github.com/wled-dev/WLED", repoUrl); // replacing upstream break "credits"
     html = html.replaceAll("https://github.com/atuline/WLED", repoUrl);
     html = html.replaceAll("https://github.com/Aircoookie/WLED", repoUrl);
   }
@@ -259,8 +259,8 @@ if (isAlreadyBuilt("wled00/data") && process.argv[2] !== '--force' && process.ar
 writeHtmlGzipped("wled00/data/index.htm", "wled00/html_ui.h", 'index', false);
 writeHtmlGzipped("wled00/data/simple.htm", "wled00/html_simple.h", 'simple');
 writeHtmlGzipped("wled00/data/pixart/pixart.htm", "wled00/html_pixart.h", 'pixart');
-//writeHtmlGzipped("wled00/data/pxmagic/pxmagic.htm", "wled00/html_pxmagic.h", 'pxmagic');
-//writeHtmlGzipped("wled00/data/pixelforge/pixelforge.htm", "wled00/html_pixelforge.h", 'pixelforge', false); // do not inline css
+writeHtmlGzipped("wled00/data/pxmagic/pxmagic.htm", "wled00/html_pxmagic.h", 'pxmagic');
+writeHtmlGzipped("wled00/data/pixelforge/pixelforge.htm", "wled00/html_pixelforge.h", 'pixelforge', false); // do not inline css
 writeHtmlGzipped("wled00/data/cpal/cpal.htm", "wled00/html_cpal.h", 'cpal');
 //writeHtmlGzipped("wled00/data/edit.htm", "wled00/html_edit.h", 'edit');
 

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -984,7 +984,7 @@ class WS2812FX {  // 96 bytes
       printSize(),
 #endif
       finalizeInit(),
-      waitUntilIdle(void),   // WLEDMM
+      waitUntilIdle(unsigned timeout = 0),   // WLEDMM
       service(void),
       setMode(uint8_t segid, uint8_t m),
       setColor(uint8_t slot, uint32_t c),
@@ -1037,8 +1037,8 @@ class WS2812FX {  // 96 bytes
       getActiveSegmentsNum(void)  const,
       __attribute__((pure)) getFirstSelectedSegId(void),
       getLastActiveSegmentId(void) const,
-      __attribute__((pure)) getActiveSegsLightCapabilities(bool selectedOnly = false),
-      setPixelSegment(uint8_t n);
+      __attribute__((pure)) getActiveSegsLightCapabilities(bool selectedOnly = false);
+      //setPixelSegment(uint8_t n);
 
     inline uint8_t getBrightness(void)  const { return _brightness; }
     inline uint8_t getSegmentsNum(void)  const { return _segments.size(); }  // returns currently present segments
@@ -1247,12 +1247,16 @@ class WS2812FX {  // 96 bytes
 #endif
 
     // will require only 1 byte
+    volatile bool _isServicing; // WLEDMM moved out of struct, so the flag can be updated in one atomic access
     struct {
-      bool _isServicing          : 1;
+      //bool _isServicing          : 1;
+      bool bullshit              : 1;
       bool _isOffRefreshRequired : 1; //periodic refresh is required for the strip to remain off.
       bool _hasWhiteChannel      : 1;
-      bool _triggered            : 1;
+      //bool _triggered            : 1;
+      bool bullshit2             : 1;
     };
+    volatile bool _triggered;   // WLEDMM moved out of struct, so the flag can be updated in one atomic access
 
     uint8_t                  _modeCount;
     std::vector<mode_ptr>    _mode;     // SRAM footprint: 4 bytes per element

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -1247,14 +1247,12 @@ class WS2812FX {  // 96 bytes
 #endif
 
     // will require only 1 byte
-    volatile bool _isServicing; // WLEDMM moved out of struct, so the flag can be updated in one atomic access
     struct {
-      //bool _isServicing          : 1;
-      bool bullshit              : 1;
+      bool _isServicing          : 1; // can stay inside the bitfield - not critical any more since we have a mutex 
       bool _isOffRefreshRequired : 1; //periodic refresh is required for the strip to remain off.
       bool _hasWhiteChannel      : 1;
       //bool _triggered            : 1;
-      bool bullshit2             : 1;
+      bool unusedBit             : 1;
     };
     volatile bool _triggered;   // WLEDMM moved out of struct, so the flag can be updated in one atomic access
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -589,6 +589,9 @@ void Segment::setUp(uint16_t i1, uint16_t i2, uint8_t grp, uint8_t spc, uint16_t
     }
     if (ofs < UINT16_MAX) offset = ofs;
     esp32SemGive(segmentMux);
+  } else {
+    DEBUG_PRINTLN(F("Segment::setUp: Failed to acquire segmentMux, skipping bounds update."));
+    boundsUnchanged = true;
   }
 
   if (!boundsUnchanged) {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1955,11 +1955,7 @@ void WS2812FX::service() {
   //if (_suspend) return;
   if (elapsed < 2) return;                                                       // keep wifi alive
   if ( !_triggered && (_targetFps != FPS_UNLIMITED) && (_targetFps != FPS_UNLIMITED_AC)) {
-#if 0
-    if (elapsed < MIN_SHOW_DELAY) return;                                        // WLEDMM too early for service - delivers higher fps
-#else
     if ((elapsed+1) < _frametime) return;                                            // code from upstream - stricter on FPS
-#endif
   }
   #else  // legacy
   if (elapsed < _frametime) return;
@@ -1997,9 +1993,6 @@ void WS2812FX::service() {
 
         if (!cctFromRgb || correctWB) busses.setSegmentCCT(seg.currentBri(seg.cct, true), correctWB);
         for (uint8_t c = 0; c < NUM_COLORS; c++) _colors_t[c] = gamma32(_colors_t[c]);
-#if 0  // WARNING this would kill _supersync_
-        now = millis() + timebase;
-#endif
         seg.startFrame();   // WLEDMM
         if (!_triggered && (seg.currentBri(seg.opacity) == 0) && (seg.lastBri == 0)) continue; // WLEDMM skip totally black segments
         // effect blending (execute previous effect)
@@ -2029,23 +2022,14 @@ void WS2812FX::service() {
   }
   esp32SemGive(segmentMux);
   } // end of critical section
-  if (_triggered) doShow = true;      // WLEDMM "triggered" always means "show"
 
   #ifdef WLEDMM_FASTPATH
   _currentSeg = & strip.getMainSegment(); // WLEDMM safe default
   #endif
   _virtualSegmentLength = 0;
   busses.setSegmentCCT(-1);
-  if(doShow) {
-#if 0 && defined(ARDUINO_ARCH_ESP32)      // EXPERIMENTAL - enabled this to enforce stricter frametime limits
-    static unsigned long lastTimeShow = 0;
-    long tdelta = millis() - lastTimeShow;
-    if ((lastTimeShow > 0) && (tdelta > 1) && (tdelta < _frametime))  // too early - release CPU to slow down
-      vTaskDelay((tdelta-1) / portTICK_PERIOD_MS);                    // "-1" because vTaskDelay() may actually delay longer than requested
-    lastTimeShow = millis();
-#else
+  if(doShow || _triggered) {
     yield();
-#endif
     show();
     _lastServiceShow = nowUp; // WLEDMM use correct timestamp
   }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -117,17 +117,11 @@ void Segment::allocLeds() {
   if ((size > 0) && (!ledsrgb || size > ledsrgbSize)) {    //softhack dont allocate zero bytes
     DEBUG_PRINTF("allocLeds (%d,%d to %d,%d), %u from %u\n", start, startY, stop, stopY, size, ledsrgb?ledsrgbSize:0);
 
-    #if defined(ARDUINO_ARCH_ESP32) // WLEDMM protect against parallel access
-    portENTER_CRITICAL(&s_wled_strip_mux);
-    #endif
-    if (ledsrgb) free(ledsrgb);   // we need a bigger buffer, so free the old one first
+    CRGB* oldLedsRgb = ledsrgb; // WLEDMM this makes the re-allocation an anmost-atomic and more threadsafe operation
     ledsrgb = nullptr;
-    ledsrgb = (CRGB*)calloc(size, 1);
+    if (oldLedsRgb) free(oldLedsRgb);   // we need a bigger buffer, so free the old one first
+    ledsrgb = (CRGB*)calloc(size, 1);   // WLEDMM This is an OS call, so we should not wrap it in portEnterCRITICAL
     ledsrgbSize = ledsrgb?size:0;
-    #if defined(ARDUINO_ARCH_ESP32) // WLEDMM protect against parallel access
-    portEXIT_CRITICAL(&s_wled_strip_mux);
-    #endif
-
     if (ledsrgb == nullptr) {
       USER_PRINTLN("allocLeds failed!!");
       errorFlag = ERR_LOW_BUF; // WLEDMM raise errorflag
@@ -1877,15 +1871,16 @@ void WS2812FX::finalizeInit(void)
     // this is a critical section that will be removed with PR #278 which removes _globalLeds
     // problem: suspendStripService provides interlocking, but there’s a window before service() observes it, 
     //          and ESP32 is dual-core. A critical section closes that window so the pointer swap is atomic across cores.
+    CRGB* oldGLeds = Segment::_globalLeds;
 #if defined(ARDUINO_ARCH_ESP32)
     portENTER_CRITICAL(&s_wled_strip_mux);
 #endif
-    free(Segment::_globalLeds);
     Segment::_globalLeds = nullptr;
-    purgeSegments(true);   // WLEDMM moved here, because it seems to improve stability.
 #if defined(ARDUINO_ARCH_ESP32)
     portEXIT_CRITICAL(&s_wled_strip_mux);
 #endif
+    free(oldGLeds);
+    purgeSegments(true);   // WLEDMM moved here, because it seems to improve stability.
   }
   if (useLedsArray && getLengthTotal()>0) { // WLEDMM avoid malloc(0)
     size_t arrSize = sizeof(CRGB) * getLengthTotal();
@@ -1994,9 +1989,10 @@ void WS2812FX::service() {
         // effect blending (execute previous effect)
         // actual code may be a bit more involved as effects have runtime data including allocated memory
         //if (seg.transitional && seg._modeP) (*_mode[seg._modeP])(progress());
-        #if defined(ARDUINO_ARCH_ESP32) // WLEDMM protect against parallel drawing
-        if (xSemaphoreTake(busDrawMux, 200) != pdTRUE) { delay(1); continue;}      // WLEDMM first acquire draw mutex
-        #endif
+
+        // WLEDMM protect against parallel drawing
+        if (esp32SemTake(busDrawMux, 200) != pdTRUE) { delay(1); continue;}      // WLEDMM first acquire draw mutex
+
         frameDelay = (*_mode[seg.currentMode(seg.mode)])();
 
         if (frameDelay < speedLimit) frameDelay = FRAMETIME;                    // WLEDMM limit effects that want to go faster than target FPS
@@ -2007,9 +2003,8 @@ void WS2812FX::service() {
 
         seg.lastBri = seg.currentBri(seg.on ? seg.opacity:0);                   // WLEDMM remember for next time
         seg.handleTransition();
-        #if defined(ARDUINO_ARCH_ESP32)
-        xSemaphoreGive(busDrawMux); // WLEDMM unlock mutex
-        #endif
+
+        esp32SemGive(busDrawMux); // WLEDMM unlock mutex
       }
 
       seg.next_time = nowUp + frameDelay;
@@ -2150,13 +2145,10 @@ void WS2812FX::show(void) {
   // all of the data has been sent.
   // See https://github.com/Makuna/NeoPixelBus/wiki/ESP32-NeoMethods#neoesp32rmt-methods
 
-  #if defined(ARDUINO_ARCH_ESP32) // WLEDMM protect against parallel access
-  if (xSemaphoreTake(busDrawMux, 200) != pdTRUE) { delay(1); return;}      // WLEDMM first acquire drawing permission (mutex), wait max 200ms
-  #endif
+  // WLEDMM protect against parallel access
+  if (esp32SemTake(busDrawMux, 200) != pdTRUE) { delay(1); return;}      // WLEDMM first acquire drawing permission (mutex), wait max 200ms
   busses.show();
-  #if defined(ARDUINO_ARCH_ESP32)
-  xSemaphoreGive(busDrawMux);                                              // WLEDMM return permissions
-  #endif
+  esp32SemGive(busDrawMux);                                              // WLEDMM return permissions
 
   unsigned long diff = showNow - _lastShow;
   uint16_t fpsCurr = 200;
@@ -2355,15 +2347,19 @@ void WS2812FX::purgeSegments(bool force) {
   // remove all inactive segments (from the back)
   int deleted = 0;
   if (_segments.size() <= 1) return;
-  for (size_t i = _segments.size()-1; i > 0; i--)
+  // WLEDMM protect against parallel access while drawing
+  if (esp32SemTake(busDrawMux, 300) != pdTRUE) return;
+
+  for (size_t i = _segments.size()-1; i > 0; i--) {
     if (_segments[i].stop == 0 || force) {
       deleted++;
       _segments.erase(_segments.begin() + i);
-    }
+  } }
   if (deleted) {
     _segments.shrink_to_fit();
     /*if (_mainSegment >= _segments.size())*/ setMainSegmentId(0);
   }
+  esp32SemGive(busDrawMux);
 }
 
 Segment& WS2812FX::getSegment(uint8_t id) {
@@ -2391,6 +2387,9 @@ void WS2812FX::restartRuntime(bool doReset) {
 void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
   DEBUG_PRINTF("resetSegments %d %dx%d\n", boundsOnly, Segment::maxWidth, Segment::maxHeight);
   if (!boundsOnly) {
+    // WLEDMM protect against parallel access while drawing
+    if (esp32SemTake(busDrawMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+
     _segments.clear(); // destructs all Segment as part of clearing
     #ifndef WLED_DISABLE_2D
     segment seg = isMatrix ? Segment(0, Segment::maxWidth, 0, Segment::maxHeight) : Segment(0, _length);
@@ -2399,6 +2398,7 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
     #endif
     _segments.push_back(seg);
     _mainSegment = 0;
+    esp32SemGive(busDrawMux);
   } else { //WLEDMM boundsonly
     for (segment &seg : _segments) {
       #ifndef WLED_DISABLE_2D
@@ -2417,6 +2417,9 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
 
 void WS2812FX::makeAutoSegments(bool forceReset) {
   if (autoSegments) { //make one segment per bus
+    // WLEDMM protect against parallel access while drawing
+    if (esp32SemTake(busDrawMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+
     uint16_t segStarts[MAX_NUM_SEGMENTS] = {0};
     uint16_t segStops [MAX_NUM_SEGMENTS] = {0};
     size_t s = 0;
@@ -2465,7 +2468,7 @@ void WS2812FX::makeAutoSegments(bool forceReset) {
     for (size_t i = 1; i < s; i++) {
       _segments.push_back(Segment(segStarts[i], segStops[i]));
     }
-
+    esp32SemGive(busDrawMux);
   } else {
 
     if (forceReset || getSegmentsNum() == 0) resetSegments();
@@ -2491,9 +2494,9 @@ void WS2812FX::makeAutoSegments(bool forceReset) {
 }
 
 void WS2812FX::fixInvalidSegments() {
-  #if defined(ARDUINO_ARCH_ESP32)          // WLEDMM protect against parallel access
-  portENTER_CRITICAL(&s_wled_strip_mux);   // this locks out all parallel tasks, including PSRAM and flash filesystem access
-  #endif
+  // WLEDMM protect against parallel access while drawing
+  if (esp32SemTake(busDrawMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+
   //make sure no segment is longer than total (sanity check)
   for (size_t i = getSegmentsNum()-1; i > 0; i--) {
     if (isMatrix) {
@@ -2513,15 +2516,13 @@ void WS2812FX::fixInvalidSegments() {
       if (_segments[i].stop  >  _length) _segments[i].stop = _length;
     }
   }
+  esp32SemGive(busDrawMux);  // give back the lock now, so purgeSegments can acquire it again
+
   // if any segments were deleted free memory
   purgeSegments();
   // this is always called as the last step after finalizeInit(), update covered bus types
   for (segment &seg : _segments)
     seg.refreshLightCapabilities();
-
-  #if defined(ARDUINO_ARCH_ESP32)
-  portEXIT_CRITICAL(&s_wled_strip_mux);
-  #endif
 }
 
 //true if all segments align with a bus, or if a segment covers the total length

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1443,8 +1443,9 @@ void Segment::refreshLightCapabilities() {
 void __attribute__((hot)) Segment::fill(uint32_t c) {
   if (!isActive()) return; // not active
 
-  const uint_fast16_t cols = is2D() ? virtualWidth() : virtualLength();             // WLEDMM use fast int types
-  const uint_fast16_t rows = virtualHeight(); // will be 1 for 1D
+  // WLEDMM use "calc_" functions because fill() is also called from json.cpp without previous seg.startFrame
+  const uint_fast16_t cols = is2D() ? calc_virtualWidth() : calc_virtualLength();             // WLEDMM use fast int types
+  const uint_fast16_t rows = calc_virtualHeight(); // will be 1 for 1D
 
   if (is2D()) {
     // pre-calculate scaled color
@@ -2013,6 +2014,9 @@ void WS2812FX::service() {
   }
   if (_triggered) doShow = true;      // WLEDMM "triggered" always means "show"
 
+  #ifdef WLEDMM_FASTPATH
+  _currentSeg = & strip.getMainSegment(); // WLEDMM safe default
+  #endif
   _virtualSegmentLength = 0;
   busses.setSegmentCCT(-1);
   if(doShow) {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -117,10 +117,19 @@ void Segment::allocLeds() {
   if ((size > 0) && (!ledsrgb || size > ledsrgbSize)) {    //softhack dont allocate zero bytes
     DEBUG_PRINTF("allocLeds (%d,%d to %d,%d), %u from %u\n", start, startY, stop, stopY, size, ledsrgb?ledsrgbSize:0);
 
-    CRGB* oldLedsRgb = ledsrgb; // WLEDMM this makes the re-allocation an anmost-atomic and more threadsafe operation
+    // WLEDMM this looks a bit over-compilicated, but it makes the re-allocation step an atomic and threadsafe operation
+    CRGB* oldLedsRgb = ledsrgb;
     ledsrgb = nullptr;
     if (oldLedsRgb) free(oldLedsRgb);   // we need a bigger buffer, so free the old one first
-    ledsrgb = (CRGB*)calloc(size, 1);   // WLEDMM This is an OS call, so we should not wrap it in portEnterCRITICAL
+    CRGB* newLedsRgb = (CRGB*)calloc(1, size);   // WLEDMM This is an OS call, so we should not wrap it in portEnterCRITICAL
+    #if defined(ARDUINO_ARCH_ESP32)
+    portENTER_CRITICAL(&s_wled_strip_mux);
+    #endif
+      ledsrgb = newLedsRgb;
+    #if defined(ARDUINO_ARCH_ESP32)
+    portEXIT_CRITICAL(&s_wled_strip_mux);
+    #endif
+
     ledsrgbSize = ledsrgb?size:0;
     if (ledsrgb == nullptr) {
       USER_PRINTLN("allocLeds failed!!");

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -561,21 +561,26 @@ void Segment::setUp(uint16_t i1, uint16_t i2, uint8_t grp, uint8_t spc, uint16_t
     markForReset();
     return;
   }
-  if (i1 < Segment::maxWidth || (i1 >= Segment::maxWidth*Segment::maxHeight && i1 < strip.getLengthTotal())) start = i1; // Segment::maxWidth equals strip.getLengthTotal() for 1D
-  stop = i2 > Segment::maxWidth*Segment::maxHeight ? min(i2,strip.getLengthTotal()) : (i2 > Segment::maxWidth ? Segment::maxWidth : max((uint16_t)1,i2));  // WLEDMM: use native min/max
-  startY = 0;
-  stopY  = 1;
-  #ifndef WLED_DISABLE_2D
-  if (Segment::maxHeight>1) { // 2D
-    if (i1Y < Segment::maxHeight) startY = i1Y;
-    stopY = i2Y > Segment::maxHeight ? Segment::maxHeight : max((uint16_t)1,i2Y);         // WLEDMM: use native min/max
+
+  if (esp32SemTake(segmentMux, portMAX_DELAY) == pdTRUE) {
+    // WLEDMM acquire lock before doing critical changes to segment
+    if (i1 < Segment::maxWidth || (i1 >= Segment::maxWidth*Segment::maxHeight && i1 < strip.getLengthTotal())) start = i1; // Segment::maxWidth equals strip.getLengthTotal() for 1D
+    stop = i2 > Segment::maxWidth*Segment::maxHeight ? min(i2,strip.getLengthTotal()) : (i2 > Segment::maxWidth ? Segment::maxWidth : max((uint16_t)1,i2));  // WLEDMM: use native min/max
+    startY = 0;
+    stopY  = 1;
+    #ifndef WLED_DISABLE_2D
+    if (Segment::maxHeight>1) { // 2D
+      if (i1Y < Segment::maxHeight) startY = i1Y;
+      stopY = i2Y > Segment::maxHeight ? Segment::maxHeight : max((uint16_t)1,i2Y);         // WLEDMM: use native min/max
+    }
+    #endif
+    if (grp) {
+      grouping = grp;
+      spacing = spc;
+    }
+    if (ofs < UINT16_MAX) offset = ofs;
+    esp32SemGive(segmentMux);
   }
-  #endif
-  if (grp) {
-    grouping = grp;
-    spacing = spc;
-  }
-  if (ofs < UINT16_MAX) offset = ofs;
 
   if (!boundsUnchanged) {
     markForReset();
@@ -1956,6 +1961,7 @@ void WS2812FX::service() {
 
   _isServicing = true;
   _segment_index = 0;
+  if (esp32SemTake(segmentMux, 250) == pdTRUE) {      // WLEDMM prevent changes to segments while servicing
   for (segment &seg : _segments) {
 #ifdef WLEDMM_FASTPATH
     _currentSeg = &seg;
@@ -2012,6 +2018,8 @@ void WS2812FX::service() {
     }
     _segment_index++;
   }
+  esp32SemGive(segmentMux);
+  } // end of critical section
   if (_triggered) doShow = true;      // WLEDMM "triggered" always means "show"
 
   #ifdef WLEDMM_FASTPATH
@@ -2352,7 +2360,7 @@ void WS2812FX::purgeSegments(bool force) {
   int deleted = 0;
   if (_segments.size() <= 1) return;
   // WLEDMM protect against parallel access while drawing
-  if (esp32SemTake(busDrawMux, 300) != pdTRUE) return;
+  if (esp32SemTake(segmentMux, 300) != pdTRUE) return;
 
   for (size_t i = _segments.size()-1; i > 0; i--) {
     if (_segments[i].stop == 0 || force) {
@@ -2363,7 +2371,7 @@ void WS2812FX::purgeSegments(bool force) {
     _segments.shrink_to_fit();
     /*if (_mainSegment >= _segments.size())*/ setMainSegmentId(0);
   }
-  esp32SemGive(busDrawMux);
+  esp32SemGive(segmentMux);
 }
 
 Segment& WS2812FX::getSegment(uint8_t id) {
@@ -2392,7 +2400,7 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
   DEBUG_PRINTF("resetSegments %d %dx%d\n", boundsOnly, Segment::maxWidth, Segment::maxHeight);
   if (!boundsOnly) {
     // WLEDMM protect against parallel access while drawing
-    if (esp32SemTake(busDrawMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+    if (esp32SemTake(segmentMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
 
     _segments.clear(); // destructs all Segment as part of clearing
     #ifndef WLED_DISABLE_2D
@@ -2402,7 +2410,7 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
     #endif
     _segments.push_back(seg);
     _mainSegment = 0;
-    esp32SemGive(busDrawMux);
+    esp32SemGive(segmentMux);
   } else { //WLEDMM boundsonly
     for (segment &seg : _segments) {
       #ifndef WLED_DISABLE_2D
@@ -2422,7 +2430,7 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
 void WS2812FX::makeAutoSegments(bool forceReset) {
   if (autoSegments) { //make one segment per bus
     // WLEDMM protect against parallel access while drawing
-    if (esp32SemTake(busDrawMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+    if (esp32SemTake(segmentMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
 
     uint16_t segStarts[MAX_NUM_SEGMENTS] = {0};
     uint16_t segStops [MAX_NUM_SEGMENTS] = {0};
@@ -2472,7 +2480,7 @@ void WS2812FX::makeAutoSegments(bool forceReset) {
     for (size_t i = 1; i < s; i++) {
       _segments.push_back(Segment(segStarts[i], segStops[i]));
     }
-    esp32SemGive(busDrawMux);
+    esp32SemGive(segmentMux);
   } else {
 
     if (forceReset || getSegmentsNum() == 0) resetSegments();
@@ -2499,7 +2507,7 @@ void WS2812FX::makeAutoSegments(bool forceReset) {
 
 void WS2812FX::fixInvalidSegments() {
   // WLEDMM protect against parallel access while drawing
-  if (esp32SemTake(busDrawMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+  if (esp32SemTake(segmentMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
 
   //make sure no segment is longer than total (sanity check)
   for (size_t i = getSegmentsNum()-1; i > 0; i--) {
@@ -2520,7 +2528,7 @@ void WS2812FX::fixInvalidSegments() {
       if (_segments[i].stop  >  _length) _segments[i].stop = _length;
     }
   }
-  esp32SemGive(busDrawMux);  // give back the lock now, so purgeSegments can acquire it again
+  esp32SemGive(segmentMux);  // give back the lock now, so purgeSegments can acquire it again
 
   // if any segments were deleted free memory
   purgeSegments();

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -562,7 +562,7 @@ void Segment::setUp(uint16_t i1, uint16_t i2, uint8_t grp, uint8_t spc, uint16_t
     return;
   }
 
-  if (esp32SemTake(segmentMux, portMAX_DELAY) == pdTRUE) {
+  if (esp32SemTake(segmentMux, 2100) == pdTRUE) { // wait long, but don't wait forever
     // WLEDMM acquire lock before doing critical changes to segment
     if (i1 < Segment::maxWidth || (i1 >= Segment::maxWidth*Segment::maxHeight && i1 < strip.getLengthTotal())) start = i1; // Segment::maxWidth equals strip.getLengthTotal() for 1D
     stop = i2 > Segment::maxWidth*Segment::maxHeight ? min(i2,strip.getLengthTotal()) : (i2 > Segment::maxWidth ? Segment::maxWidth : max((uint16_t)1,i2));  // WLEDMM: use native min/max
@@ -2400,7 +2400,7 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
   DEBUG_PRINTF("resetSegments %d %dx%d\n", boundsOnly, Segment::maxWidth, Segment::maxHeight);
   if (!boundsOnly) {
     // WLEDMM protect against parallel access while drawing
-    if (esp32SemTake(segmentMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+    if (esp32SemTake(segmentMux, 2100) != pdTRUE) return;  // wait long, but don't wait forever
 
     _segments.clear(); // destructs all Segment as part of clearing
     #ifndef WLED_DISABLE_2D
@@ -2430,7 +2430,7 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
 void WS2812FX::makeAutoSegments(bool forceReset) {
   if (autoSegments) { //make one segment per bus
     // WLEDMM protect against parallel access while drawing
-    if (esp32SemTake(segmentMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+    if (esp32SemTake(segmentMux, 2100) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
 
     uint16_t segStarts[MAX_NUM_SEGMENTS] = {0};
     uint16_t segStops [MAX_NUM_SEGMENTS] = {0};
@@ -2507,7 +2507,7 @@ void WS2812FX::makeAutoSegments(bool forceReset) {
 
 void WS2812FX::fixInvalidSegments() {
   // WLEDMM protect against parallel access while drawing
-  if (esp32SemTake(segmentMux, portMAX_DELAY) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+  if (esp32SemTake(segmentMux, 2100) != pdTRUE) return; // wait long, but don't wait forever
 
   //make sure no segment is longer than total (sanity check)
   for (size_t i = getSegmentsNum()-1; i > 0; i--) {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2405,6 +2405,8 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
     _mainSegment = 0;
     esp32SemGive(segmentMux);
   } else { //WLEDMM boundsonly
+    // WLEDMM protect against parallel access while drawing
+    if (esp32SemTake(segmentMux, 2100) != pdTRUE) return;  // wait long, but don't wait forever
     for (segment &seg : _segments) {
       #ifndef WLED_DISABLE_2D
       seg.start = 0;
@@ -2417,6 +2419,7 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
       #endif
       seg.allocLeds();
     }
+    esp32SemGive(segmentMux);
   }
 }
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2430,7 +2430,7 @@ void WS2812FX::resetSegments(bool boundsOnly) { //WLEDMM add boundsonly
 void WS2812FX::makeAutoSegments(bool forceReset) {
   if (autoSegments) { //make one segment per bus
     // WLEDMM protect against parallel access while drawing
-    if (esp32SemTake(segmentMux, 2100) != pdTRUE) return;  // warning: this waits until the mutex becomes availeable, no timeout
+    if (esp32SemTake(segmentMux, 2100) != pdTRUE) return;  // wait long, but don't wait forever
 
     uint16_t segStarts[MAX_NUM_SEGMENTS] = {0};
     uint16_t segStops [MAX_NUM_SEGMENTS] = {0};

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -116,9 +116,18 @@ void Segment::allocLeds() {
   }
   if ((size > 0) && (!ledsrgb || size > ledsrgbSize)) {    //softhack dont allocate zero bytes
     DEBUG_PRINTF("allocLeds (%d,%d to %d,%d), %u from %u\n", start, startY, stop, stopY, size, ledsrgb?ledsrgbSize:0);
+
+    #if defined(ARDUINO_ARCH_ESP32) // WLEDMM protect against parallel access
+    portENTER_CRITICAL(&s_wled_strip_mux);
+    #endif
     if (ledsrgb) free(ledsrgb);   // we need a bigger buffer, so free the old one first
+    ledsrgb = nullptr;
     ledsrgb = (CRGB*)calloc(size, 1);
     ledsrgbSize = ledsrgb?size:0;
+    #if defined(ARDUINO_ARCH_ESP32) // WLEDMM protect against parallel access
+    portEXIT_CRITICAL(&s_wled_strip_mux);
+    #endif
+
     if (ledsrgb == nullptr) {
       USER_PRINTLN("allocLeds failed!!");
       errorFlag = ERR_LOW_BUF; // WLEDMM raise errorflag
@@ -1904,14 +1913,15 @@ void WS2812FX::finalizeInit(void)
 // on 8266 this function does nothing, because we can only do "busy waiting" on ESP32
 //#define MAX_IDLE_WAIT_MS 50  // seems to work in most cases
 #define MAX_IDLE_WAIT_MS 120   // better safe than sorry - similar to the timeout used by upstream WLED
-void WS2812FX::waitUntilIdle(void) {
+void WS2812FX::waitUntilIdle(unsigned timeout) {
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_PROTECT_SERVICE)
+  if (timeout < MAX_IDLE_WAIT_MS) timeout = MAX_IDLE_WAIT_MS;
   if (isServicing()) {
     unsigned long waitStarted = millis();
     do {
       delay(2);  // Suspending for 1 tick (or more) gives other tasks a chance to run.
       //yield(); // seems to be a no-op on esp32
-    } while (isServicing() && (millis() - waitStarted < MAX_IDLE_WAIT_MS));
+    } while (isServicing() && (millis() - waitStarted < timeout));
     DEBUG_PRINTF("strip.waitUntilIdle(): strip %sidle after %d ms. (task %s with prio=%d)\n", isServicing()?"not ":"", int(millis() - waitStarted), pcTaskGetTaskName(NULL), uxTaskPriorityGet(NULL));
     if (isServicing()) USER_PRINTF("strip.waitUntilIdle(): strip NOT idle after %d ms - overriding access. (task %s with prio=%d)\n", int(millis() - waitStarted), pcTaskGetTaskName(NULL), uxTaskPriorityGet(NULL));
   }
@@ -1924,6 +1934,10 @@ void WS2812FX::waitUntilIdle(void) {
 void WS2812FX::service() {
   unsigned long nowUp = millis(); // Be aware, millis() rolls over every 49 days // WLEDMM avoid losing precision
   if (OTAisRunning) return; // WLEDMM avoid flickering during OTA
+ 
+  //#ifdef ARDUINO_ARCH_ESP32
+  //if ((_isServicing == true) && (strncmp(pcTaskGetTaskName(NULL), "loopTask", 8) != 0)) return; // WLEDMM experimental: not in looptask context - avoid self-blocking (DDP over webSockets)
+  //#endif
 
   now = nowUp + timebase;
   unsigned long elapsed = nowUp - _lastServiceShow;
@@ -1980,6 +1994,9 @@ void WS2812FX::service() {
         // effect blending (execute previous effect)
         // actual code may be a bit more involved as effects have runtime data including allocated memory
         //if (seg.transitional && seg._modeP) (*_mode[seg._modeP])(progress());
+        #if defined(ARDUINO_ARCH_ESP32) // WLEDMM protect against parallel drawing
+        if (xSemaphoreTake(busDrawMux, 200) != pdTRUE) { delay(1); continue;}      // WLEDMM first acquire draw mutex
+        #endif
         frameDelay = (*_mode[seg.currentMode(seg.mode)])();
 
         if (frameDelay < speedLimit) frameDelay = FRAMETIME;                    // WLEDMM limit effects that want to go faster than target FPS
@@ -1990,6 +2007,9 @@ void WS2812FX::service() {
 
         seg.lastBri = seg.currentBri(seg.on ? seg.opacity:0);                   // WLEDMM remember for next time
         seg.handleTransition();
+        #if defined(ARDUINO_ARCH_ESP32)
+        xSemaphoreGive(busDrawMux); // WLEDMM unlock mutex
+        #endif
       }
 
       seg.next_time = nowUp + frameDelay;
@@ -2129,7 +2149,14 @@ void WS2812FX::show(void) {
   // some buses send asynchronously and this method will return before
   // all of the data has been sent.
   // See https://github.com/Makuna/NeoPixelBus/wiki/ESP32-NeoMethods#neoesp32rmt-methods
+
+  #if defined(ARDUINO_ARCH_ESP32) // WLEDMM protect against parallel access
+  if (xSemaphoreTake(busDrawMux, 200) != pdTRUE) { delay(1); return;}      // WLEDMM first acquire drawing permission (mutex), wait max 200ms
+  #endif
   busses.show();
+  #if defined(ARDUINO_ARCH_ESP32)
+  xSemaphoreGive(busDrawMux);                                              // WLEDMM return permissions
+  #endif
 
   unsigned long diff = showNow - _lastShow;
   uint16_t fpsCurr = 200;
@@ -2464,6 +2491,9 @@ void WS2812FX::makeAutoSegments(bool forceReset) {
 }
 
 void WS2812FX::fixInvalidSegments() {
+  #if defined(ARDUINO_ARCH_ESP32)          // WLEDMM protect against parallel access
+  portENTER_CRITICAL(&s_wled_strip_mux);   // this locks out all parallel tasks, including PSRAM and flash filesystem access
+  #endif
   //make sure no segment is longer than total (sanity check)
   for (size_t i = getSegmentsNum()-1; i > 0; i--) {
     if (isMatrix) {
@@ -2488,6 +2518,10 @@ void WS2812FX::fixInvalidSegments() {
   // this is always called as the last step after finalizeInit(), update covered bus types
   for (segment &seg : _segments)
     seg.refreshLightCapabilities();
+
+  #if defined(ARDUINO_ARCH_ESP32)
+  portEXIT_CRITICAL(&s_wled_strip_mux);
+  #endif
 }
 
 //true if all segments align with a bus, or if a segment covers the total length
@@ -2505,6 +2539,7 @@ bool WS2812FX::checkSegmentAlignment() {
   return true;
 }
 
+#if 0 // WLEDMM dead code
 //After this function is called, setPixelColor() will use that segment (offsets, grouping, ... will apply)
 //Note: If called in an interrupt (e.g. JSON API), original segment must be restored,
 //otherwise it can lead to a crash on ESP32 because _segment_index is modified while in use by the main thread
@@ -2516,6 +2551,7 @@ uint8_t WS2812FX::setPixelSegment(uint8_t n) {
   }
   return prevSegId;
 }
+#endif
 
 void WS2812FX::setRange(uint16_t i, uint16_t i2, uint32_t col) {
   if (i2 >= i)

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -11,7 +11,7 @@
 #include <esp_timer.h>     // WLEDMM to get esp_timer_get_time()
 #include "freertos/FreeRTOS.h"
 #include "freertos/portmacro.h"
-static portMUX_TYPE s_wled_strip_mux = portMUX_INITIALIZER_UNLOCKED; // to protect deleting Segment::_globalLeds
+WLED_create_spinlock(ledsrgb_mux); // to protect deleting Segment::_globalLeds and Segment::ledsrgb
 #endif
 
 /*
@@ -117,18 +117,19 @@ void Segment::allocLeds() {
   if ((size > 0) && (!ledsrgb || size > ledsrgbSize)) {    //softhack dont allocate zero bytes
     DEBUG_PRINTF("allocLeds (%d,%d to %d,%d), %u from %u\n", start, startY, stop, stopY, size, ledsrgb?ledsrgbSize:0);
 
+    // DONG - Valkyrie needs food, badly     [Gauntlet, 1985]
     // WLEDMM this looks a bit over-compilicated, but it makes the re-allocation step an atomic and threadsafe operation
     CRGB* oldLedsRgb = ledsrgb;
+    portENTER_CRITICAL(&ledsrgb_mux);
     ledsrgb = nullptr;
+    portEXIT_CRITICAL(&ledsrgb_mux);
+
     if (oldLedsRgb) free(oldLedsRgb);   // we need a bigger buffer, so free the old one first
     CRGB* newLedsRgb = (CRGB*)calloc(1, size);   // WLEDMM This is an OS call, so we should not wrap it in portEnterCRITICAL
-    #if defined(ARDUINO_ARCH_ESP32)
-    portENTER_CRITICAL(&s_wled_strip_mux);
-    #endif
-      ledsrgb = newLedsRgb;
-    #if defined(ARDUINO_ARCH_ESP32)
-    portEXIT_CRITICAL(&s_wled_strip_mux);
-    #endif
+
+    portENTER_CRITICAL(&ledsrgb_mux);
+    ledsrgb = newLedsRgb;
+    portEXIT_CRITICAL(&ledsrgb_mux);
 
     ledsrgbSize = ledsrgb?size:0;
     if (ledsrgb == nullptr) {
@@ -1885,18 +1886,14 @@ void WS2812FX::finalizeInit(void)
 
   //initialize leds array. TBD: realloc if nr of leds change
   if (Segment::_globalLeds) {
-    // DONG - Valkyrie is about to die
+    // DONG - Valkyrie is about to die     [Gauntlet, 1985]
     // this is a critical section that will be removed with PR #278 which removes _globalLeds
     // problem: suspendStripService provides interlocking, but there’s a window before service() observes it, 
     //          and ESP32 is dual-core. A critical section closes that window so the pointer swap is atomic across cores.
     CRGB* oldGLeds = Segment::_globalLeds;
-#if defined(ARDUINO_ARCH_ESP32)
-    portENTER_CRITICAL(&s_wled_strip_mux);
-#endif
+    portENTER_CRITICAL(&ledsrgb_mux);
     Segment::_globalLeds = nullptr;
-#if defined(ARDUINO_ARCH_ESP32)
-    portEXIT_CRITICAL(&s_wled_strip_mux);
-#endif
+    portEXIT_CRITICAL(&ledsrgb_mux);
     free(oldGLeds);
     purgeSegments(true);   // WLEDMM moved here, because it seems to improve stability.
   }

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -1,0 +1,210 @@
+var d=document;
+var loc = false, locip, locproto = "http:";
+
+function H(pg="")   { window.open("https://mm.kno.wled.ge/"+pg); }
+function GH()       { window.open("https://github.com/MoonModules/WLED-MM"); }
+function gId(c)     { return d.getElementById(c); } // getElementById
+function cE(e)      { return d.createElement(e); } // createElement
+function gEBCN(c)   { return d.getElementsByClassName(c); } // getElementsByClassName
+function gN(s)      { return d.getElementsByName(s)[0]; } // getElementsByName
+function isE(o)     { return Object.keys(o).length === 0; } // isEmpty
+function isO(i)     { return (i && typeof i === 'object' && !Array.isArray(i)); } // isObject
+function isN(n)     { return !isNaN(parseFloat(n)) && isFinite(n); } // isNumber
+// https://stackoverflow.com/questions/3885817/how-do-i-check-that-a-number-is-float-or-integer
+function isF(n)     { return n === +n && n !== (n|0); } // isFloat
+function isI(n)     { return n === +n && n === (n|0); } // isInteger
+function toggle(el) { gId(el).classList.toggle("hide"); let n = gId('No'+el); if (n) n.classList.toggle("hide"); }
+function tooltip(cont=null) {
+	d.querySelectorAll((cont?cont+" ":"")+"[title]").forEach((element)=>{
+		element.addEventListener("pointerover", ()=>{
+			// save title
+			element.setAttribute("data-title", element.getAttribute("title"));
+			const tooltip = d.createElement("span");
+			tooltip.className = "tooltip";
+			tooltip.textContent = element.getAttribute("title");
+
+			// prevent default title popup
+			element.removeAttribute("title");
+
+			let { top, left, width } = element.getBoundingClientRect();
+
+			d.body.appendChild(tooltip);
+
+			const { offsetHeight, offsetWidth } = tooltip;
+
+			const offset = element.classList.contains("sliderwrap") ? 4 : 10;
+			top -= offsetHeight + offset;
+			left += (width - offsetWidth) / 2;
+
+			tooltip.style.top = top + "px";
+			tooltip.style.left = left + "px";
+			tooltip.classList.add("visible");
+		});
+
+		element.addEventListener("pointerout", ()=>{
+			d.querySelectorAll('.tooltip').forEach((tooltip)=>{
+				tooltip.classList.remove("visible");
+				d.body.removeChild(tooltip);
+			});
+			// restore title
+			element.setAttribute("title", element.getAttribute("data-title"));
+		});
+	});
+};
+// sequential loading of external resources (JS or CSS) with retry, calls init() when done
+function loadResources(files, init) {
+	let i = 0;
+	const loadNext = () => {
+		if (i >= files.length) {
+			if (init) {
+				d.documentElement.style.visibility = 'visible'; // make page visible after all files are loaded if it was hidden (prevent ugly display)
+				d.readyState === 'complete' ? init() : window.addEventListener('load', init);
+			}
+			return;
+		}
+		const file = files[i++];
+		const isCSS = file.endsWith('.css');
+		const el = d.createElement(isCSS ? 'link' : 'script');
+		if (isCSS) {
+			el.rel = 'stylesheet';
+			el.href = file;
+			const st = d.head.querySelector('style');
+			if (st) d.head.insertBefore(el, st); // insert before any <style> to allow overrides
+			else d.head.appendChild(el);
+		} else {
+			el.src = file;
+			d.head.appendChild(el);
+		}
+		el.onload = () => {	loadNext(); };
+		el.onerror = () => {
+			i--; // load this file again
+			setTimeout(loadNext, 100);
+		};
+	};
+	loadNext();
+}
+// https://www.educative.io/edpresso/how-to-dynamically-load-a-js-file-in-javascript
+function loadJS(FILE_URL, async = true, preGetV = undefined, postGetV = undefined) {
+	let scE = d.createElement("script");
+	scE.setAttribute("src", FILE_URL);
+	scE.setAttribute("type", "text/javascript");
+	scE.setAttribute("async", async);
+	d.body.appendChild(scE);
+	// success event 
+	scE.addEventListener("load", () => {
+		//console.log("File loaded");
+		if (preGetV) preGetV();
+		GetV();
+		if (postGetV) postGetV();
+	});
+	// error event
+	scE.addEventListener("error", (ev) => {
+		console.log("Error on loading file", ev);
+		alert("Loading of configuration script failed.\nIncomplete page data!");
+	});
+}
+function getLoc() {
+	let l = window.location;
+	if (l.protocol == "file:") {
+		loc = true;
+		locip = localStorage.getItem('locIp');
+		if (!locip) {
+			locip = prompt("File Mode. Please enter WLED-MM IP!");
+			localStorage.setItem('locIp', locip);
+		}
+	} else {
+		// detect reverse proxy
+		let path = l.pathname;
+		let paths = path.slice(1,path.endsWith('/')?-1:undefined).split("/");
+		if (paths.length > 1) paths.pop(); // remove subpage (or "settings")
+		if (paths.length > 0 && paths[paths.length-1]=="settings") paths.pop(); // remove "settings"
+		if (paths.length > 1) {
+			locproto = l.protocol;
+			loc = true;
+			locip = l.hostname + (l.port ? ":" + l.port : "") + "/" + paths.join('/');
+		}
+	}
+}
+function getURL(path) { return (loc ? locproto + "//" + locip : "") + path; }
+function B()          { window.open(getURL("/settings"),"_self"); }
+var timeout;
+function showToast(text, error = false) {
+	var x = gId("toast");
+	if (!x) return;
+	x.innerHTML = text;
+	x.className = error ? "error":"show";
+	clearTimeout(timeout);
+	x.style.animation = 'none';
+	timeout = setTimeout(function(){ x.className = x.className.replace("show", ""); }, 2900);
+}
+function uploadFile(fileObj, name) {
+	var req = new XMLHttpRequest();
+	req.addEventListener('load', function(){showToast(this.responseText,this.status >= 400)});
+	req.addEventListener('error', function(e){showToast(e.stack,true);});
+	req.open("POST", "/upload");
+	var formData = new FormData();
+	formData.append("data", fileObj.files[0], name);
+	req.send(formData);
+	fileObj.value = '';
+	return false;
+}
+// connect to WebSocket, use parent WS or open new, callback function gets passed the new WS object
+function connectWs(onOpen) {
+	let ws;
+	try {	ws = top.window.ws;} catch (e) {}
+	// reuse if open
+	if (ws && ws.readyState === WebSocket.OPEN) {
+		if (onOpen) onOpen(ws);
+	} else {
+		// create new ws connection
+		getLoc(); // ensure globals are up to date
+		let url = loc ? getURL('/ws').replace("http", "ws")
+									: "ws://" + window.location.hostname + "/ws";
+		ws = new WebSocket(url);
+		ws.binaryType = "arraybuffer";
+		if (onOpen) ws.onopen = () => onOpen(ws);
+	}
+	return ws;
+}
+
+// send LED colors to ESP using WebSocket and DDP protocol (RGB)
+// ws: WebSocket object
+// start: start pixel index
+// len: number of pixels to send
+// colors: Uint8Array with RGB values (3*len bytes)
+function sendDDP(ws, start, len, colors) {
+	if (!colors || colors.length < len * 3) return false; // not enough color data
+	let maxDDPpx = 472; // must fit into one WebSocket frame of 1428 bytes, DDP header is 10+1 bytes -> 472 RGB pixels
+	//let maxDDPpx = 172; // ESP8266: must fit into one WebSocket frame of 528 bytes -> 172 RGB pixels TODO: add support for ESP8266?
+	if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+	// send in chunks of maxDDPpx
+	for (let i = 0; i < len; i += maxDDPpx) {
+		let cnt = Math.min(maxDDPpx, len - i);
+		let off = (start + i) * 3; // DDP pixel offset in bytes
+		let dLen = cnt * 3;
+		let cOff = i * 3; // offset in color buffer
+		let pkt = new Uint8Array(11 + dLen); // DDP header is 10 bytes, plus 1 byte for WLED websocket protocol indicator
+		pkt[0] = 0x02; // DDP protocol indicator for WLED websocket. Note: below DDP protocol bytes are offset by 1
+		pkt[1] = 0x40; // flags: 0x40 = no push, 0x41 = push (i.e. render), note: this is DDP protocol byte 0
+		pkt[2] = 0x00; // reserved
+		pkt[3] = 0x01; // 1 = RGB (currently only supported mode)
+		pkt[4] = 0x01; // destination id (not used but 0x01 is default output)
+		pkt[5] = (off >> 24) & 255; // DDP protocol 4-7 is offset
+		pkt[6] = (off >> 16) & 255;
+		pkt[7] = (off >> 8) & 255;
+		pkt[8] = off & 255;
+		pkt[9] = (dLen >> 8) & 255; // DDP protocol 8-9 is data length
+		pkt[10] = dLen & 255;
+		pkt.set(colors.subarray(cOff, cOff + dLen), 11);
+		if(i + cnt >= len) {
+			pkt[1] = 0x41;  //if this is last packet, set the "push" flag to render the frame
+		}
+		try {
+			ws.send(pkt.buffer);
+		} catch (e) {
+			console.error(e);
+			return false;
+		}
+	}
+	return true;
+}

--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -204,8 +204,9 @@
 				</div>
 			</div>
 			<div style="padding-bottom: 10px;">
-				<button class="btn btn-xs" type="button" onclick="window.location.href=(loc?'http://'+locip:'')+'/cpal.htm'"><i class="icons btn-icon">&#xe18a;</i></button>
-				<button class="btn btn-xs" type="button" onclick="palettesData=null;localStorage.removeItem('wledPalx');requestJson({rmcpal:true});setTimeout(loadPalettes,250,loadPalettesData);"><i class="icons btn-icon">&#xe037;</i></button>
+				<button class="btn btn-xs" title="Add custom palette" type="button" onclick="window.location.href=(loc?'http://'+locip:'')+'/cpal.htm'"><i class="icons btn-icon">&#xe18a;</i></button>
+				<button class="btn btn-xs" title="Remove last custom palette" type="button" onclick="palettesData=null;localStorage.removeItem('wledPalx');requestJson({rmcpal:true});setTimeout(loadPalettes,250,loadPalettesData);"><i class="icons btn-icon">&#xe037;</i></button>
+				<br><button class="btn btn-xs" title="PixelForge" type="button" onclick="window.location.href=(loc?'http://'+locip:'')+'/pixelforge.htm'"><i class="icons btn-icon">&#xe410;</i></button>
 			</div>
 		</div>
 	</div>

--- a/wled00/data/pixart/pixart.js
+++ b/wled00/data/pixart/pixart.js
@@ -288,7 +288,7 @@ function generateSegmentOptions(array) {
 
 // Get segments from device
 async function getSegments() {
-  cv = gurl.value;
+  const cv = gurl.value;
   if (cv.length > 0 ){
     try {
       var arr = [];

--- a/wled00/data/pixelforge/omggif.js
+++ b/wled00/data/pixelforge/omggif.js
@@ -1,0 +1,809 @@
+// (c) Dean McNamee <dean@gmail.com>, 2013.
+//
+// https://github.com/deanm/omggif
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// omggif is a JavaScript implementation of a GIF 89a encoder and decoder,
+// including animation and compression.  It does not rely on any specific
+// underlying system, so should run in the browser, Node, or Plask.
+
+"use strict";
+
+function GifWriter(buf, width, height, gopts) {
+  var p = 0;
+
+  var gopts = gopts === undefined ? { } : gopts;
+  var loop_count = gopts.loop === undefined ? null : gopts.loop;
+  var global_palette = gopts.palette === undefined ? null : gopts.palette;
+
+  if (width <= 0 || height <= 0 || width > 65535 || height > 65535)
+    throw new Error("Width/Height invalid.");
+
+  function check_palette_and_num_colors(palette) {
+    var num_colors = palette.length;
+    if (num_colors < 2 || num_colors > 256 ||  num_colors & (num_colors-1)) {
+      throw new Error(
+          "Invalid code/color length, must be power of 2 and 2 .. 256.");
+    }
+    return num_colors;
+  }
+
+  // - Header.
+  buf[p++] = 0x47; buf[p++] = 0x49; buf[p++] = 0x46;  // GIF
+  buf[p++] = 0x38; buf[p++] = 0x39; buf[p++] = 0x61;  // 89a
+
+  // Handling of Global Color Table (palette) and background index.
+  var gp_num_colors_pow2 = 0;
+  var background = 0;
+  if (global_palette !== null) {
+    var gp_num_colors = check_palette_and_num_colors(global_palette);
+    while (gp_num_colors >>= 1) ++gp_num_colors_pow2;
+    gp_num_colors = 1 << gp_num_colors_pow2;
+    --gp_num_colors_pow2;
+    if (gopts.background !== undefined) {
+      background = gopts.background;
+      if (background >= gp_num_colors)
+        throw new Error("Background index out of range.");
+      // The GIF spec states that a background index of 0 should be ignored, so
+      // this is probably a mistake and you really want to set it to another
+      // slot in the palette.  But actually in the end most browsers, etc end
+      // up ignoring this almost completely (including for dispose background).
+      if (background === 0)
+        throw new Error("Background index explicitly passed as 0.");
+    }
+  }
+
+  // - Logical Screen Descriptor.
+  // NOTE(deanm): w/h apparently ignored by implementations, but set anyway.
+  buf[p++] = width & 0xff; buf[p++] = width >> 8 & 0xff;
+  buf[p++] = height & 0xff; buf[p++] = height >> 8 & 0xff;
+  // NOTE: Indicates 0-bpp original color resolution (unused?).
+  buf[p++] = (global_palette !== null ? 0x80 : 0) |  // Global Color Table Flag.
+             gp_num_colors_pow2;  // NOTE: No sort flag (unused?).
+  buf[p++] = background;  // Background Color Index.
+  buf[p++] = 0;  // Pixel aspect ratio (unused?).
+
+  // - Global Color Table
+  if (global_palette !== null) {
+    for (var i = 0, il = global_palette.length; i < il; ++i) {
+      var rgb = global_palette[i];
+      buf[p++] = rgb >> 16 & 0xff;
+      buf[p++] = rgb >> 8 & 0xff;
+      buf[p++] = rgb & 0xff;
+    }
+  }
+
+  if (loop_count !== null) {  // Netscape block for looping.
+    if (loop_count < 0 || loop_count > 65535)
+      throw new Error("Loop count invalid.")
+    // Extension code, label, and length.
+    buf[p++] = 0x21; buf[p++] = 0xff; buf[p++] = 0x0b;
+    // NETSCAPE2.0
+    buf[p++] = 0x4e; buf[p++] = 0x45; buf[p++] = 0x54; buf[p++] = 0x53;
+    buf[p++] = 0x43; buf[p++] = 0x41; buf[p++] = 0x50; buf[p++] = 0x45;
+    buf[p++] = 0x32; buf[p++] = 0x2e; buf[p++] = 0x30;
+    // Sub-block
+    buf[p++] = 0x03; buf[p++] = 0x01;
+    buf[p++] = loop_count & 0xff; buf[p++] = loop_count >> 8 & 0xff;
+    buf[p++] = 0x00;  // Terminator.
+  }
+
+
+  var ended = false;
+
+  this.addFrame = function(x, y, w, h, indexed_pixels, opts) {
+    if (ended === true) { --p; ended = false; }  // Un-end.
+
+    opts = opts === undefined ? { } : opts;
+
+    // TODO(deanm): Bounds check x, y.  Do they need to be within the virtual
+    // canvas width/height, I imagine?
+    if (x < 0 || y < 0 || x > 65535 || y > 65535)
+      throw new Error("x/y invalid.")
+
+    if (w <= 0 || h <= 0 || w > 65535 || h > 65535)
+      throw new Error("Width/Height invalid.")
+
+    if (indexed_pixels.length < w * h)
+      throw new Error("Not enough pixels for the frame size.");
+
+    var using_local_palette = true;
+    var palette = opts.palette;
+    if (palette === undefined || palette === null) {
+      using_local_palette = false;
+      palette = global_palette;
+    }
+
+    if (palette === undefined || palette === null)
+      throw new Error("Must supply either a local or global palette.");
+
+    var num_colors = check_palette_and_num_colors(palette);
+
+    // Compute the min_code_size (power of 2), destroying num_colors.
+    var min_code_size = 0;
+    while (num_colors >>= 1) ++min_code_size;
+    num_colors = 1 << min_code_size;  // Now we can easily get it back.
+
+    var delay = opts.delay === undefined ? 0 : opts.delay;
+
+    // From the spec:
+    //     0 -   No disposal specified. The decoder is
+    //           not required to take any action.
+    //     1 -   Do not dispose. The graphic is to be left
+    //           in place.
+    //     2 -   Restore to background color. The area used by the
+    //           graphic must be restored to the background color.
+    //     3 -   Restore to previous. The decoder is required to
+    //           restore the area overwritten by the graphic with
+    //           what was there prior to rendering the graphic.
+    //  4-7 -    To be defined.
+    // NOTE(deanm): Dispose background doesn't really work, apparently most
+    // browsers ignore the background palette index and clear to transparency.
+    var disposal = opts.disposal === undefined ? 0 : opts.disposal;
+    if (disposal < 0 || disposal > 3)  // 4-7 is reserved.
+      throw new Error("Disposal out of range.");
+
+    var use_transparency = false;
+    var transparent_index = 0;
+    if (opts.transparent !== undefined && opts.transparent !== null) {
+      use_transparency = true;
+      transparent_index = opts.transparent;
+      if (transparent_index < 0 || transparent_index >= num_colors)
+        throw new Error("Transparent color index.");
+    }
+
+    if (disposal !== 0 || use_transparency || delay !== 0) {
+      // - Graphics Control Extension
+      buf[p++] = 0x21; buf[p++] = 0xf9;  // Extension / Label.
+      buf[p++] = 4;  // Byte size.
+
+      buf[p++] = disposal << 2 | (use_transparency === true ? 1 : 0);
+      buf[p++] = delay & 0xff; buf[p++] = delay >> 8 & 0xff;
+      buf[p++] = transparent_index;  // Transparent color index.
+      buf[p++] = 0;  // Block Terminator.
+    }
+
+    // - Image Descriptor
+    buf[p++] = 0x2c;  // Image Seperator.
+    buf[p++] = x & 0xff; buf[p++] = x >> 8 & 0xff;  // Left.
+    buf[p++] = y & 0xff; buf[p++] = y >> 8 & 0xff;  // Top.
+    buf[p++] = w & 0xff; buf[p++] = w >> 8 & 0xff;
+    buf[p++] = h & 0xff; buf[p++] = h >> 8 & 0xff;
+    // NOTE: No sort flag (unused?).
+    // TODO(deanm): Support interlace.
+    buf[p++] = using_local_palette === true ? (0x80 | (min_code_size-1)) : 0;
+
+    // - Local Color Table
+    if (using_local_palette === true) {
+      for (var i = 0, il = palette.length; i < il; ++i) {
+        var rgb = palette[i];
+        buf[p++] = rgb >> 16 & 0xff;
+        buf[p++] = rgb >> 8 & 0xff;
+        buf[p++] = rgb & 0xff;
+      }
+    }
+
+    p = GifWriterOutputLZWCodeStream(
+            buf, p, min_code_size < 2 ? 2 : min_code_size, indexed_pixels);
+
+    return p;
+  };
+
+  this.end = function() {
+    if (ended === false) {
+      buf[p++] = 0x3b;  // Trailer.
+      ended = true;
+    }
+    return p;
+  };
+
+  this.getOutputBuffer = function() { return buf; };
+  this.setOutputBuffer = function(v) { buf = v; };
+  this.getOutputBufferPosition = function() { return p; };
+  this.setOutputBufferPosition = function(v) { p = v; };
+}
+
+// Main compression routine, palette indexes -> LZW code stream.
+// |index_stream| must have at least one entry.
+function GifWriterOutputLZWCodeStream(buf, p, min_code_size, index_stream) {
+  buf[p++] = min_code_size;
+  var cur_subblock = p++;  // Pointing at the length field.
+
+  var clear_code = 1 << min_code_size;
+  var code_mask = clear_code - 1;
+  var eoi_code = clear_code + 1;
+  var next_code = eoi_code + 1;
+
+  var cur_code_size = min_code_size + 1;  // Number of bits per code.
+  var cur_shift = 0;
+  // We have at most 12-bit codes, so we should have to hold a max of 19
+  // bits here (and then we would write out).
+  var cur = 0;
+
+  function emit_bytes_to_buffer(bit_block_size) {
+    while (cur_shift >= bit_block_size) {
+      buf[p++] = cur & 0xff;
+      cur >>= 8; cur_shift -= 8;
+      if (p === cur_subblock + 256) {  // Finished a subblock.
+        buf[cur_subblock] = 255;
+        cur_subblock = p++;
+      }
+    }
+  }
+
+  function emit_code(c) {
+    cur |= c << cur_shift;
+    cur_shift += cur_code_size;
+    emit_bytes_to_buffer(8);
+  }
+
+  // I am not an expert on the topic, and I don't want to write a thesis.
+  // However, it is good to outline here the basic algorithm and the few data
+  // structures and optimizations here that make this implementation fast.
+  // The basic idea behind LZW is to build a table of previously seen runs
+  // addressed by a short id (herein called output code).  All data is
+  // referenced by a code, which represents one or more values from the
+  // original input stream.  All input bytes can be referenced as the same
+  // value as an output code.  So if you didn't want any compression, you
+  // could more or less just output the original bytes as codes (there are
+  // some details to this, but it is the idea).  In order to achieve
+  // compression, values greater then the input range (codes can be up to
+  // 12-bit while input only 8-bit) represent a sequence of previously seen
+  // inputs.  The decompressor is able to build the same mapping while
+  // decoding, so there is always a shared common knowledge between the
+  // encoding and decoder, which is also important for "timing" aspects like
+  // how to handle variable bit width code encoding.
+  //
+  // One obvious but very important consequence of the table system is there
+  // is always a unique id (at most 12-bits) to map the runs.  'A' might be
+  // 4, then 'AA' might be 10, 'AAA' 11, 'AAAA' 12, etc.  This relationship
+  // can be used for an effecient lookup strategy for the code mapping.  We
+  // need to know if a run has been seen before, and be able to map that run
+  // to the output code.  Since we start with known unique ids (input bytes),
+  // and then from those build more unique ids (table entries), we can
+  // continue this chain (almost like a linked list) to always have small
+  // integer values that represent the current byte chains in the encoder.
+  // This means instead of tracking the input bytes (AAAABCD) to know our
+  // current state, we can track the table entry for AAAABC (it is guaranteed
+  // to exist by the nature of the algorithm) and the next character D.
+  // Therefor the tuple of (table_entry, byte) is guaranteed to also be
+  // unique.  This allows us to create a simple lookup key for mapping input
+  // sequences to codes (table indices) without having to store or search
+  // any of the code sequences.  So if 'AAAA' has a table entry of 12, the
+  // tuple of ('AAAA', K) for any input byte K will be unique, and can be our
+  // key.  This leads to a integer value at most 20-bits, which can always
+  // fit in an SMI value and be used as a fast sparse array / object key.
+
+  // Output code for the current contents of the index buffer.
+  var ib_code = index_stream[0] & code_mask;  // Load first input index.
+  var code_table = { };  // Key'd on our 20-bit "tuple".
+
+  emit_code(clear_code);  // Spec says first code should be a clear code.
+
+  // First index already loaded, process the rest of the stream.
+  for (var i = 1, il = index_stream.length; i < il; ++i) {
+    var k = index_stream[i] & code_mask;
+    var cur_key = ib_code << 8 | k;  // (prev, k) unique tuple.
+    var cur_code = code_table[cur_key];  // buffer + k.
+
+    // Check if we have to create a new code table entry.
+    if (cur_code === undefined) {  // We don't have buffer + k.
+      // Emit index buffer (without k).
+      // This is an inline version of emit_code, because this is the core
+      // writing routine of the compressor (and V8 cannot inline emit_code
+      // because it is a closure here in a different context).  Additionally
+      // we can call emit_byte_to_buffer less often, because we can have
+      // 30-bits (from our 31-bit signed SMI), and we know our codes will only
+      // be 12-bits, so can safely have 18-bits there without overflow.
+      // emit_code(ib_code);
+      cur |= ib_code << cur_shift;
+      cur_shift += cur_code_size;
+      while (cur_shift >= 8) {
+        buf[p++] = cur & 0xff;
+        cur >>= 8; cur_shift -= 8;
+        if (p === cur_subblock + 256) {  // Finished a subblock.
+          buf[cur_subblock] = 255;
+          cur_subblock = p++;
+        }
+      }
+
+      if (next_code === 4096) {  // Table full, need a clear.
+        emit_code(clear_code);
+        next_code = eoi_code + 1;
+        cur_code_size = min_code_size + 1;
+        code_table = { };
+      } else {  // Table not full, insert a new entry.
+        // Increase our variable bit code sizes if necessary.  This is a bit
+        // tricky as it is based on "timing" between the encoding and
+        // decoder.  From the encoders perspective this should happen after
+        // we've already emitted the index buffer and are about to create the
+        // first table entry that would overflow our current code bit size.
+        if (next_code >= (1 << cur_code_size)) ++cur_code_size;
+        code_table[cur_key] = next_code++;  // Insert into code table.
+      }
+
+      ib_code = k;  // Index buffer to single input k.
+    } else {
+      ib_code = cur_code;  // Index buffer to sequence in code table.
+    }
+  }
+
+  emit_code(ib_code);  // There will still be something in the index buffer.
+  emit_code(eoi_code);  // End Of Information.
+
+  // Flush / finalize the sub-blocks stream to the buffer.
+  emit_bytes_to_buffer(1);
+
+  // Finish the sub-blocks, writing out any unfinished lengths and
+  // terminating with a sub-block of length 0.  If we have already started
+  // but not yet used a sub-block it can just become the terminator.
+  if (cur_subblock + 1 === p) {  // Started but unused.
+    buf[cur_subblock] = 0;
+  } else {  // Started and used, write length and additional terminator block.
+    buf[cur_subblock] = p - cur_subblock - 1;
+    buf[p++] = 0;
+  }
+  return p;
+}
+
+function GifReader(buf) {
+  var p = 0;
+
+  // - Header (GIF87a or GIF89a).
+  if (buf[p++] !== 0x47 ||            buf[p++] !== 0x49 || buf[p++] !== 0x46 ||
+      buf[p++] !== 0x38 || (buf[p++]+1 & 0xfd) !== 0x38 || buf[p++] !== 0x61) {
+    throw new Error("Invalid GIF 87a/89a header.");
+  }
+
+  // - Logical Screen Descriptor.
+  var width = buf[p++] | buf[p++] << 8;
+  var height = buf[p++] | buf[p++] << 8;
+  var pf0 = buf[p++];  // <Packed Fields>.
+  var global_palette_flag = pf0 >> 7;
+  var num_global_colors_pow2 = pf0 & 0x7;
+  var num_global_colors = 1 << (num_global_colors_pow2 + 1);
+  var background = buf[p++];
+  buf[p++];  // Pixel aspect ratio (unused?).
+
+  var global_palette_offset = null;
+  var global_palette_size   = null;
+
+  if (global_palette_flag) {
+    global_palette_offset = p;
+    global_palette_size = num_global_colors;
+    p += num_global_colors * 3;  // Seek past palette.
+  }
+
+  var no_eof = true;
+
+  var frames = [ ];
+
+  var delay = 0;
+  var transparent_index = null;
+  var disposal = 0;  // 0 - No disposal specified.
+  var loop_count = null;
+
+  this.width = width;
+  this.height = height;
+
+  while (no_eof && p < buf.length) {
+    switch (buf[p++]) {
+      case 0x21:  // Graphics Control Extension Block
+        switch (buf[p++]) {
+          case 0xff:  // Application specific block
+            // Try if it's a Netscape block (with animation loop counter).
+            if (buf[p   ] !== 0x0b ||  // 21 FF already read, check block size.
+                // NETSCAPE2.0
+                buf[p+1 ] == 0x4e && buf[p+2 ] == 0x45 && buf[p+3 ] == 0x54 &&
+                buf[p+4 ] == 0x53 && buf[p+5 ] == 0x43 && buf[p+6 ] == 0x41 &&
+                buf[p+7 ] == 0x50 && buf[p+8 ] == 0x45 && buf[p+9 ] == 0x32 &&
+                buf[p+10] == 0x2e && buf[p+11] == 0x30 &&
+                // Sub-block
+                buf[p+12] == 0x03 && buf[p+13] == 0x01 && buf[p+16] == 0) {
+              p += 14;
+              loop_count = buf[p++] | buf[p++] << 8;
+              p++;  // Skip terminator.
+            } else {  // We don't know what it is, just try to get past it.
+              p += 12;
+              while (true) {  // Seek through subblocks.
+                var block_size = buf[p++];
+                // Bad block size (ex: undefined from an out of bounds read).
+                if (!(block_size >= 0)) throw Error("Invalid block size");
+                if (block_size === 0) break;  // 0 size is terminator
+                p += block_size;
+              }
+            }
+            break;
+
+          case 0xf9:  // Graphics Control Extension
+            if (buf[p++] !== 0x4 || buf[p+4] !== 0)
+              throw new Error("Invalid graphics extension block.");
+            var pf1 = buf[p++];
+            delay = buf[p++] | buf[p++] << 8;
+            transparent_index = buf[p++];
+            if ((pf1 & 1) === 0) transparent_index = null;
+            disposal = pf1 >> 2 & 0x7;
+            p++;  // Skip terminator.
+            break;
+
+          case 0xfe:  // Comment Extension.
+            while (true) {  // Seek through subblocks.
+              var block_size = buf[p++];
+              // Bad block size (ex: undefined from an out of bounds read).
+              if (!(block_size >= 0)) throw Error("Invalid block size");
+              if (block_size === 0) break;  // 0 size is terminator
+              // console.log(buf.slice(p, p+block_size).toString('ascii'));
+              p += block_size;
+            }
+            break;
+
+          default:
+            throw new Error(
+                "Unknown graphic control label: 0x" + buf[p-1].toString(16));
+        }
+        break;
+
+      case 0x2c:  // Image Descriptor.
+        var x = buf[p++] | buf[p++] << 8;
+        var y = buf[p++] | buf[p++] << 8;
+        var w = buf[p++] | buf[p++] << 8;
+        var h = buf[p++] | buf[p++] << 8;
+        var pf2 = buf[p++];
+        var local_palette_flag = pf2 >> 7;
+        var interlace_flag = pf2 >> 6 & 1;
+        var num_local_colors_pow2 = pf2 & 0x7;
+        var num_local_colors = 1 << (num_local_colors_pow2 + 1);
+        var palette_offset = global_palette_offset;
+        var palette_size = global_palette_size;
+        var has_local_palette = false;
+        if (local_palette_flag) {
+          var has_local_palette = true;
+          palette_offset = p;  // Override with local palette.
+          palette_size = num_local_colors;
+          p += num_local_colors * 3;  // Seek past palette.
+        }
+
+        var data_offset = p;
+
+        p++;  // codesize
+        while (true) {
+          var block_size = buf[p++];
+          // Bad block size (ex: undefined from an out of bounds read).
+          if (!(block_size >= 0)) throw Error("Invalid block size");
+          if (block_size === 0) break;  // 0 size is terminator
+          p += block_size;
+        }
+
+        frames.push({x: x, y: y, width: w, height: h,
+                     has_local_palette: has_local_palette,
+                     palette_offset: palette_offset,
+                     palette_size: palette_size,
+                     data_offset: data_offset,
+                     data_length: p - data_offset,
+                     transparent_index: transparent_index,
+                     interlaced: !!interlace_flag,
+                     delay: delay,
+                     disposal: disposal});
+        break;
+
+      case 0x3b:  // Trailer Marker (end of file).
+        no_eof = false;
+        break;
+
+      default:
+        throw new Error("Unknown gif block: 0x" + buf[p-1].toString(16));
+        break;
+    }
+  }
+
+  this.numFrames = function() {
+    return frames.length;
+  };
+
+  this.loopCount = function() {
+    return loop_count;
+  };
+
+  this.frameInfo = function(frame_num) {
+    if (frame_num < 0 || frame_num >= frames.length)
+      throw new Error("Frame index out of range.");
+    return frames[frame_num];
+  }
+
+  this.decodeAndBlitFrameBGRA = function(frame_num, pixels) {
+    var frame = this.frameInfo(frame_num);
+    var num_pixels = frame.width * frame.height;
+    var index_stream = new Uint8Array(num_pixels);  // At most 8-bit indices.
+    GifReaderLZWOutputIndexStream(
+        buf, frame.data_offset, index_stream, num_pixels);
+    var palette_offset = frame.palette_offset;
+
+    // NOTE(deanm): It seems to be much faster to compare index to 256 than
+    // to === null.  Not sure why, but CompareStub_EQ_STRICT shows up high in
+    // the profile, not sure if it's related to using a Uint8Array.
+    var trans = frame.transparent_index;
+    if (trans === null) trans = 256;
+
+    // We are possibly just blitting to a portion of the entire frame.
+    // That is a subrect within the framerect, so the additional pixels
+    // must be skipped over after we finished a scanline.
+    var framewidth  = frame.width;
+    var framestride = width - framewidth;
+    var xleft       = framewidth;  // Number of subrect pixels left in scanline.
+
+    // Output indicies of the top left and bottom right corners of the subrect.
+    var opbeg = ((frame.y * width) + frame.x) * 4;
+    var opend = ((frame.y + frame.height) * width + frame.x) * 4;
+    var op    = opbeg;
+
+    var scanstride = framestride * 4;
+
+    // Use scanstride to skip past the rows when interlacing.  This is skipping
+    // 7 rows for the first two passes, then 3 then 1.
+    if (frame.interlaced === true) {
+      scanstride += width * 4 * 7;  // Pass 1.
+    }
+
+    var interlaceskip = 8;  // Tracking the row interval in the current pass.
+
+    for (var i = 0, il = index_stream.length; i < il; ++i) {
+      var index = index_stream[i];
+
+      if (xleft === 0) {  // Beginning of new scan line
+        op += scanstride;
+        xleft = framewidth;
+        if (op >= opend) { // Catch the wrap to switch passes when interlacing.
+          scanstride = framestride * 4 + width * 4 * (interlaceskip-1);
+          // interlaceskip / 2 * 4 is interlaceskip << 1.
+          op = opbeg + (framewidth + framestride) * (interlaceskip << 1);
+          interlaceskip >>= 1;
+        }
+      }
+
+      if (index === trans) {
+        op += 4;
+      } else {
+        var r = buf[palette_offset + index * 3];
+        var g = buf[palette_offset + index * 3 + 1];
+        var b = buf[palette_offset + index * 3 + 2];
+        pixels[op++] = b;
+        pixels[op++] = g;
+        pixels[op++] = r;
+        pixels[op++] = 255;
+      }
+      --xleft;
+    }
+  };
+
+  // I will go to copy and paste hell one day...
+  this.decodeAndBlitFrameRGBA = function(frame_num, pixels) {
+    var frame = this.frameInfo(frame_num);
+    var num_pixels = frame.width * frame.height;
+    var index_stream = new Uint8Array(num_pixels);  // At most 8-bit indices.
+    GifReaderLZWOutputIndexStream(
+        buf, frame.data_offset, index_stream, num_pixels);
+    var palette_offset = frame.palette_offset;
+
+    // NOTE(deanm): It seems to be much faster to compare index to 256 than
+    // to === null.  Not sure why, but CompareStub_EQ_STRICT shows up high in
+    // the profile, not sure if it's related to using a Uint8Array.
+    var trans = frame.transparent_index;
+    if (trans === null) trans = 256;
+
+    // We are possibly just blitting to a portion of the entire frame.
+    // That is a subrect within the framerect, so the additional pixels
+    // must be skipped over after we finished a scanline.
+    var framewidth  = frame.width;
+    var framestride = width - framewidth;
+    var xleft       = framewidth;  // Number of subrect pixels left in scanline.
+
+    // Output indicies of the top left and bottom right corners of the subrect.
+    var opbeg = ((frame.y * width) + frame.x) * 4;
+    var opend = ((frame.y + frame.height) * width + frame.x) * 4;
+    var op    = opbeg;
+
+    var scanstride = framestride * 4;
+
+    // Use scanstride to skip past the rows when interlacing.  This is skipping
+    // 7 rows for the first two passes, then 3 then 1.
+    if (frame.interlaced === true) {
+      scanstride += width * 4 * 7;  // Pass 1.
+    }
+
+    var interlaceskip = 8;  // Tracking the row interval in the current pass.
+
+    for (var i = 0, il = index_stream.length; i < il; ++i) {
+      var index = index_stream[i];
+
+      if (xleft === 0) {  // Beginning of new scan line
+        op += scanstride;
+        xleft = framewidth;
+        if (op >= opend) { // Catch the wrap to switch passes when interlacing.
+          scanstride = framestride * 4 + width * 4 * (interlaceskip-1);
+          // interlaceskip / 2 * 4 is interlaceskip << 1.
+          op = opbeg + (framewidth + framestride) * (interlaceskip << 1);
+          interlaceskip >>= 1;
+        }
+      }
+
+      if (index === trans) {
+        op += 4;
+      } else {
+        var r = buf[palette_offset + index * 3];
+        var g = buf[palette_offset + index * 3 + 1];
+        var b = buf[palette_offset + index * 3 + 2];
+        pixels[op++] = r;
+        pixels[op++] = g;
+        pixels[op++] = b;
+        pixels[op++] = 255;
+      }
+      --xleft;
+    }
+  };
+}
+
+function GifReaderLZWOutputIndexStream(code_stream, p, output, output_length) {
+  var min_code_size = code_stream[p++];
+
+  var clear_code = 1 << min_code_size;
+  var eoi_code = clear_code + 1;
+  var next_code = eoi_code + 1;
+
+  var cur_code_size = min_code_size + 1;  // Number of bits per code.
+  // NOTE: This shares the same name as the encoder, but has a different
+  // meaning here.  Here this masks each code coming from the code stream.
+  var code_mask = (1 << cur_code_size) - 1;
+  var cur_shift = 0;
+  var cur = 0;
+
+  var op = 0;  // Output pointer.
+
+  var subblock_size = code_stream[p++];
+
+  // TODO(deanm): Would using a TypedArray be any faster?  At least it would
+  // solve the fast mode / backing store uncertainty.
+  // var code_table = Array(4096);
+  var code_table = new Int32Array(4096);  // Can be signed, we only use 20 bits.
+
+  var prev_code = null;  // Track code-1.
+
+  while (true) {
+    // Read up to two bytes, making sure we always 12-bits for max sized code.
+    while (cur_shift < 16) {
+      if (subblock_size === 0) break;  // No more data to be read.
+
+      cur |= code_stream[p++] << cur_shift;
+      cur_shift += 8;
+
+      if (subblock_size === 1) {  // Never let it get to 0 to hold logic above.
+        subblock_size = code_stream[p++];  // Next subblock.
+      } else {
+        --subblock_size;
+      }
+    }
+
+    // TODO(deanm): We should never really get here, we should have received
+    // and EOI.
+    if (cur_shift < cur_code_size)
+      break;
+
+    var code = cur & code_mask;
+    cur >>= cur_code_size;
+    cur_shift -= cur_code_size;
+
+    // TODO(deanm): Maybe should check that the first code was a clear code,
+    // at least this is what you're supposed to do.  But actually our encoder
+    // now doesn't emit a clear code first anyway.
+    if (code === clear_code) {
+      // We don't actually have to clear the table.  This could be a good idea
+      // for greater error checking, but we don't really do any anyway.  We
+      // will just track it with next_code and overwrite old entries.
+
+      next_code = eoi_code + 1;
+      cur_code_size = min_code_size + 1;
+      code_mask = (1 << cur_code_size) - 1;
+
+      // Don't update prev_code ?
+      prev_code = null;
+      continue;
+    } else if (code === eoi_code) {
+      break;
+    }
+
+    // We have a similar situation as the decoder, where we want to store
+    // variable length entries (code table entries), but we want to do in a
+    // faster manner than an array of arrays.  The code below stores sort of a
+    // linked list within the code table, and then "chases" through it to
+    // construct the dictionary entries.  When a new entry is created, just the
+    // last byte is stored, and the rest (prefix) of the entry is only
+    // referenced by its table entry.  Then the code chases through the
+    // prefixes until it reaches a single byte code.  We have to chase twice,
+    // first to compute the length, and then to actually copy the data to the
+    // output (backwards, since we know the length).  The alternative would be
+    // storing something in an intermediate stack, but that doesn't make any
+    // more sense.  I implemented an approach where it also stored the length
+    // in the code table, although it's a bit tricky because you run out of
+    // bits (12 + 12 + 8), but I didn't measure much improvements (the table
+    // entries are generally not the long).  Even when I created benchmarks for
+    // very long table entries the complexity did not seem worth it.
+    // The code table stores the prefix entry in 12 bits and then the suffix
+    // byte in 8 bits, so each entry is 20 bits.
+
+    var chase_code = code < next_code ? code : prev_code;
+
+    // Chase what we will output, either {CODE} or {CODE-1}.
+    var chase_length = 0;
+    var chase = chase_code;
+    while (chase > clear_code) {
+      chase = code_table[chase] >> 8;
+      ++chase_length;
+    }
+
+    var k = chase;
+
+    var op_end = op + chase_length + (chase_code !== code ? 1 : 0);
+    if (op_end > output_length) {
+      console.log("Warning, gif stream longer than expected.");
+      return;
+    }
+
+    // Already have the first byte from the chase, might as well write it fast.
+    output[op++] = k;
+
+    op += chase_length;
+    var b = op;  // Track pointer, writing backwards.
+
+    if (chase_code !== code)  // The case of emitting {CODE-1} + k.
+      output[op++] = k;
+
+    chase = chase_code;
+    while (chase_length--) {
+      chase = code_table[chase];
+      output[--b] = chase & 0xff;  // Write backwards.
+      chase >>= 8;  // Pull down to the prefix code.
+    }
+
+    if (prev_code !== null && next_code < 4096) {
+      code_table[next_code++] = prev_code << 8 | k;
+      // TODO(deanm): Figure out this clearing vs code growth logic better.  I
+      // have an feeling that it should just happen somewhere else, for now it
+      // is awkward between when we grow past the max and then hit a clear code.
+      // For now just check if we hit the max 12-bits (then a clear code should
+      // follow, also of course encoded in 12-bits).
+      if (next_code >= code_mask+1 && cur_code_size < 12) {
+        ++cur_code_size;
+        code_mask = code_mask << 1 | 1;
+      }
+    }
+
+    prev_code = code;
+  }
+
+  if (op !== output_length) {
+    console.log("Warning, gif stream shorter than expected.");
+  }
+
+  return output;
+}
+
+
+// CommonJS.
+//try { exports.GifWriter = GifWriter; exports.GifReader = GifReader } catch(e) {}
+try { exports.GifWriter = GifWriter; } catch(e) {}

--- a/wled00/data/pixelforge/pixelforge.htm
+++ b/wled00/data/pixelforge/pixelforge.htm
@@ -1,0 +1,1181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="author" content="@dedehai" />
+<link rel="shortcut icon" href="favicon.ico">
+<link rel="stylesheet" href="style.css"> <!-- do not use @import url() for css file, it prevents minifying! -->
+<title>WLED PixelForge</title>
+<script src="omggif.js"></script> <!-- TODO: add sequential loading, also addin common.js and optimize code size (getURL() etc.) -->
+<style>
+body {
+	max-width: 800px;
+	margin: 0 auto;
+}
+/* Header styles */
+.title {
+	font-size: 32px;
+	font-weight: bold;
+	color: #fff;
+	padding-top: 20px;
+}
+h3 {
+	margin-bottom: 0;
+}
+/* shimmer text animation */
+.title .sh {
+  background: linear-gradient(90deg,
+    #7b47db 0%, #ff6b6b 20%, #feca57 40%, #48dbfb 60%, #7b47db 100%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 4s ease-in-out 5;
+  font-size: 36px;
+}
+@keyframes shimmer { 50% { background-position: 600% 0; } }
+
+/* image grid */
+.g {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+	gap: 10px;
+	margin: 20px 0;
+	padding: 0 5px;
+}
+
+/* shared border styles */
+.it, #cv, #pv, .dp, button, .btn {
+	border: 2px solid #555;
+}
+.it:hover, .dp:hover, button:hover, .btn:hover {
+	border-color: #48a;
+}
+
+/* shared transitions */
+.it, .dp {
+	transition: all 0.3s ease;
+}
+
+.it {
+	aspect-ratio: 1;
+	border-radius: 4px;
+	background-size: 100% 100%;
+	background-position: center;
+	cursor: pointer;
+	image-rendering: pixelated;
+}
+
+/* shared flex centering */
+.it.loading, .crw, .cs {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+.it.loading {
+	background: #222;
+}
+.it.loading::before {
+	content: "Loading...";
+}
+
+/* context menu */
+.cm {
+	position: fixed;
+}
+.cm button {
+	display: block;
+	width: 100%;
+	text-align: left;
+	cursor: pointer;
+	border-radius: 1px;
+	font-size: 14px;
+	margin: 0;
+}
+.cm button:hover {
+	background: #555;
+}
+.cm button.danger {
+	color: #f44;
+}
+
+/* Editor styles */
+.ed {
+	display: none;
+	margin: 20px 0;
+	padding: 20px;
+	background: #222;
+}
+.ed.active {
+	display: block;
+}
+input[type="color"] {
+	border: 0;
+}
+
+/* canvas wrap */
+.cw {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	align-items: center;
+	width: 100%;
+}
+
+/* shared canvas styles */
+#cv, #pv {
+	background: #333;
+}
+#cv {
+	cursor: crosshair;
+	max-width: 100%;
+	border-radius: 8px;
+}
+#pv {
+	image-rendering: pixelated;
+	border-radius: 4px;
+}
+
+/* toast */
+.t {
+	position: fixed;
+	top: 20px;
+	right: 20px;
+	background: #555;
+	color: #fff;
+	padding: 12px 20px;
+	border-radius: 8px;
+	font-size: 14px;
+	z-index: 888;
+	border: 2px solid #888;
+}
+
+/* drop zone */
+.dp {
+	border: 2px dashed #555;
+	border-radius: 8px;
+	padding: 40px 20px;
+	background: #222;
+	cursor: pointer;
+	margin: 20px auto;
+	max-width: 80%;
+}
+.dp:hover {
+	background: #333;
+}
+
+/* buttons */
+button, .btn {
+	border: 2px solid #333;
+}
+
+/* sliders */
+.slc {
+	text-align: center;
+	margin-bottom: 5px;
+}
+.slc label {
+	display: block;
+	margin-bottom: 5px;
+}
+.sl {
+	width: 100%;
+	max-width: 500px;
+}
+
+/* controls row */
+.crw {
+	gap: 8px;
+	flex-wrap: wrap;
+	margin: 15px 0;
+}
+
+/* tabs */
+.tabc {
+	display: none;
+}
+.tabc.active {
+	display: block;
+}
+.tb {
+	display: flex;
+	gap: 4px;
+	border-bottom: 2px solid #555;
+	margin: 20px 0 0 0;
+	padding: 0 20px;
+}
+.tb button {
+	flex: 1;
+	background: #111;
+	border: none;
+	border-radius: 8px 8px 0 0;
+	padding: 12px 24px;
+	margin: 0;
+	color: #888;
+}
+.tb button:hover {
+	background: #222;
+	color: #aaa;
+}
+.tb button.active {
+	background: #333;
+	color: #fff;
+	border-bottom: 2px solid #333;
+}
+
+/* text tool */
+.cs {
+	flex-direction: column;
+	gap: 0;
+}
+.fr {
+	display: grid;
+	grid-template-columns: 100px 1fr;
+	align-items: center;
+	text-align: left;
+	gap: 8px;
+	max-width: 500px;
+}
+.tk {
+	color: #8cf;
+	text-decoration: underline;
+	cursor: pointer;
+}
+</style>
+</head>
+<body>
+<div class="cont">
+	<div class="title">WLED<span class="sh">PixelForge</span></div>
+
+	<div class="tb">
+		<button class="active" id="tImg">Image Tool</button>
+		<button id="tTxt">Scrolling Text</button>
+		<button id="tOth">Other Tools</button>
+	</div>
+
+	<div id="iTab" class="tabc active">
+		<h3 style="margin-top:20px;">Target Segment</h3>
+		<select id="seg"></select>
+
+		<h3>Images on Device</h3>
+		<div class="g" id="gr"></div>
+
+		<h3>Upload New Image</h3>
+		<div id="drop" class="dp">
+			<p>Drop image or click to select</p>
+		</div>
+		<input type="file" id="src" accept="image/*" style="display:none">
+
+		<div class="ed" id="ed">
+			<h3 style="margin-top:0;padding-top:0;border-top:0">Crop & Adjust Image</h3>
+
+			<div class="crw">
+				<button class="sml" id="matchAspect">Match Aspect Ratio</button>
+				<button class="sml" id="matchSize">Match Size (1:1)</button>
+				<button class="sml" id="fullSize">Full Size</button>
+				<button class="sml" id="resetCrop">Reset</button>
+			</div>
+
+			<div class="cw">
+				<div style="width:100%">
+					<div class="slc">
+						<label>Zoom: </label>
+						<input type="range" id="zoom" min="0" max="100" value="0" class="sl">
+					</div>
+					<canvas id="cv" width="500" height="400"></canvas>
+				</div>
+
+				<small>Preview at target resolution</small>
+
+				<canvas id="pv"></canvas>
+
+				<div class="slc">
+					<label>Dark Pixel Cutoff</label>
+					<input type="range" id="bt" min="0" max="255" value="0" class="sl">
+					<div style="display:flex;align-items:center;justify-content:center;margin-bottom:15px">
+						<label for="bg" style="margin-right:10px">Background Color</label>
+						<input type="color" id="bg" value="#000000">
+					</div>
+				</div>
+
+				<div style="display:none" id="sz">
+					<div>
+						<label>Output size:</label>
+						<input type="number" id="w" value="16" min="1" size="5">
+						x
+						<input type="number" id="h" value="16" min="1" size="5">
+					</div>
+				</div>
+
+			</div>
+		</div>
+
+		<div class="row" style="margin-top:20px">
+			<div class="col">
+				<label for="fn">Filename</label>
+				<input type="text" id="fn" placeholder="image" maxlength="26">
+				<small>.gif will be added</small>
+			</div>
+		</div>
+		<button class="btn" id="up">Convert & Upload to WLED</button>
+	</div>
+</div>
+
+<div id="xTab" class="tabc">
+	<h3 style="margin-top:20px;">Target Segment</h3>
+	<select id="segT"></select>
+	<div id="ti">
+		<h3>Text to show</h3>
+		<div class="col" style="display:flex;gap:10px;align-items:center;justify-content:center;flex-wrap:wrap">
+			<input type="text" id="txt" placeholder="Enter text" maxlength="64"  style="margin-left:15px;flex:1;min-width:300px;">
+			<button class="btn" id="aTxt">✓</button>
+		</div>
+
+		<h3>Settings</h3>
+		<div class="cs">
+			<div class="fr">
+				Speed	<input type="range" id="sx" min="0" max="255">
+			</div>
+			<div class="fr">
+				Y Offset	<input type="range" id="ix" min="0" max="255">
+			</div>
+			<div class="fr">
+				Trail	<input type="range" id="c1" min="0" max="255">
+			</div>
+			<div class="fr">
+				Font Size	<input type="range" id="c2" min="0" max="255">
+			</div>
+			<div class="fr">
+				Rotate <input type="range" id="c3" min="0" max="31">
+			</div>
+		</div>
+
+		<div class="col" style="display:flex;gap:20px;justify-content:center;">
+			<label style="display:flex;align-items:center;gap:5px">
+				<input type="checkbox" id="o1"> Gradient
+			</label>
+			<label style="display:flex;align-items:center;gap:5px">
+				<input type="checkbox" id="o3"> Reverse
+			</label>
+		</div>
+
+		<h3>Available Tokens</h3>
+		<div style="padding:15px;">
+			<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px;text-align:left">
+				<div><a href="#" class="tk" data-t="#TIME">#TIME</a> - HH:MM AM/PM</div>
+				<div><a href="#" class="tk" data-t="#HHMM">#HHMM</a> - HH:MM</div>
+				<div><a href="#" class="tk" data-t="#DATE">#DATE</a> - DD.MM.YYYY</div>
+				<div><a href="#" class="tk" data-t="#DDMM">#DDMM</a> - Day.Month</div>
+				<div><a href="#" class="tk" data-t="#MMDD">#MMDD</a> - Month/Day</div>
+				<div><a href="#" class="tk" data-t="#YYYY">#YYYY</a> - Year</div>
+				<div><a href="#" class="tk" data-t="#YY">#YY</a> - Year 2-digit</div>
+				<div><a href="#" class="tk" data-t="#HH">#HH</a> - Hours</div>
+				<div><a href="#" class="tk" data-t="#MM">#MM</a> - Minutes</div>
+				<div><a href="#" class="tk" data-t="#SS">#SS</a> - Seconds</div>
+				<div><a href="#" class="tk" data-t="#MO">#MO</a> - Month number</div>
+				<div><a href="#" class="tk" data-t="#DD">#DD</a> - Day number</div>
+				<div><a href="#" class="tk" data-t="#MON">#MON</a> - Month (Jan)</div>
+				<div><a href="#" class="tk" data-t="#MONL">#MONL</a> - Month (January)</div>
+				<div><a href="#" class="tk" data-t="#DAY">#DAY</a> - Weekday (Mon)</div>
+				<div><a href="#" class="tk" data-t="#DDDD">#DDDD</a> - Weekday (Monday)</div>
+			</div>
+			<div style="margin:10px;padding-top:10px;border-top:1px solid #444">
+				<strong>Tips:</strong></small><br>
+				• Mix text and tokens: "It's #HHMM O'Clock" or "#HH:#MM:#SS"<br>
+				• Add '0' suffix for leading zeros: #TIME0, #HH0, etc.
+			</div>
+		</div>
+	</div>
+	<div id="ti1D" style="display:none;">Not available in 1D</div>
+</div>
+<div id="oTab" class="tabc">
+	<div class="ed active">
+		<div>
+			<h3>Pixel Paint</h3>
+			<div><small>Interactive painting tool</small></div>
+			<button class="btn" id="t1" style="display:none"></button>
+		</div>
+	</div>
+	<hr>
+	<div class="ed active">
+		<div>
+			<h3>PIXEL MAGIC Tool</h3>
+			<div><small>Legacy pixel art editor</small></div>
+			<button class="btn" id="t2" style="display:none"></button>
+		</div>
+	</div>
+	<hr>
+</div>
+
+<div style="margin:20px 0">
+	<button class="btn" onclick="window.location.href=wu">Back to the controls</button>
+</div>
+
+<div id="ov"></div>
+<div id="mem" style="display:none;font-size:12px;color:#aaa;"></div>
+
+<script>
+const d=document,gId=i=>d.getElementById(i),cE=t=>d.createElement(t);
+
+/* canvases */
+const cv=gId('cv'),cx=cv.getContext('2d',{willReadFrequently:true});
+const pv=gId('pv'),pvx=pv.getContext('2d',{willReadFrequently:true});
+
+/* globals */
+let wu='',sI=null,sF=null,cI=null,bS=1,iS=1,pX=0,pY=0;
+let cr={x:50,y:50,w:200,h:150},drag=false,dH=null,oX=0,oY=0;
+let pan=false,psX=0,psY=0,poX=0,poY=0;
+let iL=[]; // image list
+let gF=null,gI=null,aT=null;
+let fL; // file list
+
+/* init */
+(async()=>{
+	const params=new URLSearchParams(window.location.search);
+	wu=`http://${params.get('host')||window.location.host}`;
+
+	await segLoad(); // load available segments
+	await flU(); // update file list
+	toolChk('pixelpaint.htm','t1'); // update buttons of additional tools
+	toolChk('pxmagic.htm','t2');
+	await fsMem(); // show file system memory info
+})();
+
+/* update file list */
+async function flU(){
+	try{
+		const r = await fetch(`${wu}/edit?func=list`);
+		fL = await r.json();
+	}catch(e){console.error(e);}
+}
+
+/* toast */
+function msg(m,t=''){
+	const el=cE('div');el.className='t';el.textContent=m;
+	if(t==='err')el.style.background='#a00';
+	d.body.appendChild(el);setTimeout(()=>el.remove(),3000);
+}
+/* "loading" overlay */
+function ovShow(){gId('ov').classList.add('loading');gId('ov').style.display='block';}
+function ovHide(){gId('ov').classList.remove('loading');gId('ov').style.display='none';}
+
+/* segments */
+function segLoad(){
+	const s1=gId('seg'),v1=s1.value,s2=gId('segT'),v2=s2.value;
+	fetch(`${wu}/json/state`).then(r=>r.json()).then(j=>{
+		s1.innerHTML=''; s2.innerHTML='';
+		if(j.seg&&j.seg.length){
+			j.seg.forEach(({id,n,start,stop,startY,stopY,fx})=>{
+				const w=stop-start,h=(stopY-startY)||1;
+				const t = (n || `Segment ${id}`) + (h>1 ? ` (${w}x${h})` : ` (${w}px)`) + (fx===53 ? ' [Image]' : (fx===122 ? ' [Scrolling Text]' : ''));
+				const o=new Option(t,id);
+				o.dataset.w=w; o.dataset.h=h; o.dataset.fx=fx||0;
+				s1.add(o); // gif tool
+				s2.add(o.cloneNode(true)); // scrolling text tool
+			});
+		}else{
+			const o=new Option('Segment 0',0);
+			s1.add(o); s2.add(o.cloneNode(true));
+		}
+		if(v1) s1.value=v1; if(v2) s2.value=v2;
+		s2.onchange(); // trigger on load to toggle show/hide of text tool
+		const o=s1.options[s1.selectedIndex];
+		if(o){ gId('w').value=o.dataset.w||16; gId('h').value=o.dataset.h||16; }
+	}).catch(console.error);
+}
+
+/* which seg is showing image fx 53 */
+function curImgSeg(){
+	const sel=gId('seg');
+	for(let i=0;i<sel.options.length;i++){
+		if(parseInt(sel.options[i].dataset.fx)===53) return parseInt(sel.options[i].value);
+	}
+	return null;
+}
+
+/* seg change -> update target size */
+gId('seg').onchange = () =>{
+	const o=gId('seg').selectedOptions[0];
+	gId('w').value=o.dataset.w;
+	gId('h').value=o.dataset.h;
+	if(cI) crDraw();
+};
+
+gId('segT').onchange = () => {
+	const is2D = (gId('segT').selectedOptions[0].dataset.h || 1) > 1;
+	gId('ti').style.display = is2D ? 'block' : 'none';
+	gId('ti1D').style.display = is2D ? 'none' : 'block';
+};
+
+/* image list */
+async function imgLoad(){
+	try{
+		await flU(); // update file list
+		const grid=gId('gr');
+		const types=['gif','png','jpg','jpeg','bmp'];
+		const imgs=fL.filter(f=>types.includes(f.name.split('.').pop()?.toLowerCase()));
+		const newList=imgs.map(f=>f.name.replace('/',''));
+		const miss=newList.filter(n=>!iL.includes(n));
+
+		if(iL.length===0){
+			grid.innerHTML='';
+			iL=[...newList];
+			if(!imgs.length){
+				grid.innerHTML='<div style="grid-column:1/-1;text-align:center;color:#aaa;padding:20px">No images</div>';
+				return;
+			}
+			await imgLoad2(imgs);
+		}else if(miss.length>0){
+			const missData=imgs.filter(f=>miss.includes(f.name.replace('/','')));
+			iL=[...newList];
+			await imgLoad2(missData);
+		}
+	}catch(e){console.error(e);}
+}
+
+/* load images into grid TODO: when switching tabs, it can throw 503 and have unloaded images, tried to fix it but all my attempts failed*/
+async function imgLoad2(imgs){
+	const grid=gId('gr');
+	for(const f of imgs){
+		const name=f.name.replace('/',''),url=`${wu}/${name}`;
+		const isGif=name.toLowerCase().endsWith('.gif');
+		const it=cE('div');it.className='it loading';
+		it.dataset.name=name;it.dataset.url=url;
+		it.onclick=()=>{ if(isGif) imgPlay(url,name); else unsup(url,name); };
+		it.oncontextmenu=e=>{e.preventDefault();sI={name,url};menuShow(e.pageX,e.pageY);};
+		grid.appendChild(it);
+		await new Promise(res=>{
+			const im=new Image();
+			im.onload=()=>{
+				it.style.backgroundImage=`url(${url}?cb=${Date.now()})`;
+				if(!isGif) it.style.border="5px solid red";
+				it.classList.remove('loading'); res();
+				const kb=Math.round(f.size/1024);
+				it.title=`${name}\n${im.width}x${im.height}\n${kb} KB`;
+			};
+			im.onerror=()=>{it.classList.remove('loading');it.style.background='#222';res();};
+			im.src=url+'?cb='+Date.now();
+		});
+	}
+}
+
+function imgRm(nm){
+	iL=iL.filter(n=>n!==nm);
+	const grid=gId('gr');
+	grid.querySelectorAll('.it').forEach(it=>{ if(it.dataset.name===nm) it.remove(); });
+	//if(iL.length===0){
+	//	grid.innerHTML='<div style="grid-column:1/-1;text-align:center;color:#aaa;padding:20px">No images found</div>';
+	//}
+}
+
+/* additional tools: check if present, install if not */
+function toolChk(file, btnId) {
+	try {
+		const has = fL.some(f => f.name.includes(file));
+		const b = gId(btnId);
+		b.style.display = 'block';
+		b.style.margin = '10px auto';
+		if (has) {
+			b.textContent = 'Open';
+			b.onclick = () => window.open(`${wu}/${file}`, '_blank'); // open tool: remove gz to not trigger download
+		} else {
+			b.textContent = 'Download';
+			b.onclick = async () => {
+				const fileGz = file + '.gz'; // use gz version
+				const url = `https://dedehai.github.io/${fileGz}`; // always download gz version
+				if (!confirm(`Download ${url}?`)) return;
+				try {
+					const f = await fetch(url);
+					if (!f.ok) throw new Error("Download failed " + f.status);
+					const blob = await f.blob(), fd = new FormData();
+					fd.append("data", blob, fileGz);
+					const u = await fetch(wu + "/upload", { method: "POST", body: fd });
+					alert(u.ok ? "Tool installed!" : "Upload failed");
+					await flU(); // update file list
+					toolChk(file, btnId); // re-check and update button (must pass non-gz file name)
+				} catch (e) { alert("Error " + e.message); }
+			};
+		}
+	} catch (e) { console.error(e); }
+}
+
+/* fs/mem info */
+async function fsMem(){
+	try{
+		const r=await fetch(`${wu}/json/info`);
+		const info=await r.json();
+		if(info&&info.fs){
+			gId("mem").textContent=`by @dedehai | Memory: ${info.fs.u} KB / ${info.fs.t} KB`;
+			gId("mem").style.display="block";
+		}
+	}catch(e){console.error(e);}
+}
+
+/* drag-drop + file input */
+gId('drop').onclick=()=>{gId('src').value='';gId('src').click();};
+gId('drop').ondragover=e=>{e.preventDefault();gId('drop').classList.add('active');};
+gId('drop').ondragleave=()=>gId('drop').classList.remove('active');
+gId('drop').ondrop=e=>{e.preventDefault();gId('drop').classList.remove('active');gId('src').files=e.dataTransfer.files;fileHandle();};
+gId('src').onchange=fileHandle;
+
+/* file handler */
+function fileHandle() {
+	const file = gId('src').files[0];
+	if (!file) return;
+	sF = file; gI = null; gF = [];
+	gId('sz').style.display = 'block';
+
+	const isGif = file.type === 'image/gif';
+	const rdr = new FileReader();
+
+	rdr.onload = e => {
+		if (isGif) {
+			try {
+				const arr = new Uint8Array(e.target.result);
+				const gif = new GifReader(arr);
+				gI = { width: gif.width, height: gif.height, numFrames: gif.numFrames() };
+				const ac = cE('canvas'); ac.width = gif.width; ac.height = gif.height;
+				const acx = ac.getContext('2d', { willReadFrequently: true });
+				let saved = null;
+				for (let i = 0; i < gI.numFrames; i++) {
+					const fi = gif.frameInfo(i), disp = fi.disposal || 0;
+					if (disp === 3) saved = acx.getImageData(0, 0, gif.width, gif.height);
+					const tp = new Uint8Array(gif.width * gif.height * 4);
+					gif.decodeAndBlitFrameRGBA(i, tp);
+					const tc = cE('canvas'); tc.width = gif.width; tc.height = gif.height;
+					const tctx = tc.getContext('2d');
+					const tid = new ImageData(new Uint8ClampedArray(tp), gif.width, gif.height);
+					tctx.putImageData(tid, 0, 0);
+					acx.drawImage(tc, 0, 0);
+					const full = acx.getImageData(0, 0, gif.width, gif.height);
+					gF.push({ pixels: new Uint8Array(full.data), delay: fi.delay || 10 });
+					if (disp === 2) acx.clearRect(0, 0, gif.width, gif.height);
+					else if (disp === 3 && saved) acx.putImageData(saved, 0, 0);
+				}
+				const tc = cE('canvas'); tc.width = gI.width; tc.height = gI.height;
+				const tctx = tc.getContext('2d');
+				tctx.putImageData(new ImageData(new Uint8ClampedArray(gF[0].pixels), gI.width, gI.height), 0, 0);
+				imgShow(tc.toDataURL(), file.name);
+			} catch (err) {
+				msg('GIF load failed', 'err');
+				console.error(err);
+			}
+		} else {
+			// static image → treat as single-frame GIF
+			const im = new Image();
+			im.onload = () => {
+				const c = cE('canvas');
+				c.width = im.width; c.height = im.height;
+				const ctx = c.getContext('2d');
+				ctx.drawImage(im, 0, 0);
+				const id = ctx.getImageData(0, 0, im.width, im.height);
+				gF = [{ pixels: new Uint8Array(id.data), delay: 0 }];
+				gI = { width: im.width, height: im.height, numFrames: 1 };
+				imgShow(c.toDataURL(), file.name);
+			};
+			im.src = e.target.result;
+		}
+	};
+
+	isGif ? rdr.readAsArrayBuffer(file) : rdr.readAsDataURL(file);
+}
+
+/* display image on canvas */
+function imgShow(src, name) {
+	cI = new Image();
+	cI.onload = () => {
+		gId('ed').classList.add('active');
+		gId('drop').innerHTML = `<p>Image loaded: ${name}<br><small>Drop another to replace</small></p>`;
+		gId('fn').value = name.split('.')[0].substring(0, 16);
+		viewReset();
+		cr.w = cv.width * 0.8; cr.h = cv.height * 0.8;
+		cr.x = (cv.width - cr.w) / 2; cr.y = (cv.height - cr.h) / 2;
+		crClamp();
+		gifStart(); // handles both single- and multi-frame
+	};
+	cI.src = src;
+}
+
+function gifStart() {
+	if (aT) clearInterval(aT);
+	if (!gF || !gI || gF.length === 0) return crDraw();
+
+	let idx = 0;
+	const tc = cE('canvas');
+	tc.width = gI.width;
+	tc.height = gI.height;
+	const tctx = tc.getContext('2d');
+
+	const step = () => {
+		const id = new ImageData(new Uint8ClampedArray(gF[idx].pixels), gI.width, gI.height);
+		tctx.putImageData(id, 0, 0);
+		cI.src = tc.toDataURL();
+		idx = (idx + 1) % gF.length;
+	};
+
+	cI.onload = () => crDraw();
+	step();
+
+	if (gF.length > 1) {
+		const avg = gF.reduce((s, f) => s + f.delay, 0) / gF.length;
+		aT = setInterval(step, Math.max(avg * 10, 50));
+	}
+}
+function gifStop(){ if(aT){ clearInterval(aT); aT=null; } }
+
+/* formats not supported by WLED */
+function unsup(url, name) {
+	alert(`Image format not supported.\nPlease convert to GIF or use PIXEL MAGIC TOOL`);
+	fetch(url).then(r => r.blob()).then(b => {
+		const f = new File([b], name, { type: b.type });
+		const dt = new DataTransfer();
+		dt.items.add(f);
+		gId('src').files = dt.files;
+		fileHandle();
+	}).catch(() => msg('Failed to load image', 'err'));
+}
+
+/* size change -> redraw */
+gId('w').oninput=()=>{if(cI)crDraw();};
+gId('h').oninput=()=>{if(cI)crDraw();};
+
+/* crop helpers */
+function crClamp(){
+	cr.w=Math.max(30,Math.min(cr.w,cv.width));
+	cr.h=Math.max(30,Math.min(cr.h,cv.height));
+	cr.x=Math.max(0,Math.min(cr.x,cv.width-cr.w));
+	cr.y=Math.max(0,Math.min(cr.y,cv.height-cr.h));
+}
+function viewReset(){
+	bS=Math.min(cv.width/cI.width,cv.height/cI.height);
+	iS=bS;
+	pX=(cv.width-cI.width*iS)/2;
+	pY=(cv.height-cI.height*iS)/2;
+}
+
+/* zoom */
+gId('zoom').oninput=()=>{
+	if(!cI)return;
+	const t=gId('zoom').value/100,ns=bS*Math.pow(40,t);
+	const cxm=cv.width/2,cym=cv.height/2;
+	const dx=cxm-pX,dy=cym-pY,f=ns/iS;
+	pX=cxm-dx*f; pY=cym-dy*f; iS=ns;
+	crClamp(); crDraw();
+};
+
+/* color change */
+gId('bg').oninput=crDraw;
+
+/* quick controls */
+gId('matchAspect').onclick=e=>{
+	e.preventDefault();
+	const r=+gId('w').value/+gId('h').value;
+	cr.h=cr.w/r; crClamp(); crDraw();
+};
+gId('matchSize').onclick=e=>{
+	e.preventDefault();
+	if(!cI)return;
+	cr.w=+gId('w').value*iS; cr.h=+gId('h').value*iS;
+	crClamp(); crDraw();
+};
+gId('fullSize').onclick=e=>{
+	e.preventDefault();
+	if(!cI)return;
+	cr.x=0; cr.y=0; cr.w=cv.width; cr.h=cv.height;
+	crClamp(); crDraw();
+};
+gId('resetCrop').onclick=e=>{
+	e.preventDefault();
+	if(!cI)return;
+	cr.w=cv.width*0.8; cr.h=cv.height*0.8;
+	cr.x=(cv.width-cr.w)/2; cr.y=(cv.height-cr.h)/2;
+	crClamp(); crDraw();
+};
+
+/* crop handles */
+function crHandles(r){
+	const s=40,o=s/2,ox=r.x-o,oy=r.y-o,ow=r.w+s,oh=r.h+s;
+	return{
+		nw:{x:ox,y:oy,w:s,h:s}, ne:{x:ox+ow-s,y:oy,w:s,h:s},
+		sw:{x:ox,y:oy+oh-s,w:s,h:s}, se:{x:ox+ow-s,y:oy+oh-s,w:s,h:s},
+		n:{x:ox+s/2,y:oy,w:ow-s,h:s}, s:{x:ox+s/2,y:oy+oh-s,w:ow-s,h:s},
+		w:{x:ox,y:oy+s/2,w:s,h:oh-s}, e:{x:ox+ow-s,y:oy+s/2,w:s,h:oh-s}
+	};
+}
+function crHit(mx,my){
+	const h=crHandles(cr);
+	for(const k in h){let r=h[k];if(mx>=r.x&&mx<=r.x+r.w&&my>=r.y&&my<=r.y+r.h)return k;}
+	return null;
+}
+
+/* event coord */
+function posGet(e){
+	const r=cv.getBoundingClientRect();
+	const sx=cv.width/r.width,sy=cv.height/r.height;
+	if(e.touches){
+		return {x:(e.touches[0].clientX-r.left)*sx,y:(e.touches[0].clientY-r.top)*sy};
+	}else{
+		return {x:(e.clientX-r.left)*sx,y:(e.clientY-r.top)*sy};
+	}
+}
+
+/* actions */
+function actStart(mx,my){
+	dH=crHit(mx,my);
+	if(dH){drag=true;return;}
+	if(mx>cr.x&&mx<cr.x+cr.w&&my>cr.y&&my<cr.y+cr.h){
+		drag=true;dH="move";oX=mx-cr.x;oY=my-cr.y;
+	}else{
+		pan=true;psX=mx;psY=my;poX=pX;poY=pY;
+	}
+}
+function actMove(mx,my){
+	if(drag){
+		switch(dH){
+			case "move":cr.x=mx-oX;cr.y=my-oY;break;
+			case "nw":cr.w+=(cr.x-mx);cr.h+=(cr.y-my);cr.x=mx;cr.y=my;break;
+			case "ne":cr.w=mx-cr.x;cr.h+=(cr.y-my);cr.y=my;break;
+			case "sw":cr.w+=(cr.x-mx);cr.x=mx;cr.h=my-cr.y;break;
+			case "se":cr.w=mx-cr.x;cr.h=my-cr.y;break;
+			case "n":cr.h+=(cr.y-my);cr.y=my;break;
+			case "s":cr.h=my-cr.y;break;
+			case "w":cr.w+=(cr.x-mx);cr.x=mx;break;
+			case "e":cr.w=mx-cr.x;break;
+		}
+		crClamp(); crDraw();
+	}else if(pan){
+		pX=poX+(mx-psX); pY=poY+(my-psY);
+		crClamp(); crDraw();
+	}
+}
+function actEnd(){ drag=false; dH=null; pan=false; }
+
+/* mouse */
+cv.onmousedown=e=>{if(!cI)return;const {x,y}=posGet(e);actStart(x,y);};
+cv.onmousemove=e=>{if(!cI)return;const {x,y}=posGet(e);actMove(x,y);};
+cv.onmouseup=actEnd;
+
+/* touch */
+cv.ontouchstart=e=>{
+	if(!cI||e.touches.length!==1)return;
+	e.preventDefault();
+	const {x,y}=posGet(e); actStart(x,y);
+};
+cv.ontouchmove=e=>{
+	if(!cI||e.touches.length!==1)return;
+	e.preventDefault();
+	const {x,y}=posGet(e); actMove(x,y);
+};
+cv.ontouchend=e=>{e.preventDefault();actEnd();};
+cv.ontouchcancel=e=>{e.preventDefault();actEnd();};
+
+/* draw + preview */
+function crDraw(){
+	cx.clearRect(0,0,cv.width,cv.height);
+	if(!cI)return;
+	cx.fillStyle=gId('bg').value; cx.fillRect(0,0,cv.width,cv.height);
+	cx.imageSmoothingEnabled=false;
+	cx.drawImage(cI,0,0,cI.width,cI.height,pX,pY,cI.width*iS,cI.height*iS);
+	/* crop frame */
+	cx.lineWidth=3; cx.setLineDash([6,4]); cx.shadowColor="#000"; cx.shadowBlur=2;
+	cx.strokeStyle="#FFF"; cx.beginPath(); cx.roundRect(cr.x,cr.y,cr.w,cr.h,6); cx.stroke();
+	cx.shadowColor="#000F";
+	prevUpd();
+}
+
+gId('bt').addEventListener('input',()=>{prevUpd();});
+function blackTh(c){
+	let t=+gId('bt').value,
+		dt=c.getImageData(0,0,c.canvas.width,c.canvas.height),
+		b=gId('bg').value.match(/\w\w/g).map(x=>parseInt(x,16));
+	for(let i=0;i<dt.data.length;i+=4)
+		if(dt.data[i]<t&&dt.data[i+1]<t&&dt.data[i+2]<t)
+			dt.data[i]=b[0],dt.data[i+1]=b[1],dt.data[i+2]=b[2];
+	c.putImageData(dt,0,0);
+}
+
+function prevUpd(){
+	if(!cI)return;
+	let w=+gId('w').value,h=+gId('h').value;
+	// Temporary canvas at target size
+	const tc = cE('canvas'); tc.width = w; tc.height = h;
+	const tcx = tc.getContext('2d');
+	tcx.fillStyle=gId('bg').value;
+	tcx.fillRect(0,0,w,h); // fill background (for transparent images)
+	tcx.drawImage(cI,(cr.x-pX)/iS,(cr.y-pY)/iS,cr.w/iS,cr.h/iS,0,0,w,h);
+	blackTh(tcx);
+	// scale/stretch to preview canvas, limit to 256px in largest dimension but keep aspect ratio
+	const ratio = h/w;
+	if(ratio > 1) {
+		pv.height = 256;
+		pv.width = Math.max(4, Math.round(256 / ratio)); // min 4px width for better visibility
+	} else {
+		pv.width = 256;
+		pv.height = Math.max(4, Math.round(256 * ratio));
+	}
+	pvx.imageSmoothingEnabled=false;
+	pvx.drawImage(tc,0,0,w,h,0,0,pv.width,pv.height);
+}
+
+// generate gif palette using median-cut algorithm, palette is padded to power of 2 size (gif standard)
+function genPal(pix){
+	const map=new Map();
+	for(let i=0;i<pix.length;i+=4){
+		const c=(pix[i]<<16)|(pix[i+1]<<8)|pix[i+2];
+		map.set(c,(map.get(c)||0)+1);
+	}
+	let buckets=[Array.from(map,([rgb,count])=>({r:rgb>>16&255,g:rgb>>8&255,b:rgb&255,count}))];
+	while(buckets.length<256&&buckets.some(b=>b.length>1)){
+		buckets.sort((a,b)=>b.length-a.length);
+		const b=buckets.shift();
+		const ch=['r','g','b'].map(k=>({k,range:Math.max(...b.map(c=>c[k]))-Math.min(...b.map(c=>c[k]))}))
+			.reduce((a,b)=>a.range>b.range?a:b).k;
+		b.sort((a,c)=>a[ch]-c[ch]);
+		const m=b.length>>1;
+		buckets.push(b.slice(0,m),b.slice(m));
+	}
+	const pal=buckets.map(b=>{
+		const t=b.reduce((s,c)=>s+c.count,0);
+		const r=Math.round(b.reduce((s,c)=>s+c.r*c.count,0)/t);
+		const g=Math.round(b.reduce((s,c)=>s+c.g*c.count,0)/t);
+		const bl=Math.round(b.reduce((s,c)=>s+c.b*c.count,0)/t);
+		return(r<<16)|(g<<8)|bl;
+	});
+	let p2=1;
+	while(p2<pal.length)p2<<=1; // make it power of 2
+	for(let i=pal.length;i<p2;i++)pal[i]=pal[pal.length-1];
+	const idx=new Uint8Array(pix.length/4);
+	for(let i=0,j=0;i<pix.length;i+=4,j++){
+		let r=pix[i],g=pix[i+1],b=pix[i+2],best=0,min=1e9;
+		for(let k=0;k<buckets.length;k++){
+			const p=pal[k],pr=p>>16&255,pg=p>>8&255,pb=p&255;
+			const d=(r-pr)**2+(g-pg)**2+(b-pb)**2;
+			if(d<min){min=d;best=k;}
+		}
+		idx[j]=best;
+	}
+	return{indexed:idx,palette:pal};
+}
+
+// calculate optimal grid dimensions for 1D pixel data (gif is restricted to 320x320)
+function grid(length) {
+	if (length <= 320) return { w: length, h: 1 };
+	let best = [1, length], waste = length;
+	// find best matching width/height with least wasted pixels (should never be more than 1)
+	for (let w = 320; w >= 2; w--) {
+		const h = Math.ceil(length / w);
+		const wst = w * h - length;
+		if (wst < waste) {
+			best = [w, h];
+			waste = wst;
+			if (!waste) break;
+		}
+	}
+	return { w: best[0], h: best[1] };
+}
+
+/* create GIF and upload */
+gId('up').onclick = async () => {
+	if (!gF || !gI) return; // no image
+	const w = +gId('w').value, h = +gId('h').value, fn = gId('fn').value.trim() || 'image';
+	const filename = `${fn}.gif`;
+	const repl = iL.includes(filename);
+	if (repl && !confirm(`${filename} already exists. Overwrite?`)) return;
+
+	ovShow();
+	try {
+		const tc = cE('canvas'); tc.width = gI.width; tc.height = gI.height;
+		const tctx = tc.getContext('2d');
+		const cc = cE('canvas'); cc.width = w; cc.height = h;
+		const cctx = cc.getContext('2d');
+		cctx.imageSmoothingEnabled = false;
+
+		const frames = [];
+		for (let i = 0; i < gF.length; i++) {
+			const id = new ImageData(new Uint8ClampedArray(gF[i].pixels), gI.width, gI.height);
+			tctx.putImageData(id, 0, 0);
+			cctx.fillStyle = gId('bg').value;
+			cctx.fillRect(0, 0, w, h);
+			cctx.drawImage(tc, (cr.x - pX) / iS, (cr.y - pY) / iS, cr.w / iS, cr.h / iS, 0, 0, w, h);
+			blackTh(cctx);
+			const fd = cctx.getImageData(0, 0, w, h);
+			frames.push({ data: fd.data, delay: gF[i].delay });
+		}
+
+		const g = grid(w); // calculate optimal grid size: 1D image is saved as "2D gif" if w > 320 (WLED gif size limit), 2D can not be larger than 256x256 so is unchange
+		let gw = g.w, gh = Math.max(g.h, h); // gif width and height
+		const all = new Uint8Array(frames.length * gw * gh * 4);
+		// concat all frames to single array to create palette from all colors
+		frames.forEach((f, i) => {
+			const off = i * gw * gh * 4;
+			for (let j = 0; j < gw * gh; j++) {
+				const src = (j < w*h ? j : w*h-1) * 4; // pad with last pixel of source frame if out of bounds (for 1D images)
+				all[off + j*4] = f.data[src]; all[off + j*4 + 1] = f.data[src + 1]; all[off + j*4 + 2] = f.data[src + 2]; all[off + j*4 + 3] = 255;
+			}
+		});
+		const { indexed, palette } = genPal(all);
+		const gifData = [];
+		const wr = new GifWriter(gifData, gw, gh, { palette, loop: 0 });
+		for (let i = 0; i < frames.length; i++) {
+			const framePixels = indexed.slice(i * gw * gh, (i + 1) * gw * gh); // slice global array back into per-frame data
+			wr.addFrame(0, 0, gw, gh, framePixels, { delay: frames[i].delay, disposal: 2 });
+		}
+		wr.end();
+
+		const fU = new File([new Uint8Array(gifData)], filename, { type: 'image/gif' });
+		const fd = new FormData();
+		fd.append('file', fU, filename);
+		const r = await fetch(`${wu}/upload`, { method: 'POST', body: fd });
+
+		if (r.ok) {
+			msg(`${filename} uploaded`);
+			if (repl) imgRm(filename);
+			await imgLoad();
+			gId('src').value = '';
+			gId('drop').innerHTML = '<p>Drop image or click to select</p>';
+		} else msg('Upload failed', 'err');
+	} catch (e) {
+		msg(`Error: ${e.message}`, 'err');
+	} finally {
+		ovHide();
+	}
+};
+
+/* play on device */
+async function imgPlay(url,name){
+	const tgt=+gId('seg').value,cur=curImgSeg();
+	if(cur!==null && cur!==tgt){
+		if(!confirm(`Segment ${cur} is currently displaying an image. Switch image display to segment ${tgt}?`))return;
+	}
+	ovShow();
+	try{
+		const j={
+			on:true,
+			seg: cur!==null && cur!==tgt
+				? [{id:cur,fx:0,n:""},{id:tgt,fx:53,frz:false,sx:128,n:name}]
+				: {id:tgt,fx:53,frz:false,sx:128,n:name}
+		};
+		const r=await fetch(`${wu}/json/state`,{method:'POST',body:JSON.stringify(j)});
+		const out=await r.json();
+		if(out.success){
+			msg(`Playing ${name}`);
+			await segLoad();
+		}else msg('Failed to play','err');
+	}catch(e){msg(`Error: ${e.message}`,'err');}
+	finally{ovHide();}
+}
+
+/* ctx menu */
+function menuShow(x,y){
+	menuClose();
+	const m=cE('div');
+	m.className='cm';
+	m.style.left=x+'px'; m.style.top=y+'px';
+	m.innerHTML=`
+		<button onclick="imgDl()">Download</button>
+		<button class="danger" onclick="imgDel()">Delete</button>`;
+	d.body.appendChild(m);
+	setTimeout(()=>{
+		const h=e=>{
+			if(!e.target.closest('.cm')){menuClose();d.removeEventListener('click',h);}
+		};
+		d.addEventListener('click',h);
+	},100);
+}
+function menuClose(){d.querySelectorAll('.cm').forEach(m=>m.remove());}
+
+async function imgDl(){
+	try{
+		const r=await fetch(sI.url),b=await r.blob();
+		const u=URL.createObjectURL(b),a=cE('a');
+		a.href=u;a.download=sI.name;a.click();
+		URL.revokeObjectURL(u); msg('Downloaded');
+	}catch(e){msg('Download failed','err');}
+	menuClose();
+}
+async function imgDel(){
+	if(!confirm(`Delete ${sI.name}?`))return;
+	ovShow();
+	try{
+		const r = await fetch(`${wu}/edit?func=delete&path=/${sI.name}`);
+		if(r.ok){ msg('Deleted'); imgRm(sI.name); }
+		else msg('Delete failed! File in use?','err');
+	}catch(e){msg('Delete failed','err');}
+	finally{ovHide();}
+	menuClose();
+}
+
+/* tab select and additional tools */
+function tabSw(tab) {
+	'iTab,xTab,oTab,tImg,tTxt,tOth'.split(',').forEach((id,i)=>{
+		gId(id).classList.toggle('active', tab===['img','txt','oth'][i%3]);
+	});
+	localStorage.tab=tab;
+	({txt:txtSegLoad,img:imgLoad}[tab]||(()=>{}))(); // functions to execute on tab switch (currently none for oth)
+}
+'Img,Txt,Oth'.split(',').forEach((s,i)=>{
+	gId('t'+s).onclick=()=>tabSw(['img','txt','oth'][i]);
+});
+tabSw(localStorage.tab||'img');
+
+/* tokens insert */
+function txtIns(el,t){
+	const s=el.selectionStart??el.value.length,e=el.selectionEnd??el.value.length,v=el.value;
+	const nv=(v.slice(0,s)+t+v.slice(e)).slice(0,64);
+	const p=Math.min(s+t.length,nv.length);
+	el.value=nv;el.focus();el.selectionStart=el.selectionEnd=p;
+}
+document.addEventListener('click',e=>{
+	const a=e.target.closest('.tk'); if(!a) return;
+	e.preventDefault(); txtIns(gId('txt'),a.dataset.t);
+	// txtUp();
+});
+
+/* load seg settings into text UI */
+async function txtSegLoad(){
+	const id=+gId('segT').value;
+	try{
+
+		const r=await fetch(`${wu}/json/state`),j=await r.json();
+		if(j.seg&&j.seg[id]){
+			const s=j.seg[id];
+			gId('txt').value=s.n||'';
+			gId('sx').value=s.sx||128;
+			gId('ix').value=s.ix||128;
+			gId('c1').value=s.c1||0;
+			gId('c2').value=s.c2||0;
+			gId('c3').value=s.c3||0;
+			gId('o1').checked=!(!s.o1);
+			gId('o3').checked=!(!s.o3);
+		}
+	}catch(e){console.error(e);}
+}
+
+/* auto apply on change */
+['sx','ix','c1','c2','c3','o1','o3'].forEach(id=>{ gId(id).onchange=txtUp; });
+
+/* send text settings */
+function txtUp(){
+	const id=+gId('segT').value,txt=gId('txt').value.trim().slice(0,64);
+	const j={on:true,seg:{id,fx:122,n:txt,sx:+gId('sx').value,ix:+gId('ix').value,c1:+gId('c1').value,c2:+gId('c2').value,c3:+gId('c3').value,o1:gId('o1').checked,o3:gId('o3').checked}};
+	fetch(`${wu}/json/state`,{method:'POST',body:JSON.stringify(j)})
+		.then(r => { if(r.ok) segLoad(); })
+		.catch(console.error);
+}
+
+/* apply button */
+gId('aTxt').onclick=async()=>{
+	const id=+gId('segT').value,txt=gId('txt').value.trim();
+	ovShow();
+	try{
+		const j={on:true,seg:{id,fx:122,n:txt,sx:+gId('sx').value,ix:+gId('ix').value,c1:+gId('c1').value,c2:+gId('c2').value,c3:+gId('c3').value,o1:gId('o1').checked,o3:gId('o3').checked}};
+		const r=await fetch(`${wu}/json/state`,{method:'POST',body:JSON.stringify(j)});
+		const out=await r.json();
+		if(out.success!==false){ msg(`Applied to Segment ${id}`); await segLoad(); }
+		else msg('Failed to apply','err');
+	}catch(e){ msg(`Error: ${e.message}`,'err'); }
+	finally{ ovHide(); }
+};
+</script>
+</body>
+</html>

--- a/wled00/data/pixelforge/pixelforge.htm
+++ b/wled00/data/pixelforge/pixelforge.htm
@@ -402,9 +402,17 @@ button, .btn {
 	<hr>
 	<div class="ed active">
 		<div>
+			<h3>Video Lab</h3>
+			<div><small>Stream video and generate animated GIFs (beta)</small></div>
+			<button class="btn" id="t2" style="display:none"></button>
+		</div>
+	</div>
+	<hr>
+	<div class="ed active">
+		<div>
 			<h3>PIXEL MAGIC Tool</h3>
 			<div><small>Legacy pixel art editor</small></div>
-			<button class="btn" id="t2" style="display:none"></button>
+			<button class="btn" id="t3" style="display:none"></button>
 		</div>
 	</div>
 	<hr>
@@ -442,7 +450,8 @@ let fL; // file list
 	await segLoad(); // load available segments
 	await flU(); // update file list
 	toolChk('pixelpaint.htm','t1'); // update buttons of additional tools
-	toolChk('pxmagic.htm','t2');
+	toolChk('videolab.htm','t2');
+	toolChk('pxmagic.htm','t3');
 	await fsMem(); // show file system memory info
 })();
 

--- a/wled00/data/pixelforge/pixelforge.htm
+++ b/wled00/data/pixelforge/pixelforge.htm
@@ -419,6 +419,8 @@ button, .btn {
 
 <script>
 const d=document,gId=i=>d.getElementById(i),cE=t=>d.createElement(t);
+const imgageFX = 53; // image effect number
+const txtFX = 122;   // scrolling text effect number
 
 /* canvases */
 const cv=gId('cv'),cx=cv.getContext('2d',{willReadFrequently:true});
@@ -471,7 +473,7 @@ function segLoad(){
 		if(j.seg&&j.seg.length){
 			j.seg.forEach(({id,n,start,stop,startY,stopY,fx})=>{
 				const w=stop-start,h=(stopY-startY)||1;
-				const t = (n || `Segment ${id}`) + (h>1 ? ` (${w}x${h})` : ` (${w}px)`) + (fx===53 ? ' [Image]' : (fx===122 ? ' [Scrolling Text]' : ''));
+				const t = (n || `Segment ${id}`) + (h>1 ? ` (${w}x${h})` : ` (${w}px)`) + (fx===imgageFX ? ' [Image]' : (fx===txtFX ? ' [Scrolling Text]' : ''));
 				const o=new Option(t,id);
 				o.dataset.w=w; o.dataset.h=h; o.dataset.fx=fx||0;
 				s1.add(o); // gif tool
@@ -492,7 +494,7 @@ function segLoad(){
 function curImgSeg(){
 	const sel=gId('seg');
 	for(let i=0;i<sel.options.length;i++){
-		if(parseInt(sel.options[i].dataset.fx)===53) return parseInt(sel.options[i].value);
+		if(parseInt(sel.options[i].dataset.fx)===imgageFX) return parseInt(sel.options[i].value);
 	}
 	return null;
 }

--- a/wled00/data/pixelforge/pixelforge.htm
+++ b/wled00/data/pixelforge/pixelforge.htm
@@ -321,6 +321,7 @@ button, .btn {
 	</div>
 </div>
 
+<!-- WLED-MM not yet supported -->
 <div id="xTab" class="tabc">
 	<h3 style="margin-top:20px;">Target Segment</h3>
 	<select id="segT"></select>
@@ -388,6 +389,8 @@ button, .btn {
 	</div>
 	<div id="ti1D" style="display:none;">Not available in 1D</div>
 </div>
+<!-- WLEDMM end -->
+
 <div id="oTab" class="tabc">
 	<div class="ed active">
 		<div>
@@ -444,7 +447,8 @@ let fL; // file list
 /* update file list */
 async function flU(){
 	try{
-		const r = await fetch(`${wu}/edit?func=list`);
+		//const r = await fetch(`${wu}/edit?func=list`);
+		const r = await fetch(`${wu}/edit?list=/`);
 		fL = await r.json();
 	}catch(e){console.error(e);}
 }
@@ -1097,7 +1101,10 @@ async function imgDel(){
 	if(!confirm(`Delete ${sI.name}?`))return;
 	ovShow();
 	try{
-		const r = await fetch(`${wu}/edit?func=delete&path=/${sI.name}`);
+		//const r = await fetch(`${wu}/edit?func=delete&path=/${sI.name}`);
+		const fd = new FormData();
+		fd.append('path', `/${sI.name}`);
+		const r = await fetch(`${wu}/edit`, {method:'DELETE', body: fd});
 		if(r.ok){ msg('Deleted'); imgRm(sI.name); }
 		else msg('Delete failed! File in use?','err');
 	}catch(e){msg('Delete failed','err');}

--- a/wled00/data/pixelforge/pixelforge.htm
+++ b/wled00/data/pixelforge/pixelforge.htm
@@ -381,8 +381,8 @@ button, .btn {
 				<div><a href="#" class="tk" data-t="#DDDD">#DDDD</a> - Weekday (Monday)</div>
 			</div>
 			<div style="margin:10px;padding-top:10px;border-top:1px solid #444">
-				<strong>Tips:</strong></small><br>
-				• Mix text and tokens: "It's #HHMM O'Clock" or "#HH:#MM:#SS"<br>
+				<strong>Tips:</strong><br>
+				• Mix text and tokens: "It's #HHMM O'clock" or "#HH:#MM:#SS"<br>
 				• Add '0' suffix for leading zeros: #TIME0, #HH0, etc.
 			</div>
 		</div>

--- a/wled00/data/pxmagic/pxmagic.htm
+++ b/wled00/data/pxmagic/pxmagic.htm
@@ -1,0 +1,1980 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="author" content="@ajotanc" />
+
+    <title>Pixel Magic Tool</title>
+
+    <style>
+      :root {
+        --s-thumb: #0006;
+        --s-background: #0003;
+        --overlay: rgba(0, 0, 0, 0.5);
+        --background: #111;
+        --text: #bbb;
+        --gray-dark: #222;
+        --gray-medium: #333;
+        --gray-light: #eeeeee;
+        --blue-dark: #284352;
+        --blue-medium: #3b708b;
+        --blue-light: #48a;
+        --success-dark: #03440c;
+        --success-medium: #548c2f;
+        --success-light: #8ac926;
+        --error-dark: #a80a0a;
+        --error-medium: #c9262b;
+        --error-light: #ff595e;
+        --warning-dark: #dc2f02;
+        --warning-medium: #e85d04;
+        --warning-light: #f48c06;
+      }
+
+      ::-webkit-scrollbar {
+        width: 6px;
+      }
+
+      ::-webkit-scrollbar-track {
+        background: transparent;
+      }
+
+      ::-webkit-scrollbar-thumb {
+        background: var(--s-thumb);
+        opacity: 0.2;
+        border-radius: 5px;
+      }
+
+      ::-webkit-scrollbar-thumb:hover {
+        background: var(--s-background);
+      }
+
+      ::selection {
+        background: var(--blue-light);
+      }
+
+      * {
+        font-family: "Helvetica", Verdana, sans-serif;
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        margin: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        background: var(--background);
+      }
+
+      canvas {
+        width: 100%;
+      }
+
+      small {
+        display: block;
+        font-weight: 400;
+        margin: 2px 0 5px;
+        color: var(--gray-light);
+        font-size: 0.75rem;
+      }
+
+      footer {
+        display: flex;
+        justify-content: center;
+        margin-block: 20px;
+      }
+
+      a {
+        text-decoration: none;
+        color: var(--blue-light);
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+
+      a:is(:hover, :focus, :active) {
+        color: var(--blue-medium);
+      }
+
+      #wledEdit {
+        padding: 1.5px 8px;
+        background: var(--blue-light);
+        margin-left: 6px;
+        border-radius: 4px;
+        color: var(--gray-light);
+      }
+
+      .container {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+      }
+
+      .content {
+        width: min(768px, calc(100% - 40px));
+        margin-inline: 20px;
+      }
+
+      .row {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: space-between;
+        margin-top: 20px;
+      }
+
+      .col {
+        flex-basis: calc(50% - 10px);
+        position: relative;
+        padding-inline: 5px;
+      }
+
+      .col-full {
+        flex-basis: 100%;
+        position: relative;
+        padding-inline: 5px;
+      }
+
+      .col-small {
+        flex-basis: 33.3333%;
+        position: relative;
+        padding-inline: 5px;
+      }
+
+      .header {
+        display: flex;
+        flex-direction: column;
+        padding-block: 20px;
+      }
+
+      .header .title {
+        font-size: 2.5rem;
+        line-height: 2.5rem;
+        font-weight: 800;
+        color: var(--gray-light);
+        padding-bottom: 5px;
+      }
+
+      .header .subtitle {
+        font-size: 0.75rem;
+        color: var(--text);
+      }
+
+      .header .rainbow {
+        background: linear-gradient(
+          to right,
+          #ef5350,
+          #f48fb1,
+          #7e57c2,
+          #2196f3,
+          #26c6da,
+          #43a047,
+          #eeff41,
+          #f9a825,
+          #ff5722
+        );
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-size: 200% 200%;
+        animation: rainbow 5s linear infinite;
+        transition: background-position 0.5s ease;
+      }
+
+      label {
+        display: flex;
+        margin-bottom: 5px;
+        font-weight: bold;
+        color: var(--text);
+        align-items: center;
+      }
+
+      input[type="text"],
+      input[type="number"],
+      select,
+      textarea {
+        width: 100%;
+        padding: 10px;
+        border-radius: 50px;
+        background-color: var(--gray-medium);
+        border: 1px solid var(--gray-medium);
+        outline: none;
+        color: var(--gray-light);
+        font-size: 0.875rem;
+      }
+
+      .input-group {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .input-group input:not([type="range"]) {
+        border-radius: 50px 0 0 50px;
+      }
+
+      .input-group .input-description {
+        width: 100%;
+        max-width: 38px;
+        height: 38px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: var(--gray-dark);
+        background: var(--gray-light);
+        border-radius: 0px 50px 50px 0;
+        border: 1px solid var(--gray-light);
+        border-left: 0;
+        font-size: 0.875rem;
+        line-height: 1rem;
+      }
+
+      .input-group .square {
+        border-radius: 50px !important;
+        margin-left: 10px;
+      }
+
+      .input-group .square input {
+        text-align: center;
+        background: none;
+        padding: 0;
+        border: 0;
+        color: var(--gray-dark);
+      }
+
+      textarea {
+        resize: none;
+        border-radius: 8px;
+      }
+
+      .custom-select select {
+        appearance: none;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        background-image: none;
+        padding-right: 39px;
+        cursor: pointer;
+      }
+
+      .custom-select label::after {
+        content: "";
+        position: absolute;
+        top: calc(50% + 6px);
+        right: 21px;
+        transform: rotate(135deg);
+        width: 6px;
+        height: 6px;
+        border-top: 2px solid var(--gray-light);
+        border-right: 2px solid var(--gray-light);
+        pointer-events: none;
+      }
+
+      .dropzone {
+        width: 100%;
+        border: 1px dashed var(--gray-light);
+        background-color: var(--gray-dark);
+        color: var(--gray-light);
+        text-align: center;
+        padding: 40px 10px;
+        border-radius: 8px;
+        margin-top: 20px;
+        transition: all 0.5s ease-in-out;
+      }
+
+      .dropzone:hover {
+        cursor: pointer;
+        color: var(--gray-dark);
+        background-color: var(--gray-light);
+        border-color: var(--gray-dark);
+      }
+
+      .dropzone.dragover {
+        background-color: var(--gray-medium);
+      }
+
+      .range-slider {
+        appearance: none;
+        background-color: var(--gray-light);
+        height: 8px;
+        width: 100%;
+        border-radius: 10px;
+        outline: none;
+        margin-block: 15px;
+      }
+
+      .range-slider::-webkit-slider-thumb,
+      .range-slider::-moz-range-thumb {
+        appearance: none;
+        height: 16px;
+        width: 16px;
+        background-color: var(--blue-light);
+        border-radius: 50%;
+        cursor: pointer;
+        border: 0;
+      }
+
+      .switch {
+        position: relative;
+        display: inline-block;
+        width: 38px;
+        height: 20px;
+      }
+
+      .switch input {
+        outline: none;
+        display: none;
+      }
+
+      .switch-slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--gray-medium);
+        border-radius: 34px;
+        transition: 0.4s;
+      }
+
+      .switch-slider:before {
+        position: absolute;
+        content: "";
+        height: 14px;
+        width: 14px;
+        left: 3px;
+        bottom: 3px;
+        background-color: white;
+        border-radius: 50%;
+        transition: 0.4s;
+      }
+
+      input:checked + .switch-slider {
+        background-color: var(--blue-light);
+      }
+
+      input:focus + .switch-slider {
+        box-shadow: 0 0 1px var(--blue-light);
+      }
+
+      input:checked + .switch-slider:before {
+        transform: translateX(18px);
+      }
+
+      #toast-container {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        z-index: 9999;
+      }
+
+      .toast {
+        display: flex;
+        align-items: center;
+        width: auto;
+        padding: 6px 12px;
+        margin-top: 10px;
+        border-radius: 8px;
+        transform: translateY(30px);
+        opacity: 0;
+        visibility: hidden;
+      }
+
+      .toast .toast-body {
+        padding-block: 8px;
+        font-weight: 600;
+        color: var(--text);
+        letter-spacing: 0.5px;
+      }
+
+      .toast.success {
+        background-color: var(--success-medium);
+      }
+
+      .toast.error {
+        background-color: var(--error-light);
+      }
+
+      .toast.warning {
+        background-color: var(--warning-light);
+      }
+
+      .toast-progress {
+        position: absolute;
+        left: 4px;
+        bottom: 4px;
+        width: calc(100% - 8px);
+        height: 3px;
+        transform: scaleX(0);
+        transform-origin: left;
+        border-radius: 8px;
+      }
+
+      .toast.success .toast-progress {
+        background: linear-gradient(
+          to right,
+          var(--success-light),
+          var(--success-medium)
+        );
+      }
+
+      .toast.error .toast-progress {
+        background: linear-gradient(
+          to right,
+          var(--error-light),
+          var(--error-medium)
+        );
+      }
+
+      .toast.warning .toast-progress {
+        background: linear-gradient(
+          to right,
+          var(--warning-light),
+          var(--warning-medium)
+        );
+      }
+
+      .carousel {
+        display: flex;
+        height: 100%;
+        width: 100%;
+        cursor: pointer;
+      }
+
+      .button {
+        width: 100%;
+        border: 0;
+        padding: 10px 18px;
+        border-radius: 50px;
+        color: var(--text);
+        cursor: pointer;
+        margin-bottom: 10px;
+        background: var(--gray-medium);
+        border: 1px solid var(--gray-dark);
+        transition: all 0.5s ease-in-out;
+        font-size: 0.875rem;
+        font-weight: 600;
+      }
+
+      .button:hover {
+        background: var(--gray-dark);
+        border: 1px solid var(--gray-medium);
+      }
+
+      .button:last-child {
+        margin-bottom: 0;
+      }
+
+      .buttons {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+      }
+
+      #overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: var(--overlay);
+        display: none;
+      }
+
+      #overlay.loading::after {
+        content: "";
+        display: block;
+        position: absolute;
+        top: calc(50% - 19px);
+        left: calc(50% - 19px);
+        width: 26px;
+        height: 26px;
+        border: 6px solid var(--gray-light);
+        border-top-color: var(--gray-dark);
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+
+      #recreatedImage {
+        margin-block: 20px;
+      }
+
+      .invalid {
+        border: 1px solid var(--error-dark) !important;
+      }
+
+      .error-message {
+        display: block;
+        color: var(--error-dark);
+        padding-block: 4px;
+        font-weight: 600;
+        font-size: 0.75rem;
+      }
+
+      @media (max-width: 767px) {
+        .row {
+          flex-wrap: wrap;
+          flex-direction: column;
+          margin: 0;
+        }
+
+        .col,
+        .col-full,
+        .col-small {
+          flex-basis: 100%;
+          margin-top: 20px;
+          padding: 0;
+        }
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @keyframes progress {
+        to {
+          transform: scaleX(1);
+        }
+      }
+
+      @keyframes fadeIn {
+        5% {
+          opacity: 1;
+          visibility: visible;
+          transform: translateY(0);
+        }
+
+        95% {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      @keyframes rainbow {
+        0% {
+          background-position: 0% 0;
+        }
+        100% {
+          background-position: 200% 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="content">
+        <form id="formGenerate" novalidate>
+          <div class="header">
+            <span class="title"
+              >PIXEL <span class="rainbow">MAGIC</span> TOOL</span
+            >
+            <span class="subtitle"
+              >It is a tool that converts any image into code in
+              <strong>JSON WLED</strong> format for
+              <strong>2D Matrix</strong> panels</span
+            >
+          </div>
+          <div class="row">
+            <div class="col" validate>
+              <label for="hostname">Hostname</label>
+              <input type="text" name="hostname" id="hostname" required />
+            </div>
+            <div class="col" validate>
+              <label for="name">Preset Name</label>
+              <input
+                type="text"
+                name="name"
+                id="name"
+                value="New Preset"
+                required />
+            </div>
+          </div>
+          <div class="row">
+            <div class="col" validate>
+              <div class="custom-select">
+                <label for="pattern">Pattern</label>
+                <select name="pattern" id="pattern" required>
+                  <option value="1" title="['ffffff']">Individual</option>
+                  <option value="2" title="[0, 'ffffff']">Index</option>
+                  <option value="3" title="[0, 5, 'ffffff']" selected>
+                    Range
+                  </option>
+                </select>
+              </div>
+            </div>
+            <div class="col" validate>
+              <div class="custom-select">
+                <label for="output">Output</label>
+                <select name="output" id="output" required>
+                  <option value="json" selected>WLED JSON</option>
+                  <option value="ha">Home Assistant</option>
+                  <option value="curl">CURL</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="row output" style="display: none">
+            <div class="col" validate>
+              <label for="device">Device</label>
+              <input type="text" name="device" id="device" required />
+            </div>
+            <div class="col" validate>
+              <label for="uniqueId">Unique Id</label>
+              <input type="text" name="uniqueId" id="uniqueId" required />
+            </div>
+            <div class="col" validate>
+              <label for="friendlyName">Friendly Name</label>
+              <input
+                type="text"
+                name="friendlyName"
+                id="friendlyName"
+                required />
+            </div>
+          </div>
+          <div class="row">
+            <div class="col" validate>
+              <div class="custom-select">
+                <label for="segments">Segment Id</label>
+                <select name="segments" id="segments">
+                  <option value="0" data-width="16" data-height="16">
+                    Segment 0
+                  </option>
+                </select>
+              </div>
+            </div>
+            <div class="col" validate>
+              <label for="brightness">Brightness</label>
+              <div class="input-group">
+                <input
+                  type="range"
+                  name="brightness"
+                  id="brightness"
+                  min="0"
+                  max="255"
+                  value="128"
+                  class="range-slider" />
+                <div class="input-description square">
+                  <input
+                    type="text"
+                    name="brightnessValue"
+                    id="brightnessValue"
+                    value="128" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col" validate>
+              <label for="animation">Animation</label>
+              <label class="switch">
+                <input
+                  type="checkbox"
+                  name="animation"
+                  id="animation"
+                  data-parent="animation" />
+                <span class="switch-slider"></span>
+              </label>
+            </div>
+            <div class="col" validate>
+              <label for="transparentImage">Transparent Image</label>
+              <label class="switch">
+                <input
+                  type="checkbox"
+                  name="transparentImage"
+                  id="transparentImage"
+                  data-parent="transparentImage" />
+                <span class="switch-slider"></span>
+              </label>
+            </div>
+            <div class="col" validate>
+              <label for="resizeImage">Resize Image</label>
+              <label class="switch">
+                <input
+                  type="checkbox"
+                  name="resizeImage"
+                  id="resizeImage"
+                  data-parent="resizeImage"
+                  checked />
+                <span class="switch-slider"></span>
+              </label>
+            </div>
+          </div>
+          <div class="row resizeImage">
+            <div class="col" validate>
+              <label for="width">Width</label>
+              <input type="number" name="width" id="width" value="16" />
+            </div>
+            <div class="col" validate>
+              <label for="height">Height</label>
+              <input type="number" name="height" id="height" value="16" />
+            </div>
+          </div>
+          <div class="row animation" style="display: none">
+            <div class="col" validate>
+              <label for="frames">Frames</label>
+              <input type="number" name="frames" id="frames" value="4" />
+            </div>
+            <div class="col" validate>
+              <label for="duration">Duration</label>
+              <div class="input-group">
+                <input
+                  type="number"
+                  name="duration"
+                  id="duration"
+                  value="0.5"
+                  required="required"
+                  min="0"
+                  step="0.1"
+                  inputmode="numeric" />
+                <div class="input-description">
+                  <span>sec</span>
+                </div>
+              </div>
+            </div>
+            <div class="col" validate>
+              <label for="transition">Transition</label>
+              <div class="input-group">
+                <input
+                  type="number"
+                  name="transition"
+                  id="transition"
+                  value="0.2"
+                  required="required"
+                  min="0"
+                  step="0.1"
+                  inputmode="numeric" />
+                <div class="input-description">
+                  <span>sec</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row transparentImage" style="display: none">
+            <div class="col-full" validate>
+              <label for="color">Choose a color</label>
+              <small>
+                Color that will replace the
+                <strong>transparent pixels</strong> in the image
+              </small>
+              <input type="color" name="color" id="color" value="#00BFFF" />
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-full" validate>
+              <div class="custom-select">
+                <label for="images">
+                  <span>Images upload to WLED</span>
+                  <a id="wledEdit" href="http://[wled-ip]/edit" target="_blank">
+                    upload
+                  </a>
+                </label>
+                <select name="images" id="images">
+                  <option value="">Select image</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div id="dropzone" class="dropzone" validate>
+            <p id="dropzoneLabel">
+              Drag and drop a file here or click to select a local file
+            </p>
+            <input
+              type="file"
+              name="source"
+              id="source"
+              accept="image/*"
+              style="display: none" />
+          </div>
+          <div class="row">
+            <div class="col-full">
+              <button type="button" class="button" id="btnGenerate">
+                Generate
+              </button>
+            </div>
+            <div class="col-small" id="gbth" style="display: none">
+              <button
+                type="button"
+                class="button"
+                onclick="window.location.href = WLED_URL;">
+                Back
+              </button>
+            </div>
+          </div>
+        </form>
+        <div id="preview" style="display: none">
+          <div id="recreatedImage"></div>
+          <textarea name="response" id="response" rows="8" readonly="readonly">
+          </textarea>
+          <div class="buttons">
+            <div class="row">
+              <div class="col">
+                <button type="button" class="button" id="btnCopyToClipboard">
+                  Copy to Clipboard
+                </button>
+              </div>
+              <div class="col">
+                <button type="button" class="button" id="btnSave">Save</button>
+              </div>
+              <div class="col">
+                <button type="button" class="button" id="btnDownloadPreset">
+                  Download
+                </button>
+              </div>
+            </div>
+            <div class="row" id="simulate" style="display: none">
+              <div class="col-full">
+                <button type="button" class="button" id="btnSimulatePreset">
+                  Simulate
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <footer>
+        <a href="https://github.com/ajotanc/PixelMagicTool" target="_blank">
+          Github &copy; Pixel Magic Tool
+        </a>
+      </footer>
+    </div>
+    <div id="toast-container"></div>
+    <div id="overlay"></div>
+  </body>
+  <script>
+    const d = document;
+    const params = new URLSearchParams(window.location.search);
+    const host = params.get("hn")
+      ? params.get("hn")
+      : window.location.host
+      ? window.location.host
+      : "0.0.0.0";
+    const protocol =
+      window.location.protocol === "file:" ? "http:" : window.location.protocol;
+
+    let WLED_URL = `${protocol}//${host}`;
+
+    const hostname = gId("hostname");
+    hostname.value = host;
+
+    hostname.addEventListener("blur", async () => {
+      WLED_URL = `${protocol}//${hostname.value}`;
+
+      await segments();
+      await images();
+
+      hostnameLabel();
+    });
+
+    gId("gbth").style.display =
+      window.location.protocol === "http:" ? "flex" : "none";
+
+    let jsonSaveWLED = [];
+    let jsonSendWLED = {};
+
+    (async function () {
+      await segments();
+      await images();
+
+      hostnameLabel();
+    })();
+
+    function gId(e) {return d.getElementById(e);}
+    function cE(e) {return d.createElement(e);}
+    function hostnameLabel() {
+      const link = gId("wledEdit");
+      link.href = WLED_URL + "/edit";
+    }
+
+    async function playlist() {
+      const { value: duration } = gId("duration");
+      const { value: transition } = gId("transition");
+      const { value: name } = gId("name");
+
+      const urlPreset = `${WLED_URL}/presets.json`;
+      const url = `${WLED_URL}/json`;
+
+      try {
+        const response = await fetch(urlPreset);
+        const data = await response.json();
+        const items = Object.keys(data);
+
+        const ps = items.filter(
+          (key) =>
+            typeof data[key] === "object" &&
+            !data[key].playlist &&
+            data[key].n &&
+            data[key].n.startsWith(name)
+        );
+
+        const id =
+          items.find(
+            (key) =>
+              typeof data[key] === "object" &&
+              data[key].playlist &&
+              data[key].n &&
+              data[key].n === name
+          ) || parseInt(items.pop()) + 1;
+
+        const body = {
+          psave: parseInt(id),
+          n: name,
+          on: true,
+          o: false,
+          playlist: {
+            ps,
+            dur: Array.from({ length: ps.length }, () => duration * 10),
+            transition: Array.from(
+              { length: ps.length },
+              () => transition * 10
+            ),
+            repeat: 0,
+            end: 0,
+          },
+        };
+
+        const options = {
+          method: "POST",
+          body: JSON.stringify(body),
+        };
+
+        try {
+          const response = await fetch(url, options);
+          const { success } = await response.json();
+
+          if (success) {
+            toast(`Playlist "${name}" save successfully`);
+          }
+        } catch (error) {
+          toast(`Error saving preset: ${error}`, "error");
+        }
+      } catch (error) {
+        toast(error, "error");
+      }
+    }
+
+    async function insert(data, isAnimated = false, delay = 5000) {
+      const urlPreset = `${WLED_URL}/presets.json`;
+      const url = `${WLED_URL}/json`;
+
+      let requestsCompleted = 0;
+
+      show();
+
+      const promises = data.map(async (item) => {
+        return new Promise((resolve, reject) => {
+          setTimeout(async () => {
+            try {
+              const response = await fetch(urlPreset);
+              const data = await response.json();
+              const items = Object.keys(data);
+
+              const id =
+                items.find(
+                  (key) =>
+                    typeof data[key] === "object" &&
+                    !data[key].playlist &&
+                    data[key].n === item.n
+                ) || parseInt(items.pop()) + 1;
+
+              const body = Object.assign(item, { psave: parseInt(id) });
+              const options = {
+                method: "POST",
+                body: JSON.stringify(body),
+              };
+
+              try {
+                const response = await fetch(url, options);
+                const { success } = await response.json();
+
+                if (success) {
+                  toast(`Preset "${item.n}" save successfully`);
+                  window.parent.postMessage("loadPresets", WLED_URL);
+                }
+              } catch (error) {
+                toast(`Error saving preset: ${error}`, "error");
+              }
+            } catch (error) {
+              toast(error, "error");
+            } finally {
+              resolve();
+            }
+          }, delay * requestsCompleted++);
+        });
+      });
+
+      await Promise.all(promises);
+
+      if (isAnimated) {
+        setTimeout(async () => {
+          await playlist()
+            .then(() => {
+              hide();
+            })
+            .finally(() => {
+              hide();
+            });
+        }, delay);
+      } else {
+        hide();
+      }
+    }
+
+    async function images() {
+      const url = `${WLED_URL}/edit?list=/`;
+      const select = gId("images");
+
+      show();
+
+      try {
+        const response = await fetch(url);
+        const data = await response.json();
+        const mimeTypes = ["jpeg", "jpg", "png", "gif"];
+
+        const images = data.filter((file) => {
+          const { name } = file;
+          const [filename, mimetype] = name.split(".");
+          file.name = name.replace("/", "");
+          return mimeTypes.includes(mimetype);
+        });
+
+        const options = [{ text: "Select image", value: "" }];
+
+        if (images.length > 0) {
+          options.push(
+            ...images.map(({ name }) => ({
+              text: name,
+              value: `${WLED_URL}/${name}`,
+            }))
+          );
+
+          select.innerHTML = "";
+
+          options.forEach(({ text, value }) => {
+            const option = new Option(text, value);
+
+            if (index === 0) {
+              option.selected = true;
+            }
+
+            select.appendChild(option);
+          });
+        }
+      } catch (error) {
+        toast(error, "error");
+      } finally {
+        hide();
+      }
+    }
+
+    async function segments() {
+      const select = gId("segments");
+      const width = gId("width");
+      const height = gId("height");
+
+      show();
+
+      try {
+        const url = `${WLED_URL}/json/state`;
+        const response = await fetch(url);
+        const { seg: segments } = await response.json();
+
+        const options = [
+          { text: "Segment Default", value: 0, width: 16, height: 16 },
+        ];
+
+        if (segments) {
+          options.splice(0);
+          options.push(
+            ...segments.map(({ id, n, start, stop, startY, stopY }) => ({
+              text: n ? n : `Segment ${id}`,
+              value: id,
+              width: stop - start,
+              height: stopY - startY,
+            }))
+          );
+        }
+
+        select.innerHTML = "";
+
+        options.forEach(({ text, value, width: w, height: h }, index) => {
+          const option = new Option(text, value);
+          option.dataset.width = w;
+          option.dataset.height = h;
+
+          if (index === 0) {
+            option.selected = true;
+            width.value = w;
+            height.value = h;
+          }
+
+          select.add(option);
+        });
+      } catch (error) {
+        toast(error, "error");
+      } finally {
+        hide();
+      }
+    }
+
+    gId("dropzone").addEventListener("dragover", (e) => {
+      e.preventDefault();
+    });
+
+    gId("dropzone").addEventListener("drop", (e) => {
+      e.preventDefault();
+
+      source.files = e.dataTransfer.files;
+
+      const { name } = source.files[0];
+      gId("dropzoneLabel").textContent = `Image ${name} selected!`;
+
+      validate(e);
+    });
+
+    gId("dropzone").addEventListener("click", () => {
+      source.click();
+    });
+
+    gId("source").addEventListener("change", (e) => {
+      const dropzoneLabel = gId("dropzoneLabel");
+      const { value } = e.target;
+
+      if (value) {
+        const { name } = e.target.files[0];
+        dropzoneLabel.textContent = `Image ${name} selected!`;
+      } else {
+        dropzoneLabel.textContent =
+          "Drag and drop a file here or click to select a file";
+      }
+
+      validate(e);
+    });
+
+    gId("btnSimulatePreset").addEventListener("click", async () => {
+      const url = `${WLED_URL}/json/state`;
+
+      const options = {
+        method: "POST",
+        body: JSON.stringify(jsonSendWLED),
+      };
+
+      show();
+
+      try {
+        const response = await fetch(url, options);
+        const { success } = await response.json();
+
+        if (success) {
+          toast("Successfully simulated preset");
+        }
+      } catch (error) {
+        toast(error, "error");
+      } finally {
+        hide();
+      }
+    });
+
+    gId("btnSave").addEventListener("click", async () => {
+      const { checked } = gId("animation");
+      const { value: name } = gId("name");
+
+      if (checked) {
+        await insert(jsonSaveWLED, true);
+      } else {
+        jsonSaveWLED.splice(0);
+
+        jsonSaveWLED.push(
+          Object.assign({}, jsonSendWLED, { n: name, o: false })
+        );
+
+        await insert(jsonSaveWLED);
+      }
+    });
+
+    gId("btnCopyToClipboard").addEventListener("click", async () => {
+      const response = gId("response");
+
+      response.select();
+
+      try {
+        await navigator.clipboard.writeText(response.value);
+        toast("Text copied to clipboard");
+      } catch (error) {
+        try {
+          await d.execCommand("copy");
+          toast("Text copied to clipboard");
+        } catch (error) {
+          toast(error, "error");
+        }
+      }
+    });
+
+    gId("btnDownloadPreset").addEventListener("click", () => {
+      const { value: response } = gId("response");
+      const { value: output } = gId("output");
+
+      const timestamp = new Date().getTime();
+      const filename = `WLED_${timestamp}`;
+
+      downloadFile(response, filename, output);
+    });
+
+    gId("segments").addEventListener("change", (e) => {
+      const { width, height } = e.target.selectedOptions[0].dataset;
+
+      gId("width").value = w;
+      gId("height").value = h;
+    });
+
+    gId("output").addEventListener("change", (e) => {
+      const { value } = e.target.selectedOptions[0];
+
+      d.querySelector(".output").style.display =
+        value === "ha" ? "flex" : "none";
+    });
+
+    gId("brightnessValue").addEventListener("input", (e) => {
+      const { value } = e.target;
+      const bri = value <= 255 ? value : 255;
+
+      gId("brightness").value = bri;
+      e.target.value = bri;
+    });
+
+    gId("brightness").addEventListener("input", (e) => {
+      const { value } = e.target;
+
+      gId("brightnessValue").value = value;
+    });
+
+    gId("images").addEventListener("change", (e) => {
+      const dropzone = gId("dropzone");
+      const { value } = e.target.selectedOptions[0];
+
+      if (!value) {
+        const source = gId("source");
+
+        gId("dropzoneLabel").textContent =
+          "Drag and drop a file here or click to select a local file";
+        source.value = "";
+
+        dropzone.style.display = "block";
+      } else {
+        dropzone.style.display = "none";
+      }
+    });
+
+    gId("transparentImage").addEventListener("change", (e) => {
+      const { checked } = e.target;
+
+      d.querySelector(".transparentImage").style.display = checked
+        ? "flex"
+        : "none";
+    });
+
+    gId("resizeImage").addEventListener("change", (e) => {
+      const { checked } = e.target;
+
+      d.querySelector(".resizeImage").style.display = checked ? "flex" : "none";
+    });
+
+    gId("animation").addEventListener("change", (e) => {
+      const animation = d.querySelector(".animation");
+      const source = gId("source");
+
+      const { checked } = e.target;
+
+      if (checked) {
+        toast(
+          'If you want all frames in the image, set it to "0"',
+          "warning",
+          5000
+        );
+
+        source.setAttribute("accept", "image/gif");
+        animation.style.display = "flex";
+      } else {
+        source.setAttribute("accept", "image/*");
+        animation.style.display = "none";
+      }
+    });
+
+    gId("btnGenerate").addEventListener("click", async (event) => {
+      const { checked } = gId("animation");
+
+      if (validate(event)) {
+        jsonSaveWLED.splice(0);
+
+        gId("preview").style.display = "block";
+        gId("recreatedImage").innerHTML = "";
+
+        const simulate = gId("simulate");
+
+        if (checked) {
+          simulate.style.display = "none";
+          await generateAnimation();
+        } else {
+          simulate.style.display = "flex";
+          await generate();
+        }
+      }
+    });
+
+    async function createObjectURL(url) {
+      return fetch(url)
+        .then((response) => response.arrayBuffer())
+        .then((buffer) => {
+          const binaryData = new Uint8Array(buffer);
+          const base64 = btoa(String.fromCharCode(...binaryData));
+          return `data:image/png;base64,${base64}`;
+        });
+    }
+
+    function loadImage(url) {
+      return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = (error) => reject(error);
+        img.src = url;
+      });
+    }
+
+    async function generate() {
+      const file = gId("source").files[0];
+
+      const { value: images } = gId("images");
+      const { value: output } = gId("output");
+
+      show();
+
+      try {
+        const response = gId("response");
+        const recreatedImage = gId("recreatedImage");
+
+        const urlImage = !images
+          ? URL.createObjectURL(file)
+          : await createObjectURL(images);
+					
+        const image = await loadImage(urlImage);
+        const { canvas, bri, id, i } = recreate(image);
+
+        await new Promise((resolve) => {
+          Object.assign(jsonSendWLED, {
+            on: true,
+            bri,
+            seg: {
+              id,
+              i,
+            },
+          });
+
+          resolve();
+        });
+
+        const jsonData = JSON.stringify(jsonSendWLED);
+        const dataResponse = formatOutput(output, jsonData);
+
+        response.value = dataResponse;
+        recreatedImage.appendChild(canvas);
+      } catch (error) {
+        toast(error, "error");
+      } finally {
+        hide();
+      }
+    }
+
+    async function generateAnimation() {
+      const file = gId("source").files[0];
+      const images = gId("images");
+      const response = gId("response");
+
+      const { value: presetName } = gId("name");
+      const { value: amount } = gId("frames");
+      const { value: output } = gId("output");
+      const { value: duration } = gId("duration");
+
+      const { text: imageName, value: imageValue } = images.selectedOptions[0];
+
+      show();
+
+      try {
+        const body = new FormData();
+
+        if (!imageValue) {
+          body.append("image", file);
+        } else {
+          const responseImage = await fetch(imageValue);
+          const blob = await responseImage.blob();
+
+          const file = new File([blob], imageName, { type: blob.type });
+
+          body.append("image", file);
+        }
+
+        const responseFrames = await fetch(
+          `https://pixelmagictool.vercel.app/api/wled/frames?amount=${amount}`,
+          {
+            method: "POST",
+            body,
+          }
+        );
+
+        const { message, frames } = await responseFrames.json();
+
+        if (!responseFrames.ok) {
+          toast(message, "error");
+          return;
+        }
+
+        jsonSaveWLED = [];
+
+        const texteares = [];
+        const canvases = [];
+
+        const delay = duration * 1000;
+
+        const promises = frames.map(async (frame, index) => {
+          const image = await loadImage(frame);
+          const { canvas, bri, id, i } = recreate(image);
+          const jsonData = {
+            on: true,
+            bri,
+            seg: { id, i },
+          };
+
+          const n = `${presetName} ${index + 1}`;
+
+          texteares.push(`${n}|${JSON.stringify(jsonData)}`);
+          canvases.push(canvas);
+
+          jsonSaveWLED.push(Object.assign(jsonData, { n, o: true }));
+        });
+
+        await Promise.all(promises);
+
+        const dataResponse = texteares.map((item) => {
+          const [presetName, json] = item.split("|");
+          const outputFormatted = formatOutput(output, json);
+          const comment = ["ha", "curl"].includes(output) ? "#" : "//";
+
+          return `${comment} ${presetName}\n${outputFormatted}`;
+        });
+
+        response.value = dataResponse.join("\n");
+        toast(message);
+        carousel("recreatedImage", canvases, delay);
+      } catch (error) {
+        toast(error, "error");
+      } finally {
+        hide();
+      }
+    }
+
+    function recreate(image) {
+      const { value: pattern } = gId("pattern");
+      const { value: segmentId } = gId("segments");
+      const { value: brightness } = gId("brightness");
+      const { value: inputWidth } = gId("width");
+      const { value: inputHeight } = gId("height");
+      const { checked: resizeImage } = gId("resizeImage");
+
+      const resizeWidth = parseInt(inputWidth);
+      const resizeHeight = parseInt(inputHeight);
+
+      const { width: dataWidth, height: dataHeight } =
+        gId("segments").selectedOptions[0].dataset;
+
+      const segmentWidth = parseInt(dataWidth);
+      const segmentHeight = parseInt(dataHeight);
+
+      const imgWidth = image.naturalWidth;
+      const imgHeight = image.naturalHeight;
+
+      const width = resizeImage ? resizeWidth : imgWidth;
+      const height = resizeImage ? resizeHeight : imgHeight;
+
+      const overallWidth = resizeImage ? segmentWidth : width;
+      const overallHeight = resizeImage ? segmentHeight : height;
+
+      const startX = Math.floor((segmentWidth - width) / 2);
+      const startY = Math.floor((segmentHeight - height) / 2);
+
+      const pixelsRef = 48;
+
+      const canvasWidth = overallWidth * pixelsRef;
+      const canvasHeight = overallHeight * pixelsRef;
+
+      const fontSize = canvasWidth <= 768 ? 14 : 18;
+
+      const colors = [];
+
+      const { ctx: reference } = createCanvas(width, height);
+
+      reference.drawImage(image, 0, 0, width, height);
+
+      const imageData = reference.getImageData(0, 0, width, height);
+      const pixels = imageData.data;
+
+      const { canvas, ctx } = createCanvas(canvasWidth, canvasHeight);
+
+      ctx.fillStyle = "#000000";
+      ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+
+      for (let h = 0; h < overallHeight; h++) {
+        for (let w = 0; w < overallWidth; w++) {
+          let pixelId = h * overallWidth + w + 1;
+
+          let coordinateX = w * pixelsRef;
+          let coordinateY = h * pixelsRef;
+
+          let pixelX = w - startX;
+          let pixelY = h - startY;
+
+          let hex = "000000";
+
+          if (
+            (resizeImage &&
+              pixelX >= 0 &&
+              pixelX < width &&
+              pixelY >= 0 &&
+              pixelY < height) ||
+            (!resizeImage && w < width && h < height)
+          ) {
+            let index = resizeImage ? pixelY * width + pixelX : h * width + w;
+
+            let red = pixels[index * 4];
+            let green = pixels[index * 4 + 1];
+            let blue = pixels[index * 4 + 2];
+            let alpha = pixels[index * 4 + 3];
+
+            hex = pixelColor(red, green, blue, alpha);
+            let { r, g, b } = hexToRgb(hex);
+
+            colors.push(hex);
+
+            ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+            ctx.fillRect(coordinateX, coordinateY, pixelsRef, pixelsRef);
+          } else {
+            colors.push("000000");
+          }
+
+          ctx.lineWidth = 1;
+          ctx.strokeStyle = "#111111";
+          ctx.strokeRect(coordinateX, coordinateY, pixelsRef, pixelsRef);
+
+          let offsetX = coordinateX + pixelsRef / 2;
+          let offsetY = coordinateY + pixelsRef / 2;
+
+          ctx.font = `${fontSize}px Arial`;
+          ctx.fillStyle = hex === "000000" ? "#eeeeee" : "#111111";
+          ctx.textAlign = "center";
+          ctx.textBaseline = "middle";
+          ctx.fillText(pixelId, offsetX, offsetY);
+        }
+      }
+
+      switch (pattern) {
+        case "1":
+          i = colors;
+          break;
+        case "2":
+          i = index(colors);
+          break;
+        case "3":
+          i = range(colors);
+          break;
+      }
+
+      return {
+        canvas,
+        bri: parseInt(brightness),
+        id: parseInt(segmentId),
+        i,
+      };
+    }
+
+    function range(colors) {
+      let startIndex = 0;
+      let endIndex = 0;
+      let currentColor = colors[0];
+      let pattern = [];
+
+      colors.forEach((color, index) => {
+        if (color !== currentColor) {
+          endIndex = index;
+          const repetitions = endIndex - startIndex;
+
+          if (repetitions == 1) {
+            pattern.push(currentColor);
+          } else {
+            pattern.push(startIndex, endIndex, currentColor);
+          }
+          startIndex = index;
+        }
+        currentColor = color;
+      });
+
+      const lastRepetition = colors.length - startIndex;
+
+      if (lastRepetition === 1) {
+        pattern.push(currentColor);
+      } else {
+        pattern.push(startIndex, colors.length, currentColor);
+      }
+
+      return pattern;
+    }
+
+    function pixelColor(r, g, b, a) {
+      const { checked } = gId("transparentImage");
+      const { value } = gId("color");
+
+      if (a === 0) {
+        if (checked) {
+          return value.replace("#", "").toLowerCase();
+        }
+
+        return rgbToHex(255, 255, 255);
+      }
+
+      return rgbToHex(r, g, b);
+    }
+
+    function hexToRgb(hex) {
+      hex = hex.replace("#", "");
+
+      if (hex.length === 3) {
+        hex = hex.replace(/(.)/g, "$1$1");
+      }
+
+      const [r, g, b] = hex
+        .match(/.{2}/g)
+        .map((component) => parseInt(component, 16));
+
+      return { r, g, b };
+    }
+
+    function rgbToHex(r, g, b) {
+      const hex = ((r << 16) | (g << 8) | b).toString(16);
+      return ("000000" + hex).slice(-6);
+    }
+
+    function index(colors) {
+      const pattern = [];
+      colors.forEach((led, index) => {
+        pattern.push(index, led);
+      });
+
+      return pattern;
+    }
+
+    function createCanvas(width, height) {
+      const canvas = cE("canvas");
+
+      canvas.width = width;
+      canvas.height = height;
+
+      const ctx = canvas.getContext("2d", { willReadFrequently: true });
+
+      ctx.imageSmoothingQuality = "high";
+      ctx.imageSmoothingEnabled = false;
+
+      return { canvas, ctx };
+    }
+
+    function formatOutput(output, json) {
+      return output === "ha"
+        ? yaml(json)
+        : output === "curl"
+        ? curl(json)
+        : json;
+    }
+
+    function downloadFile(text, filename, output) {
+      let mimeType;
+      let fileExtension;
+      let response;
+
+      switch (output) {
+        case "json":
+          mimeType = "application/json";
+          fileExtension = "json";
+          break;
+        case "ha":
+          mimeType = "application/x-yaml";
+          fileExtension = "yaml";
+          break;
+        case "curl":
+          mimeType = "text/plain";
+          fileExtension = "txt";
+          break;
+      }
+
+      const blob = new Blob([text], { type: mimeType });
+      const url = URL.createObjectURL(blob);
+
+      const anchorElement = cE("a");
+      anchorElement.href = url;
+      anchorElement.download = `${filename}.${fileExtension}`;
+
+      anchorElement.click();
+
+      URL.revokeObjectURL(url);
+    }
+
+    function yaml(jsonData) {
+      const { value: device } = gId("device");
+      const { value: friendly_name } = gId("friendlyName");
+      const { value: unique_id } = gId("uniqueId");
+      const { value: hostname } = gId("hostname");
+
+      if (device) {
+        const yamlData = {
+          switches: {
+            [device]: {
+              friendly_name,
+              unique_id,
+              command_on: `curl -X POST "http://${hostname}/json/state" -d '${jsonData}' -H "Content-Type: application/json"`,
+              command_off: `curl -X POST "http://${hostname}/json/state" -d '{"on":false}' -H "Content-Type: application/json"`,
+            },
+          },
+        };
+
+        return convertToYaml(yamlData);
+      }
+    }
+
+    function curl(jsonData) {
+      const { value: hostname } = gId("hostname");
+      return `curl -X POST "http://${hostname}/json/state" -d '${jsonData}' -H "Content-Type: application/json"`;
+    }
+
+    function convertToYaml(obj) {
+      function processValue(value, indentationLevel) {
+        if (typeof value === "object" && !Array.isArray(value)) {
+          return processObject(value, indentationLevel + 1);
+        } else {
+          return value;
+        }
+      }
+
+      function processObject(obj, indentationLevel = 0) {
+        const indent = "  ".repeat(indentationLevel);
+        const lines = Object.entries(obj).map(([key, value]) => {
+          if (typeof value === "object" && !Array.isArray(value)) {
+            return `${indent}${key}:\n${processObject(
+              value,
+              indentationLevel + 1
+            )}`;
+          } else {
+            return `${indent}${key}: ${processValue(value, indentationLevel)}`;
+          }
+        });
+
+        return lines.join("\n");
+      }
+
+      return processObject(obj);
+    }
+
+    function toast(
+      message,
+      type = "success",
+      duration = 2000,
+      hideElement = "preview"
+    ) {
+      const hide = gId(hideElement);
+      const toast = cE("div");
+      const wait = 100;
+
+      toast.style.animation = "fadeIn";
+      toast.style.animationDuration = `${duration + wait}ms`;
+      toast.style.animationTimingFunction = "linear";
+
+      toast.classList.add("toast", type);
+
+      const body = cE("span");
+      body.classList.add("toast-body");
+
+      body.textContent = message;
+
+      toast.appendChild(body);
+
+      const progress = cE("div");
+      progress.classList.add("toast-progress");
+
+      progress.style.animation = "progress";
+      progress.style.animationDuration = `${duration + wait}ms`;
+      progress.style.animationDelay = "0s";
+
+      toast.appendChild(progress);
+
+      gId("toast-container").appendChild(toast);
+
+      setTimeout(() => {
+        toast.style.opacity = 0;
+        setTimeout(() => {
+          toast.remove();
+        }, wait);
+      }, duration);
+
+      if (type === "error") {
+        hide.style.display = "none";
+      }
+    }
+
+    function carousel(id, images, delay = 3000) {
+      let index = 0;
+      const carousel = cE("div");
+      carousel.classList.add("carousel");
+
+      images.forEach((canvas, i) => {
+        if (i === index) {
+          carousel.appendChild(canvas);
+        } else {
+          canvas.style.display = "none";
+          carousel.appendChild(canvas);
+        }
+      });
+
+      const container = gId(id);
+      container.innerHTML = "";
+      container.appendChild(carousel);
+
+      function next() {
+        images[index].style.display = "none";
+        index++;
+        if (index >= images.length) {
+          index = 0;
+        }
+
+        images[index].style.display = "block";
+        loop();
+      }
+
+      function previous() {
+        images[index].style.display = "none";
+        index--;
+        if (index < 0) {
+          index = images.length - 1;
+        }
+
+        images[index].style.display = "block";
+        loop();
+      }
+
+      let timeoutId;
+      function loop() {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+          next();
+          if (index === 0) {
+            carousel.scrollTo(0, 0);
+          }
+        }, delay);
+      }
+      loop();
+
+      carousel.addEventListener("mouseover", () => {
+        clearTimeout(timeoutId);
+      });
+
+      carousel.addEventListener("mouseout", () => {
+        loop();
+      });
+    }
+
+    function show() {
+      const overlay = gId("overlay");
+      overlay.classList.add("loading");
+      overlay.style.display = "block";
+      overlay.style.cursor = "not-allowed";
+
+      d.body.style.overflow = "hidden";
+    }
+
+    function hide() {
+      const overlay = gId("overlay");
+      overlay.classList.remove("loading");
+      overlay.style.display = "none";
+      overlay.style.cursor = "default";
+
+      d.body.style.overflow = "auto";
+    }
+
+    function validate(event) {
+      event.preventDefault();
+
+      const form = gId("formGenerate");
+      const inputs = form.querySelectorAll("input, select, textarea");
+
+      let isValid = true;
+
+      const browserLanguage = navigator.language || navigator.userLanguage;
+      const messageRequired =
+        browserLanguage === "pt-br"
+          ? "Este campo é obrigatório"
+          : "This field is required";
+
+      inputs.forEach((input) => {
+        const parent = input.closest("[validate]");
+
+        if (!parent) {
+          return;
+        }
+
+        let isVisible = true;
+
+        let tempParent = parent;
+        while (tempParent !== d.body) {
+          const parentStyles = window.getComputedStyle(tempParent);
+          if (
+            parentStyles.display === "none" ||
+            parentStyles.display === "hidden"
+          ) {
+            isVisible = false;
+            break;
+          }
+          tempParent = tempParent.parentNode;
+        }
+
+        if (
+          isVisible &&
+          (!input.checkValidity() ||
+            (input.type === "file" && input.files.length === 0))
+        ) {
+          input.classList.add("invalid");
+
+          const errorMessage =
+            input.dataset.errorMessage ||
+            input.validationMessage ||
+            messageRequired;
+
+          let errorElement = parent.querySelector(".error-message");
+
+          if (!errorElement) {
+            errorElement = cE("div");
+            errorElement.classList.add("error-message");
+            parent.appendChild(errorElement);
+          }
+
+          errorElement.innerText = errorMessage;
+          isValid = false;
+        } else {
+          input.classList.remove("invalid");
+          const errorElement = parent.querySelector(".error-message");
+
+          if (errorElement) {
+            parent.removeChild(errorElement);
+          }
+        }
+      });
+
+      return isValid;
+    }
+  </script>
+</html>

--- a/wled00/data/pxmagic/pxmagic.htm
+++ b/wled00/data/pxmagic/pxmagic.htm
@@ -1053,7 +1053,7 @@
 
           select.innerHTML = "";
 
-          options.forEach(({ text, value }) => {
+          options.forEach(({ text, value }, index) => {
             const option = new Option(text, value);
 
             if (index === 0) {

--- a/wled00/data/pxmagic/pxmagic.htm
+++ b/wled00/data/pxmagic/pxmagic.htm
@@ -1226,8 +1226,8 @@
     gId("segments").addEventListener("change", (e) => {
       const { width, height } = e.target.selectedOptions[0].dataset;
 
-      gId("width").value = w;
-      gId("height").value = h;
+      gId("width").value = width;
+      gId("height").value = height;
     });
 
     gId("output").addEventListener("change", (e) => {
@@ -1576,7 +1576,7 @@
           ctx.fillText(pixelId, offsetX, offsetY);
         }
       }
-
+      let i; // avoid inplicitly creating a global variable
       switch (pattern) {
         case "1":
           i = colors;

--- a/wled00/data/settings.htm
+++ b/wled00/data/settings.htm
@@ -99,6 +99,11 @@
 <button type="submit" onclick="window.location='./settings/sync'">Sync Interfaces</button>
 <button type="submit" onclick="window.location='./settings/time'">Time &amp; Macros</button>
 <button type="submit" onclick="window.location='./settings/sec'">Security &amp; Updates</button>
+<br>
 <button type="submit" onclick="window.location='./edit'">File System ☾</button> <!--WLEDMM-->
-</body>
+<button id="pixbtn" style="display:none;" type="submit" onclick="window.location='./pixart.htm'">Pixel Art Converter ☾</button>
+<button id="pxmbtn" style="display:none;" type="submit" onclick="window.location='./pxmagic.htm'">Pixel Magic Tool</button>
+<button id="forgebtn" style="display:none;" type="submit" onclick="window.location='./pixelforge.htm'">WLED Pixel Forge</button>
+<br>
+ </body>
 </html>

--- a/wled00/data/settings.htm
+++ b/wled00/data/settings.htm
@@ -68,9 +68,8 @@
 		}
 	</script>
 	<style>
+	  @import url("style.css");
 		body {
-			text-align: center;
-			background: #222;
 			height: 100px;
 			margin: 0;
 		}
@@ -78,17 +77,13 @@
 			--h: 9vh;
 		}
 		button {
-			background: #333;
-			color: #fff;
-			font-family: Verdana, Helvetica, sans-serif;
 			display: block;
-			border: 1px solid #333;
 			border-radius: var(--h);
 			font-size: 6vmin;
 			/* height: var(--h); WLEDMM remove to allow more compact display*/
 			width: calc(100% - 40px);
 			margin: 2vh auto 0;
-			cursor: pointer;
+			padding: 0;
 		}
 	</style>
 </head>

--- a/wled00/data/style.css
+++ b/wled00/data/style.css
@@ -33,6 +33,7 @@ button, .btn {
   min-width: 48px;
   cursor: pointer;
   text-decoration: none;
+  transition: all 0.3s ease;
 }
 button.sml {
   padding: 8px;
@@ -41,6 +42,11 @@ button.sml {
   min-width: 40px;
   margin: 0 0 0 10px;
 }
+button:hover, .btn:hover{
+  background:#555;
+  border-color:#555;
+}
+
 #scan {
   margin-top: -10px;
 }

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -56,16 +56,18 @@ void handleDDPPacket(e131_packet_t* p) {
 
   if (!realtimeOverride || (realtimeMode && useMainSegmentOnly)) {
     #if defined(ARDUINO_ARCH_ESP32)
-    if (xSemaphoreTake(busDrawMux, 200) != pdTRUE) { delay(1);}  // WLEDMM first acquire drawing permission (wait max 200ms)
+    // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
+    if (xSemaphoreTake(busDrawMux, 200) == pdTRUE) { 
     #endif
-    for (uint16_t i = start; i < stop; i++) {
-      setRealtimePixel(i, data[c], data[c+1], data[c+2], ddpChannelsPerLed >3 ? data[c+3] : 0);
-      c += ddpChannelsPerLed;
-      pixels++;
-    }
-    packets ++;
+      for (uint16_t i = start; i < stop; i++) {
+        setRealtimePixel(i, data[c], data[c+1], data[c+2], ddpChannelsPerLed >3 ? data[c+3] : 0);
+        c += ddpChannelsPerLed;
+        pixels++;
+      }
+      packets ++;
     #if defined(ARDUINO_ARCH_ESP32)
-    xSemaphoreGive(busDrawMux);                                  // WLEDMM release drawing permissions
+      xSemaphoreGive(busDrawMux);                                  // WLEDMM release drawing permissions
+    }
     #endif
   }
 

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -55,20 +55,16 @@ void handleDDPPacket(e131_packet_t* p) {
   realtimeLock(realtimeTimeoutMs, REALTIME_MODE_DDP);
 
   if (!realtimeOverride || (realtimeMode && useMainSegmentOnly)) {
-    #if defined(ARDUINO_ARCH_ESP32)
     // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
-    if (xSemaphoreTake(busDrawMux, 200) == pdTRUE) { 
-    #endif
+    if (esp32SemTake(busDrawMux, 200) == pdTRUE) { 
       for (uint16_t i = start; i < stop; i++) {
         setRealtimePixel(i, data[c], data[c+1], data[c+2], ddpChannelsPerLed >3 ? data[c+3] : 0);
         c += ddpChannelsPerLed;
         pixels++;
       }
       packets ++;
-    #if defined(ARDUINO_ARCH_ESP32)
-      xSemaphoreGive(busDrawMux);                                  // WLEDMM release drawing permissions
+      esp32SemGive(busDrawMux);                                  // WLEDMM release drawing permissions
     }
-    #endif
   }
 
   bool push = p->flags & DDP_PUSH_FLAG;
@@ -195,8 +191,11 @@ void handleDMXData(uint16_t uni, uint16_t dmxChannels, uint8_t* e131_data, uint8
       if (realtimeOverride && !(realtimeMode && useMainSegmentOnly)) return;
 
       wChannel = (availDMXLen > 3) ? e131_data[dataOffset+3] : 0;
-      for (uint16_t i = 0; i < totalLen; i++)
-        setRealtimePixel(i, e131_data[dataOffset+0], e131_data[dataOffset+1], e131_data[dataOffset+2], wChannel);
+      if (esp32SemTake(busDrawMux, 200) == pdTRUE) { // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
+        for (uint16_t i = 0; i < totalLen; i++)
+          setRealtimePixel(i, e131_data[dataOffset+0], e131_data[dataOffset+1], e131_data[dataOffset+2], wChannel);
+        esp32SemGive(busDrawMux);
+      }
       break;
 
     case DMX_MODE_SINGLE_DRGB:  // 4 channel: [Dimmer,R,G,B]
@@ -211,9 +210,11 @@ void handleDMXData(uint16_t uni, uint16_t dmxChannels, uint8_t* e131_data, uint8
         bri = e131_data[dataOffset+0];
         strip.setBrightness(bri, true);
       }
-
-      for (uint16_t i = 0; i < totalLen; i++)
-        setRealtimePixel(i, e131_data[dataOffset+1], e131_data[dataOffset+2], e131_data[dataOffset+3], wChannel);
+      if (esp32SemTake(busDrawMux, 200) == pdTRUE) { // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
+        for (uint16_t i = 0; i < totalLen; i++)
+          setRealtimePixel(i, e131_data[dataOffset+1], e131_data[dataOffset+2], e131_data[dataOffset+3], wChannel);
+        esp32SemGive(busDrawMux);
+      }
       break;
 
     case DMX_MODE_PRESET:       // 2 channel: [Dimmer,Preset]
@@ -357,16 +358,19 @@ void handleDMXData(uint16_t uni, uint16_t dmxChannels, uint8_t* e131_data, uint8
           }
         }
 
-        if (!is4Chan) {
-          for (uint16_t i = previousLeds; i < ledsTotal; i++) {
-            setRealtimePixel(i, e131_data[dmxOffset], e131_data[dmxOffset+1], e131_data[dmxOffset+2], 0);
-            dmxOffset+=3;
+        if (esp32SemTake(busDrawMux, 200) == pdTRUE) { // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
+          if (!is4Chan) {
+            for (uint16_t i = previousLeds; i < ledsTotal; i++) {
+              setRealtimePixel(i, e131_data[dmxOffset], e131_data[dmxOffset+1], e131_data[dmxOffset+2], 0);
+              dmxOffset+=3;
+            }
+          } else {
+            for (uint16_t i = previousLeds; i < ledsTotal; i++) {
+              setRealtimePixel(i, e131_data[dmxOffset], e131_data[dmxOffset+1], e131_data[dmxOffset+2], e131_data[dmxOffset+3]);
+              dmxOffset+=4;
+            }
           }
-        } else {
-          for (uint16_t i = previousLeds; i < ledsTotal; i++) {
-            setRealtimePixel(i, e131_data[dmxOffset], e131_data[dmxOffset+1], e131_data[dmxOffset+2], e131_data[dmxOffset+3]);
-            dmxOffset+=4;
-          }
+          esp32SemGive(busDrawMux);
         }
         break;
       }

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -16,6 +16,7 @@ void handleDDPPacket(e131_packet_t* p) {
   int lastPushSeq = e131LastSequenceNumber[0];
 
   //reject late packets belonging to previous frame (assuming 4 packets max. before push)
+#if 0  // WLEDMM fixme - we definitely have more than 5-10 packets per frame !!!
   if (e131SkipOutOfSequence && lastPushSeq) {
     int sn = p->sequenceNum & 0xF;
     if (sn) {
@@ -26,8 +27,14 @@ void handleDDPPacket(e131_packet_t* p) {
       }
     }
   }
+#endif
 
   uint8_t ddpChannelsPerLed = ((p->dataType & 0b00111000)>>3 == 0b011) ? 4 : 3; // data type 0x1B (formerly 0x1A) is RGBW (type 3, 8 bit/channel)
+
+  // WLEDMM for debugging
+  static unsigned lastPush = millis();
+  static unsigned packets = 0;
+  static unsigned pixels = 0;
 
   uint32_t start =  htonl(p->channelOffset) / ddpChannelsPerLed;
   start += DMXAddress / ddpChannelsPerLed;
@@ -48,15 +55,29 @@ void handleDDPPacket(e131_packet_t* p) {
   realtimeLock(realtimeTimeoutMs, REALTIME_MODE_DDP);
 
   if (!realtimeOverride || (realtimeMode && useMainSegmentOnly)) {
+    #if defined(ARDUINO_ARCH_ESP32)
+    if (xSemaphoreTake(busDrawMux, 200) != pdTRUE) { delay(1);}  // WLEDMM first acquire drawing permission (wait max 200ms)
+    #endif
     for (uint16_t i = start; i < stop; i++) {
       setRealtimePixel(i, data[c], data[c+1], data[c+2], ddpChannelsPerLed >3 ? data[c+3] : 0);
       c += ddpChannelsPerLed;
+      pixels++;
     }
+    packets ++;
+    #if defined(ARDUINO_ARCH_ESP32)
+    xSemaphoreGive(busDrawMux);                                  // WLEDMM release drawing permissions
+    #endif
   }
 
   bool push = p->flags & DDP_PUSH_FLAG;
   ddpSeenPush |= push;
   if (!ddpSeenPush || push) { // if we've never seen a push, or this is one, render display
+    #ifdef WLED_DEBUG
+      if (push) { USER_PRINT("-P-");} else { USER_PRINT("--");}
+      USER_PRINTF("> %dms (%upck, %upix) ", int(millis() - lastPush), packets, pixels);
+      lastPush = millis();
+      pixels = packets = 0;
+    #endif
     e131NewData = true;
     byte sn = p->sequenceNum & 0xF;
     if (sn) e131LastSequenceNumber[0] = sn;

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -91,6 +91,8 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
   uint8_t* e131_data = nullptr;
   uint8_t seq = 0, mde = REALTIME_MODE_E131;
 
+  if (!receiveDirect) { exitRealtime(); return; } // WLEDMM kill switch
+
   if (protocol == P_ARTNET)
   {
     if (p->art_opcode == ARTNET_OPCODE_OPPOLL) {

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -439,7 +439,7 @@ void sappend(char stype, const char* key, int val);
 void sappends(char stype, const char* key, char* val);
 void prepareHostname(char* hostname);
 bool isAsterisksOnly(const char* str, byte maxLen)  __attribute__((pure));
-bool requestJSONBufferLock(uint8_t module=255);
+bool requestJSONBufferLock(uint8_t module=255, unsigned timeoutMS = 1800);
 void releaseJSONBufferLock();
 uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLen);
 uint8_t extractModeSlider(uint8_t mode, uint8_t slider, char *dest, uint8_t maxLen, uint8_t *var = nullptr);

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -299,6 +299,11 @@ bool writeObjectToFile(const char* file, const char* key, JsonDocument* content)
     s = millis();
   #endif
 
+  if (doCloseFile) {
+    if (f) { DEBUG_PRINTLN("writeObjectToFile("+String(file)+"): file f is already open, closing to prevent file corruption."); }
+    closeFile();  // WLEDMM: Ensure previous file is closed
+  }
+
   size_t pos = 0;
   f = WLED_FS.open(file, "r+");
   if (!f && !WLED_FS.exists(file)) { f = WLED_FS.open(file, "w+");

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -419,7 +419,7 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
 
     seg.map1D2D = oldMap1D2D; // restore mapping
     if (drawSuccess) strip.trigger(); // force segment update
-    else USER_PRINTLN(F("deserializeSegment() image drawing failed, cannot not to acquire busDrawMux.")); // log failure messaage
+    else USER_PRINTLN(F("deserializeSegment() image drawing failed, cannot to acquire busDrawMux.")); // log failure messaage
     suspendStripService = oldLock; // restore previous lock status
   }
   // send UDP/WS if segment options changed (except selection; will also deselect current preset)

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -540,9 +540,9 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
 #ifdef ARDUINO_ARCH_ESP32
   // WLEDMM: Acquire strip lock right before segment operations (deferred for better UX)
   suspendStripService = true; // temporarily lock out strip updates
-  delay(2); // WLEDMM experimental - de-serialize takes time, so allow other tasks to run
+  vTaskDelay(pdMS_TO_TICKS(2)); // WLEDMM trigger a short task context switch
   if (strip.isServicing()) {
-    USER_PRINTLN(F("deserializeState(): strip is still drawing effects."));
+    DEBUG_PRINTLN(F("deserializeState(): strip is still drawing effects."));
     strip.waitUntilIdle();
   }
 #endif

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -97,10 +97,10 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
     if (esp32SemTake(segmentMux, 2100) == pdTRUE) { // wait long, but don't wait forever
       // WLEDMM make sure we have exclusive access to the segment list
       strip.appendSegment(Segment(0, strip.getLengthTotal()));
+      id = strip.getSegmentsNum()-1; // segments are added at the end of list
+      newSeg = true;
       esp32SemGive(segmentMux);
     }
-    id = strip.getSegmentsNum()-1; // segments are added at the end of list
-    newSeg = true;
   }
 
   // WLEDMM: before changing segments, make sure our strip is _not_ servicing effects in parallel

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -493,16 +493,15 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
     }
   }
 
-#ifdef ARDUINO_ARCH_ESP32
-  delay(2); // WLEDMM experimental - de-serialize takes time, so allow other tasks to run
-#endif
-
+  // esp32: suspendStripService is deferred until the first segment operation
+#ifndef ARDUINO_ARCH_ESP32
   // WLEDMM: before changing strip, make sure our strip is _not_ servicing effects in parallel
   suspendStripService = true; // temporarily lock out strip updates
   if (strip.isServicing()) {
     USER_PRINTLN(F("deserializeState(): strip is still drawing effects."));
     strip.waitUntilIdle();
   }
+#endif
 
   // temporary transition (applies only once)
   tr = root[F("tt")] | -1;
@@ -537,6 +536,16 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
   }
 
   if (root[F("psave")].isNull()) doReboot = root[F("rb")] | doReboot;
+
+#ifdef ARDUINO_ARCH_ESP32
+  // WLEDMM: Acquire strip lock right before segment operations (deferred for better UX)
+  suspendStripService = true; // temporarily lock out strip updates
+  delay(2); // WLEDMM experimental - de-serialize takes time, so allow other tasks to run
+  if (strip.isServicing()) {
+    USER_PRINTLN(F("deserializeState(): strip is still drawing effects."));
+    strip.waitUntilIdle();
+  }
+#endif
 
   // do not allow changing main segment while in realtime mode (may get odd results else)
   if (!realtimeMode) strip.setMainSegmentId(root[F("mainseg")] | strip.getMainSegmentId()); // must be before realtimeLock() if "live"

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -548,6 +548,7 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
 #endif
 
   // do not allow changing main segment while in realtime mode (may get odd results else)
+  // esp32: safe to change MainSegment without having segmentMux - strip.service() is already suspended
   if (!realtimeMode) strip.setMainSegmentId(root[F("mainseg")] | strip.getMainSegmentId()); // must be before realtimeLock() if "live"
 
   realtimeOverride = root[F("lor")] | realtimeOverride;

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -645,10 +645,12 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
 
   doAdvancePlaylist = root[F("np")] | doAdvancePlaylist; //advances to next preset in playlist when true
   
+  // WLEDMM: Release suspendStripService before stateUpdated() to avoid timeout
+  if (iAmGroot) suspendStripService = false;
+
   stateUpdated(callMode);
   if (presetToRestore) currentPreset = presetToRestore;
 
-  if (iAmGroot) suspendStripService = false; // WLEDMM release lock
   return stateResponse;
 }
 
@@ -727,9 +729,11 @@ void serializeSegment(JsonObject& root, Segment& seg, byte id, bool forPreset, b
 void serializeState(JsonObject root, bool forPreset, bool includeBri, bool segmentBounds, bool selectedSegmentsOnly)
 {
   //WLEDMM add DEBUG_PRINT (not USER_PRINT)
+  #ifdef WLED_DEBUG
   String temp;
   serializeJson(root, temp);
   DEBUG_PRINTF("serializeState %d %s\n", forPreset, temp.c_str());
+  #endif
 
   if (includeBri) {
     root["on"] = (bri > 0);

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -419,7 +419,7 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
 
     seg.map1D2D = oldMap1D2D; // restore mapping
     if (drawSuccess) strip.trigger(); // force segment update
-    else USER_PRINTLN(F("deserializeSegment() image drawing failed, cannot to acquire busDrawMux.")); // log failure messaage
+    else USER_PRINTLN(F("deserializeSegment() image drawing failed, could not acquire busDrawMux.")); // log failure messaage
     suspendStripService = oldLock; // restore previous lock status
   }
   // send UDP/WS if segment options changed (except selection; will also deselect current preset)

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -94,7 +94,7 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
   // if using vectors use this code to append segment
   if (id >= strip.getSegmentsNum()) {
     if (stop <= 0) return false; // ignore empty/inactive segments
-    if (esp32SemTake(segmentMux, portMAX_DELAY) == pdTRUE) {
+    if (esp32SemTake(segmentMux, 2100) == pdTRUE) { // wait long, but don't wait forever
       // WLEDMM make sure we have exclusive access to the segment list
       strip.appendSegment(Segment(0, strip.getLengthTotal()));
       esp32SemGive(segmentMux);

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -353,8 +353,9 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
       USER_PRINTLN(F("deserializeSegment() image: strip is still drawing effects."));
       strip.waitUntilIdle();
     }
+    // WLEDMM protect against parallel drawing
+    if (esp32SemTake(busDrawMux, 250) == pdTRUE) {      // WLEDMM first acquire draw mutex, start of critical section
     seg.startFrame();
-    // WLEDMM end
 
     // set brightness immediately and disable transition
     transitionDelayTemp = 0;
@@ -404,6 +405,9 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
         set = 0;
       }
     }
+    esp32SemGive(busDrawMux); // release lock
+    } // end of critical section
+
     seg.map1D2D = oldMap1D2D; // restore mapping
     strip.trigger(); // force segment update
     suspendStripService = oldLock; // restore previous lock status

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -94,7 +94,11 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
   // if using vectors use this code to append segment
   if (id >= strip.getSegmentsNum()) {
     if (stop <= 0) return false; // ignore empty/inactive segments
-    strip.appendSegment(Segment(0, strip.getLengthTotal()));
+    if (esp32SemTake(segmentMux, portMAX_DELAY) == pdTRUE) {
+      // WLEDMM make sure we have exclusive access to the segment list
+      strip.appendSegment(Segment(0, strip.getLengthTotal()));
+      esp32SemGive(segmentMux);
+    }
     id = strip.getSegmentsNum()-1; // segments are added at the end of list
     newSeg = true;
   }

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -100,6 +100,9 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
       id = strip.getSegmentsNum()-1; // segments are added at the end of list
       newSeg = true;
       esp32SemGive(segmentMux);
+    } else {
+      USER_PRINTLN(F("deserializeSegment(): segment not added - failed to acquire segmentMux."));
+      return false;      
     }
   }
 
@@ -358,6 +361,7 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
       strip.waitUntilIdle();
     }
     // WLEDMM protect against parallel drawing
+    bool drawSuccess = false;
     if (esp32SemTake(busDrawMux, 250) == pdTRUE) {      // WLEDMM first acquire draw mutex, start of critical section
     seg.startFrame();
 
@@ -409,11 +413,13 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
         set = 0;
       }
     }
+    drawSuccess = true;
     esp32SemGive(busDrawMux); // release lock
     } // end of critical section
 
     seg.map1D2D = oldMap1D2D; // restore mapping
-    strip.trigger(); // force segment update
+    if (drawSuccess) strip.trigger(); // force segment update
+    else USER_PRINTLN(F("deserializeSegment() image drawing failed, cannot not to acquire busDrawMux.")); // log failure messaage
     suspendStripService = oldLock; // restore previous lock status
   }
   // send UDP/WS if segment options changed (except selection; will also deselect current preset)

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -560,7 +560,13 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
     if (root["live"].as<bool>()) {
       transitionDelayTemp = 0;
       jsonTransitionOnce = true;
+#ifdef WLED_ENABLE_JSONLIVE
+      // infinite timeout only when JSON LIVE leds preview is enabled
       realtimeLock(65000);
+#else
+      // more meaningful timeout : use configurable timeout; *3 for some safety margin without staying "live" forever
+      realtimeLock(realtimeTimeoutMs *3);  // Use configurable timeout like other protocols 
+#endif
     } else {
       exitRealtime();
     }

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -12,8 +12,10 @@ static volatile byte presetToApply = 0;
 static volatile byte callModeToApply = 0;
 static volatile byte presetToSave = 0;
 static volatile int8_t saveLedmap = -1;
-static char quickLoad[12]; // WLEDMM 9->12 to prevent crashing with unicode
-static char saveName[33];
+#define QLOAD_BUFFER 12 // string needed for quickload // WLEDMM 9->12 to prevent crashing with unicode
+#define FNAME_BUFFER 32 // string needed for saveName
+static char quickLoad[QLOAD_BUFFER+1] = {'\0'}; // 1 extra byte for '\0'
+static char saveName[FNAME_BUFFER+1]  = {'\0'}; // 1 extra byte for '\0'
 static bool includeBri = true, segBounds = true, selectedOnly = false, playlistSave = false;
 
 static const char *getFileName(bool persist = true) {
@@ -305,15 +307,17 @@ void handlePresets()
 void savePreset(byte index, const char* pname, JsonObject sObj)
 {
   if (index == 0 || (index > 250 && index < 255)) return;
-  if (pname) strlcpy(saveName, pname, 33);
+  if (pname) strlcpy(saveName, pname, FNAME_BUFFER+1);
   else {
-    if (sObj["n"].is<const char*>()) strlcpy(saveName, sObj["n"].as<const char*>(), 33);
+    if (sObj["n"].is<const char*>()) strlcpy(saveName, sObj["n"].as<const char*>(), FNAME_BUFFER+1);
     else                             sprintf_P(saveName, PSTR("Preset %d"), index);
   }
 
   DEBUG_PRINT(F("Saving preset (")); DEBUG_PRINT(index); DEBUG_PRINT(F(") ")); DEBUG_PRINTLN(saveName);
   auto oldpresetToSave = presetToSave; // for recovery in case that esp32SemTake(presetFileMux) fails
   auto oldplaylistSave = playlistSave;
+  char oldQuickLoad[QLOAD_BUFFER+1];
+  strlcpy(oldQuickLoad, quickLoad, sizeof(oldQuickLoad));
 
   presetToSave = index;
   playlistSave = false;
@@ -334,6 +338,7 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
           USER_PRINTLN(F("savePreset(): preset file busy, cannot write"));
           presetToSave = oldpresetToSave;
           playlistSave = oldplaylistSave;
+          strlcpy(quickLoad, oldQuickLoad, sizeof(quickLoad));
           return; // early exit, no change
       }
 
@@ -342,6 +347,7 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
         esp32SemGive(presetFileMux);  // Release file mutex
         presetToSave = oldpresetToSave; // bugfix: restore previous state on error exit
         playlistSave = oldplaylistSave;
+        strlcpy(quickLoad, oldQuickLoad, sizeof(quickLoad));
         return; // cannot save API calls to temporary preset (255)
       }
       sObj.remove("o");

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -312,6 +312,7 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
   }
 
   DEBUG_PRINT(F("Saving preset (")); DEBUG_PRINT(index); DEBUG_PRINT(F(") ")); DEBUG_PRINTLN(saveName);
+  auto oldpresetToSave = presetToSave; // for recovery in case that esp32SemTake(presetFileMux) fails
 
   presetToSave = index;
   playlistSave = false;
@@ -330,6 +331,7 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
       // WLEDMM Acquire file mutex before writing presets.json, to prevent presets.json corruption
       if (esp32SemTake(presetFileMux, 2500) != pdTRUE) {
           USER_PRINTLN(F("savePreset(): preset file busy, cannot write"));
+          presetToSave = oldpresetToSave;
           return; // early exit, no change
       }
 

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -329,7 +329,7 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
 
       // WLEDMM Acquire file mutex before writing presets.json, to prevent presets.json corruption
       if (esp32SemTake(presetFileMux, 2500) != pdTRUE) {
-          USER_PRINTLN(F("doSaveState(): preset file busy, cannot write"));
+          USER_PRINTLN(F("savePreset(): preset file busy, cannot write"));
           return; // early exit, no change
       }
 

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -358,8 +358,16 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
 }
 
 void deletePreset(byte index) {
+  // WLEDMM Acquire file mutex before writing presets.json, to prevent presets.json corruption
+  if (esp32SemTake(presetFileMux, 2500) != pdTRUE) {
+    USER_PRINTLN(F("deletePreset(): preset file busy, cannot write"));
+    return; // early exit, no change
+  }
+
   StaticJsonDocument<24> empty;
   writeObjectToFileUsingId(getFileName(), index, &empty);
+
+  esp32SemGive(presetFileMux);  // Release file mutex
   presetsModifiedTime = toki.second(); //unix time
   updateFSInfo();
 }

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -336,7 +336,10 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
       }
 
       presetToSave = 0;
-      if (index > 250 || !fileDoc) return; // cannot save API calls to temporary preset (255)
+      if (index > 250 || !fileDoc) {
+        esp32SemGive(presetFileMux);  // Release file mutex
+        return; // cannot save API calls to temporary preset (255)
+      }
       sObj.remove("o");
       sObj.remove("v");
       sObj.remove("time");

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -313,6 +313,7 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
 
   DEBUG_PRINT(F("Saving preset (")); DEBUG_PRINT(index); DEBUG_PRINT(F(") ")); DEBUG_PRINTLN(saveName);
   auto oldpresetToSave = presetToSave; // for recovery in case that esp32SemTake(presetFileMux) fails
+  auto oldplaylistSave = playlistSave;
 
   presetToSave = index;
   playlistSave = false;
@@ -332,6 +333,7 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
       if (esp32SemTake(presetFileMux, 2500) != pdTRUE) {
           USER_PRINTLN(F("savePreset(): preset file busy, cannot write"));
           presetToSave = oldpresetToSave;
+          playlistSave = oldplaylistSave;
           return; // early exit, no change
       }
 

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -38,7 +38,14 @@ static void doSaveState() {
   bool persist = (presetToSave < 251);
   const char *filename = getFileName(persist);
 
-  if (!requestJSONBufferLock(10)) return; // will set fileDoc
+  if (!requestJSONBufferLock(10)) return; // will set fileDoc // async write
+
+  // WLEDMM Acquire file mutex before writing presets.json or tmp.json
+  if (esp32SemTake(presetFileMux, 2500) != pdTRUE) {
+    USER_PRINTLN(F("doSaveState(): preset file busy, cannot write"));
+    releaseJSONBufferLock();
+    return;
+  }
 
   initPresetsFile(); // just in case if someone deleted presets.json using /edit
   JsonObject sObj = doc.to<JsonObject>();
@@ -82,6 +89,8 @@ static void doSaveState() {
   writeObjectToFileUsingId(filename, presetToSave, fileDoc);
 
   if (persist) presetsModifiedTime = toki.second(); //unix time
+
+  esp32SemGive(presetFileMux);  // Release file mutex
   releaseJSONBufferLock();
   updateFSInfo();
 
@@ -316,7 +325,14 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
   } else {
     // this is a playlist or API call
     if (sObj[F("playlist")].isNull()) {
-      // we will save API call immediately (often causes presets.json corruption)
+      // we will save API call immediately (often causes presets.json corruption in the past)
+
+      // WLEDMM Acquire file mutex before writing presets.json, to prevent presets.json corruption
+      if (esp32SemTake(presetFileMux, 2500) != pdTRUE) {
+          USER_PRINTLN(F("doSaveState(): preset file busy, cannot write"));
+          return; // early exit, no change
+      }
+
       presetToSave = 0;
       if (index > 250 || !fileDoc) return; // cannot save API calls to temporary preset (255)
       sObj.remove("o");
@@ -325,8 +341,11 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
       sObj.remove(F("error"));
       sObj.remove(F("psave"));
       if (sObj["n"].isNull()) sObj["n"] = saveName;
+
       initPresetsFile(); // just in case if someone deleted presets.json using /edit
       writeObjectToFileUsingId(getFileName(index<255), index, fileDoc);
+
+      esp32SemGive(presetFileMux);  // Release file mutex
       presetsModifiedTime = toki.second(); //unix time
       updateFSInfo();
     } else {

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -340,6 +340,8 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
       presetToSave = 0;
       if (index > 250 || !fileDoc) {
         esp32SemGive(presetFileMux);  // Release file mutex
+        presetToSave = oldpresetToSave; // bugfix: restore previous state on error exit
+        playlistSave = oldplaylistSave;
         return; // cannot save API calls to temporary preset (255)
       }
       sObj.remove("o");

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -162,9 +162,8 @@ void realtimeLock(uint32_t timeoutMs, byte md)
 
     if (strip.isServicing()) {
       USER_PRINTLN(F("realtimeLock() entering RTM: strip is still drawing effects."));
-      strip.waitUntilIdle();
+      strip.waitUntilIdle(350);
     }
-    strip.service(); // WLEDMM make sure that all segments are properly initialized
     busses.invalidateCache(true);
     // WLEDMM end
 

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -211,7 +211,7 @@ void realtimeLock(uint32_t timeoutMs, byte md)
   // WLEDMM cache current "main segment"
   if (esp32SemTake(busDrawMux, 1200) == pdTRUE) { // stupid long timeout, but we don't want to wait forever
     // WLEDMM protect against parallel cache updates from different tasks
-    //   positive side-effect: this also introduces a wait if other bus activities are happeening in parallel
+    //   positive side effect: this also introduces a wait if other bus activities are happening in parallel
     Segment& mainSegRef = strip.getMainSegment();
     theMainSeg = &mainSegRef; //convert from reference to pointer
     if (realtimeOverride && !(realtimeMode && useMainSegmentOnly)) {
@@ -223,6 +223,13 @@ void realtimeLock(uint32_t timeoutMs, byte md)
       theStripLength = strip.getLengthTotal();
     }
     esp32SemGive(busDrawMux);
+  } else {
+    // mutex acquisition failed, log debug message and pretend we are in override mode
+    DEBUG_PRINTLN(F("realtimeLock: failed to acquire busDrawMux for cache update."));
+    // clear cache to prevent stale pointer usage
+    theMainSeg = nullptr;
+    theMainSegLength = 0;
+    theStripLength = 0;
   }
 
   if (realtimeOverride) return;
@@ -244,7 +251,7 @@ void exitRealtime() {
   } else {
     strip.show(); // possible fix for #3589
   }
-  // WLEDMM invalide cached main segment pointer and length
+  // WLEDMM invalidate cached main segment pointer and length
   #ifdef ARDUINO_ARCH_ESP32
   portENTER_CRITICAL(&critical_lock); // critical section to make cache reset atomic and thread-safe
   #endif

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -203,10 +203,15 @@ void realtimeLock(uint32_t timeoutMs, byte md)
   realtimeMode = md;
 
   // WLEDMM cache current "main segment"
-  Segment& mainSegRef = strip.getMainSegment();
-  theMainSeg = &mainSegRef; //convert from reference to pointer
-  theMainSegLength = realtimeOverride ? 0 : theMainSeg->length();
-  theStripLength = realtimeOverride ? 0 : strip.getLengthTotal();
+  if (esp32SemTake(busDrawMux, 1200) == pdTRUE) { // stupid long timeout, but we don't want to wait forever
+    // WLEDMM protect against parallel cache updates from different tasks
+    //   positive side-effect: this also introduces a wait if other bus activities are happeening in parallel
+    Segment& mainSegRef = strip.getMainSegment();
+    theMainSeg = &mainSegRef; //convert from reference to pointer
+    theMainSegLength = realtimeOverride ? 0 : theMainSeg->length();
+    theStripLength = realtimeOverride ? 0 : strip.getLengthTotal();
+    esp32SemGive(busDrawMux);
+  }
 
   if (realtimeOverride) return;
   if (arlsForceMaxBri) strip.setBrightness(scaledBri(255), true);
@@ -228,9 +233,13 @@ void exitRealtime() {
     strip.show(); // possible fix for #3589
   }
   // WLEDMM invalide cached main segment pointer and length
-  theMainSeg = nullptr;
-  theMainSegLength  = 0;
-  theStripLength = 0;
+  if (esp32SemTake(busDrawMux, 200) == pdTRUE) {
+    // WLEDMM protect against parallel cache updates from different tasks
+    theMainSeg = nullptr;
+    theMainSegLength  = 0;
+    theStripLength = 0;
+    esp32SemGive(busDrawMux);
+  }
   busses.invalidateCache(false);  // WLEDMM
   USER_PRINTLN(F("exitRealtime() realtime mode ended."));
   updateInterfaces(CALL_MODE_WS_SEND);

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -609,8 +609,8 @@ void handleNotifications()
     return;
   }
 
-  //UDP realtime: 1 warls 2 drgb 3 drgbw
-  if (udpIn[0] > 0 && udpIn[0] < 5)
+  //UDP realtime: 1 warls 2 drgb 3 drgbw 4 dnrgb 5 dnrgbw
+  if (udpIn[0] > 0 && udpIn[0] < 6)
   {
     realtimeIP = (isSupp) ? notifier2Udp.remoteIP() : notifierUdp.remoteIP();
     DEBUG_PRINTLN(realtimeIP);

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -214,8 +214,14 @@ void realtimeLock(uint32_t timeoutMs, byte md)
     //   positive side-effect: this also introduces a wait if other bus activities are happeening in parallel
     Segment& mainSegRef = strip.getMainSegment();
     theMainSeg = &mainSegRef; //convert from reference to pointer
-    theMainSegLength = realtimeOverride ? 0 : theMainSeg->length();
-    theStripLength = realtimeOverride ? 0 : strip.getLengthTotal();
+    if (realtimeOverride && !(realtimeMode && useMainSegmentOnly)) {
+      // prevent drawing during user override
+      theMainSegLength = 0;
+      theStripLength = 0;
+    } else {
+      theMainSegLength = theMainSeg->length();
+      theStripLength = strip.getLengthTotal();
+    }
     esp32SemGive(busDrawMux);
   }
 

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -659,7 +659,7 @@ void handleNotifications()
         }
       } else if (udpIn[0] == 5 && packetSize > 8) { //dnrgbw
         uint16_t id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
-        for (int i = 4; i < packetSize -2; i += 4) {
+        for (int i = 4; i < packetSize -3; i += 4) {
           if (id >= totalLen) break;
           setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
           id++;

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -184,7 +184,10 @@ void realtimeLock(uint32_t timeoutMs, byte md)
       stop  = strip.getLengthTotal();
     }
     // clear strip/segment
-    for (size_t i = start; i < stop; i++) strip.setPixelColor(i,BLACK);
+    if (esp32SemTake(busDrawMux, 200) == pdTRUE) { // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
+      for (size_t i = start; i < stop; i++) strip.setPixelColor(i,BLACK);
+      esp32SemGive(busDrawMux);
+    }
     // if WLED was off and using main segment only, freeze non-main segments so they stay off
     if (useMainSegmentOnly && bri == 0) {
       for (size_t s=0; s < strip.getSegmentsNum(); s++) {
@@ -326,10 +329,13 @@ void handleNotifications()
 #endif
       uint16_t id = 0;
       uint16_t totalLen = strip.getLengthTotal();
-      for (int i = 0; i < packetSize -2; i += 3)
-      {
-        setRealtimePixel(id, lbuf[i], lbuf[i+1], lbuf[i+2], 0);
-        id++; if (id >= totalLen) break;
+      if (esp32SemTake(busDrawMux, 200) == pdTRUE) { // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
+        for (int i = 0; i < packetSize -2; i += 3)
+        {
+          setRealtimePixel(id, lbuf[i], lbuf[i+1], lbuf[i+2], 0);
+          id++; if (id >= totalLen) break;
+        }
+        esp32SemGive(busDrawMux);
       }
       if (!(realtimeMode && useMainSegmentOnly)) strip.show();
       return;
@@ -573,14 +579,16 @@ void handleNotifications()
 
     uint16_t id = (tpmPayloadFrameSize/3)*(packetNum-1); //start LED
     uint16_t totalLen = strip.getLengthTotal();
-    for (size_t i = 6; i < tpmPayloadFrameSize + 4U; i += 3)
-    {
-      if (id < totalLen)
+    if (esp32SemTake(busDrawMux, 200) == pdTRUE) { // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
+      for (size_t i = 6; i < tpmPayloadFrameSize + 4U; i += 3)
       {
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
-        id++;
+        if (id < totalLen) {
+          setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+          id++;
+        }
+        else break;
       }
-      else break;
+      esp32SemGive(busDrawMux);
     }
     if (tpmPacketCount == numPackets) //reset packet count and show if all packets were received
     {
@@ -606,49 +614,40 @@ void handleNotifications()
     }
     if (realtimeOverride && !(realtimeMode && useMainSegmentOnly)) return;
 
-    uint16_t totalLen = strip.getLengthTotal();
-    if (udpIn[0] == 1 && packetSize > 5) //warls
-    {
-      for (int i = 2; i < packetSize -3; i += 4)
-      {
-        setRealtimePixel(udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3], 0);
+    if (esp32SemTake(busDrawMux, 250) == pdTRUE) { // WLEDMM acquire drawing permission (wait max 200ms) before setting pixels
+      uint16_t totalLen = strip.getLengthTotal();
+      if (udpIn[0] == 1 && packetSize > 5) { //warls
+        for (int i = 2; i < packetSize -3; i += 4) {
+          setRealtimePixel(udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3], 0);
+        }
+      } else if (udpIn[0] == 2 && packetSize > 4) { //drgb
+        uint16_t id = 0;
+        for (int i = 2; i < packetSize -2; i += 3) {
+          setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+          id++; if (id >= totalLen) break;
+        }
+      } else if (udpIn[0] == 3 && packetSize > 6) { //drgbw
+        uint16_t id = 0;
+        for (int i = 2; i < packetSize -3; i += 4) {
+          setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
+          id++; if (id >= totalLen) break;
+        }
+      } else if (udpIn[0] == 4 && packetSize > 7) { //dnrgb
+        uint16_t id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
+        for (int i = 4; i < packetSize -2; i += 3) {
+          if (id >= totalLen) break;
+          setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
+          id++;
+        }
+      } else if (udpIn[0] == 5 && packetSize > 8) { //dnrgbw
+        uint16_t id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
+        for (int i = 4; i < packetSize -2; i += 4) {
+          if (id >= totalLen) break;
+          setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
+          id++;
+        }
       }
-    } else if (udpIn[0] == 2 && packetSize > 4) //drgb
-    {
-      uint16_t id = 0;
-      for (int i = 2; i < packetSize -2; i += 3)
-      {
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
-
-        id++; if (id >= totalLen) break;
-      }
-    } else if (udpIn[0] == 3 && packetSize > 6) //drgbw
-    {
-      uint16_t id = 0;
-      for (int i = 2; i < packetSize -3; i += 4)
-      {
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
-
-        id++; if (id >= totalLen) break;
-      }
-    } else if (udpIn[0] == 4 && packetSize > 7) //dnrgb
-    {
-      uint16_t id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
-      for (int i = 4; i < packetSize -2; i += 3)
-      {
-        if (id >= totalLen) break;
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
-        id++;
-      }
-    } else if (udpIn[0] == 5 && packetSize > 8) //dnrgbw
-    {
-      uint16_t id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
-      for (int i = 4; i < packetSize -2; i += 4)
-      {
-        if (id >= totalLen) break;
-        setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
-        id++;
-      }
+      esp32SemGive(busDrawMux); // end of critical section
     }
     strip.show();
     return;

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -154,6 +154,9 @@ void notify(byte callMode, bool followUp)
 static Segment* theMainSeg = nullptr;
 static int theMainSegLength = 0;
 static int theStripLength = 0;
+#ifdef ARDUINO_ARCH_ESP32
+static portMUX_TYPE critical_lock = portMUX_INITIALIZER_UNLOCKED; // to make cache clearing an atomic operation
+#endif
 
 void realtimeLock(uint32_t timeoutMs, byte md)
 {
@@ -236,13 +239,15 @@ void exitRealtime() {
     strip.show(); // possible fix for #3589
   }
   // WLEDMM invalide cached main segment pointer and length
-  if (esp32SemTake(busDrawMux, 200) == pdTRUE) {
-    // WLEDMM protect against parallel cache updates from different tasks
+  #ifdef ARDUINO_ARCH_ESP32
+  portENTER_CRITICAL(&critical_lock); // critical section to make cache reset atomic and thread-safe
+  #endif
     theMainSeg = nullptr;
     theMainSegLength  = 0;
     theStripLength = 0;
-    esp32SemGive(busDrawMux);
-  }
+  #ifdef ARDUINO_ARCH_ESP32
+  portEXIT_CRITICAL(&critical_lock); // end of critical section
+  #endif
   busses.invalidateCache(false);  // WLEDMM
   USER_PRINTLN(F("exitRealtime() realtime mode ended."));
   updateInterfaces(CALL_MODE_WS_SEND);

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -150,6 +150,11 @@ void notify(byte callMode, bool followUp)
   notificationCount = followUp ? notificationCount + 1 : 0;
 }
 
+// WLEDMM cache current main segment: updated in realtimeLock, reset in exitRealtime, used in setRealTimePixel
+static Segment* theMainSeg = nullptr;
+static int theMainSegLength = 0;
+static int theStripLength = 0;
+
 void realtimeLock(uint32_t timeoutMs, byte md)
 {
   if (!realtimeMode && !realtimeOverride) {
@@ -197,6 +202,12 @@ void realtimeLock(uint32_t timeoutMs, byte md)
   }
   realtimeMode = md;
 
+  // WLEDMM cache current "main segment"
+  Segment& mainSegRef = strip.getMainSegment();
+  theMainSeg = &mainSegRef; //convert from reference to pointer
+  theMainSegLength = realtimeOverride ? 0 : theMainSeg->length();
+  theStripLength = realtimeOverride ? 0 : strip.getLengthTotal();
+
   if (realtimeOverride) return;
   if (arlsForceMaxBri) strip.setBrightness(scaledBri(255), true);
   if (briT > 0 && md == REALTIME_MODE_GENERIC) strip.show();
@@ -216,6 +227,10 @@ void exitRealtime() {
   } else {
     strip.show(); // possible fix for #3589
   }
+  // WLEDMM invalide cached main segment pointer and length
+  theMainSeg = nullptr;
+  theMainSegLength  = 0;
+  theStripLength = 0;
   busses.invalidateCache(false);  // WLEDMM
   USER_PRINTLN(F("exitRealtime() realtime mode ended."));
   updateInterfaces(CALL_MODE_WS_SEND);
@@ -650,8 +665,8 @@ void handleNotifications()
 
 void setRealtimePixel(uint16_t i, byte r, byte g, byte b, byte w)
 {
-  uint16_t pix = i + arlsOffset;
-  if (pix < strip.getLengthTotal()) {
+  int pix = i + arlsOffset;
+  if (pix < theStripLength) { // WLEDMM use cached length
     if (!arlsDisableGammaCorrection && gammaCorrectCol) {
       r = gamma8(r);
       g = gamma8(g);
@@ -659,8 +674,8 @@ void setRealtimePixel(uint16_t i, byte r, byte g, byte b, byte w)
       w = gamma8(w);
     }
     if (useMainSegmentOnly) {
-      Segment &seg = strip.getMainSegment();
-      if (pix<seg.length()) seg.setPixelColor(pix, r, g, b, w);
+      //Segment &seg = strip.getMainSegment();
+      if ((theMainSeg) && (pix < theMainSegLength)) theMainSeg->setPixelColor(pix, r, g, b, w); // WLEDMM used cached main segment
     } else {
       strip.setPixelColor(pix, r, g, b, w);
     }

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -692,7 +692,7 @@ void handleNotifications()
 void setRealtimePixel(uint16_t i, byte r, byte g, byte b, byte w)
 {
   int pix = i + arlsOffset;
-  if (pix < theStripLength) { // WLEDMM use cached length
+  if (unsigned(pix) < theStripLength) { // WLEDMM use cached length
     if (!arlsDisableGammaCorrection && gammaCorrectCol) {
       r = gamma8(r);
       g = gamma8(g);
@@ -701,7 +701,7 @@ void setRealtimePixel(uint16_t i, byte r, byte g, byte b, byte w)
     }
     if (useMainSegmentOnly) {
       //Segment &seg = strip.getMainSegment();
-      if ((theMainSeg) && (pix < theMainSegLength)) theMainSeg->setPixelColor(pix, r, g, b, w); // WLEDMM used cached main segment
+      if ((theMainSeg) && (unsigned(pix) < theMainSegLength)) theMainSeg->setPixelColor(pix, r, g, b, w); // WLEDMM used cached main segment
     } else {
       strip.setPixelColor(pix, r, g, b, w);
     }

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -220,19 +220,19 @@ bool isAsterisksOnly(const char* str, byte maxLen)
 
 
 //threading/network callback details: https://github.com/Aircoookie/WLED/pull/2336#discussion_r762276994
-bool requestJSONBufferLock(uint8_t module)
+bool requestJSONBufferLock(uint8_t module, unsigned timeoutMS)
 {
   bool haveLock = false;
   #ifdef ARDUINO_ARCH_ESP32
     // We use a recursive mutex to prevent parallel JSON writes from parallel tasks.
     // This also fixes hanging up for the full timeout interval in cases when the contention is from the same task.
     // see https://github.com/wled/WLED/pull/4089 for more details.
-    if (esp32SemTake(jsonBufferLockMutex, 1800) == pdTRUE) haveLock = true;  // WLEDMM must wait longer than suspendStripService timeout = 1500ms
+    if (esp32SemTake(jsonBufferLockMutex, timeoutMS) == pdTRUE) haveLock = true;  // WLEDMM must wait longer than suspendStripService timeout = 1500ms
   #else
     // 8266: only wait in case that can_yield() tells us we can yield and delay
     if (can_yield()) {
       unsigned long now = millis();
-      while (jsonBufferLock && millis()-now < 1800) delay(1); // wait for fraction for buffer lock // WLEDMM must wait longer than suspendStripService timeout = 1500ms
+      while (jsonBufferLock && millis()-now < timeoutMS) delay(1); // wait for fraction for buffer lock // WLEDMM must wait longer than suspendStripService timeout = 1500ms
       if (!jsonBufferLock) haveLock = true;
     }
   #endif

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -222,17 +222,31 @@ bool isAsterisksOnly(const char* str, byte maxLen)
 //threading/network callback details: https://github.com/Aircoookie/WLED/pull/2336#discussion_r762276994
 bool requestJSONBufferLock(uint8_t module)
 {
-  unsigned long now = millis();
+  bool haveLock = false;
+  #ifdef ARDUINO_ARCH_ESP32
+    // We use a recursive mutex to prevent parallel JSON writes from parallel tasks.
+    // This also fixes hanging up for the full timeout interval in cases when the contention is from the same task.
+    // see https://github.com/wled/WLED/pull/4089 for more details.
+    if (esp32SemTake(jsonBufferLockMutex, 1800) == pdTRUE) haveLock = true;  // WLEDMM must wait longer than suspendStripService timeout = 1500ms
+  #else
+    // 8266: only wait in case that can_yield() tells us we can yield and delay
+    if (can_yield()) {
+      unsigned long now = millis();
+      while (jsonBufferLock && millis()-now < 1800) delay(1); // wait for fraction for buffer lock // WLEDMM must wait longer than suspendStripService timeout = 1500ms
+      if (!jsonBufferLock) haveLock = true;
+    }
+  #endif
 
-  while (jsonBufferLock && millis()-now < 1100) delay(1); // wait for fraction for buffer lock
-
-  if (jsonBufferLock) {
+  if (jsonBufferLock || !haveLock) {
+    if (haveLock) esp32SemGive(jsonBufferLockMutex);  // we got the mutex, but jsonBufferLock says the opposite -> give up
+    delay(10); // WLEDMM experimental: small extra wait, in case that esp32 cores temporarily disagree on the value of jsonBufferLock
     USER_PRINT(F("ERROR: Locking JSON buffer failed! (still locked by "));
     USER_PRINT(jsonBufferLock);
     USER_PRINTLN(")");
     return false; // waiting time-outed
   }
 
+  // success - we keep holding the mutex until releaseJSONBufferLock()
   jsonBufferLock = module ? module : 255;
   DEBUG_PRINT(F("JSON buffer locked. ("));
   DEBUG_PRINT(jsonBufferLock);
@@ -250,6 +264,7 @@ void releaseJSONBufferLock()
   DEBUG_PRINTLN(")");
   fileDoc = nullptr;
   jsonBufferLock = 0;
+  esp32SemGive(jsonBufferLockMutex); // return the mutex
 }
 
 

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -238,7 +238,9 @@ bool requestJSONBufferLock(uint8_t module)
   #endif
 
   if (jsonBufferLock || !haveLock) {
+    #ifdef ARDUINO_ARCH_ESP32
     if (haveLock) esp32SemGive(jsonBufferLockMutex);  // we got the mutex, but jsonBufferLock says the opposite -> give up
+    #endif
     USER_PRINT(F("ERROR: Locking JSON buffer failed! (still locked by "));
     USER_PRINT(jsonBufferLock);
     USER_PRINTLN(")");
@@ -263,7 +265,9 @@ void releaseJSONBufferLock()
   DEBUG_PRINTLN(")");
   fileDoc = nullptr;
   jsonBufferLock = 0;
+  #ifdef ARDUINO_ARCH_ESP32
   esp32SemGive(jsonBufferLockMutex); // return the mutex
+  #endif
 }
 
 

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -239,7 +239,6 @@ bool requestJSONBufferLock(uint8_t module)
 
   if (jsonBufferLock || !haveLock) {
     if (haveLock) esp32SemGive(jsonBufferLockMutex);  // we got the mutex, but jsonBufferLock says the opposite -> give up
-    delay(10); // WLEDMM experimental: small extra wait, in case that esp32 cores temporarily disagree on the value of jsonBufferLock
     USER_PRINT(F("ERROR: Locking JSON buffer failed! (still locked by "));
     USER_PRINT(jsonBufferLock);
     USER_PRINTLN(")");

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -478,7 +478,9 @@ void WLED::setup()
 
   #ifdef ARDUINO_ARCH_ESP32
   busDrawMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent concurrent running of strip.show and strip.service
+  segmentMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent segment changes while effects are running
   xSemaphoreGiveRecursive(busDrawMux);                 // init semaphores to initially allow drawing
+  xSemaphoreGiveRecursive(segmentMux);
   #endif
 
   #ifdef ARDUINO_ARCH_ESP32

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -477,6 +477,11 @@ void WLED::setup()
   init_math();  // WLEDMM: pre-calculate some lookup tables
 
   #ifdef ARDUINO_ARCH_ESP32
+  busDrawMux = xSemaphoreCreateBinary();      // WLEDMM prevent concurrent running of strip.show and strip.service
+  xSemaphoreGive(busDrawMux);                 // init semaphores to initially allow drawing
+  #endif
+
+  #ifdef ARDUINO_ARCH_ESP32
   #if defined(WLED_DEBUG) && (defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3) || ARDUINO_USB_CDC_ON_BOOT)
   if (!Serial) delay(2500);  // WLEDMM allow CDC USB serial to initialise (WLED_DEBUG only)
   #endif

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -479,8 +479,10 @@ void WLED::setup()
   #ifdef ARDUINO_ARCH_ESP32
   busDrawMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent concurrent running of strip.show and strip.service
   segmentMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent segment changes while effects are running
+  jsonBufferLockMutex = xSemaphoreCreateRecursiveMutex(); // WLEDMM prevent concurrent JSON buffer writing
   xSemaphoreGiveRecursive(busDrawMux);                 // init semaphores to initially allow drawing
   xSemaphoreGiveRecursive(segmentMux);
+  xSemaphoreGiveRecursive(jsonBufferLockMutex);
   #endif
 
   #ifdef ARDUINO_ARCH_ESP32

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -480,6 +480,8 @@ void WLED::setup()
   busDrawMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent concurrent running of strip.show and strip.service
   segmentMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent segment changes while effects are running
   jsonBufferLockMutex = xSemaphoreCreateRecursiveMutex(); // WLEDMM prevent concurrent JSON buffer writing
+  if ((busDrawMux == nullptr) || (segmentMux == nullptr) || (jsonBufferLockMutex == nullptr))
+    USER_PRINTLN(F("setup error: xSemaphoreCreateRecursiveMutex failed.")); // should never happen.
   xSemaphoreGiveRecursive(busDrawMux);                 // init semaphores to initially allow drawing
   xSemaphoreGiveRecursive(segmentMux);
   xSemaphoreGiveRecursive(jsonBufferLockMutex);

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -477,8 +477,8 @@ void WLED::setup()
   init_math();  // WLEDMM: pre-calculate some lookup tables
 
   #ifdef ARDUINO_ARCH_ESP32
-  busDrawMux = xSemaphoreCreateBinary();      // WLEDMM prevent concurrent running of strip.show and strip.service
-  xSemaphoreGive(busDrawMux);                 // init semaphores to initially allow drawing
+  busDrawMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent concurrent running of strip.show and strip.service
+  xSemaphoreGiveRecursive(busDrawMux);                 // init semaphores to initially allow drawing
   #endif
 
   #ifdef ARDUINO_ARCH_ESP32
@@ -1103,15 +1103,15 @@ bool WLED::initEthernet()
 
 void WLED::initConnection()
 {
+  #ifdef WLED_ENABLE_WEBSOCKETS
+  ws.onEvent(wsEvent);
+  #endif
+
 #ifdef ARDUINO_ARCH_ESP32
   unsigned long t_wait = millis();
   while(strip.isUpdating() && (millis() - t_wait < 86)) delay(1); // WLEDMM try to catch a moment when strip is idle
   //if (strip.isUpdating()) USER_PRINTLN("WLED::initConnection: strip still updating.");
 #endif
-
-  #ifdef WLED_ENABLE_WEBSOCKETS
-  ws.onEvent(wsEvent);
-  #endif
 
   WiFi.disconnect(true);        // close old connections
 #ifdef ESP8266

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -480,11 +480,14 @@ void WLED::setup()
   busDrawMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent concurrent running of strip.show and strip.service
   segmentMux = xSemaphoreCreateRecursiveMutex();       // WLEDMM prevent segment changes while effects are running
   jsonBufferLockMutex = xSemaphoreCreateRecursiveMutex(); // WLEDMM prevent concurrent JSON buffer writing
-  if ((busDrawMux == nullptr) || (segmentMux == nullptr) || (jsonBufferLockMutex == nullptr))
+  presetFileMux = xSemaphoreCreateRecursiveMutex();   // WLEDMM prevent concurrent presets.json file writing
+  if ((busDrawMux == nullptr) || (segmentMux == nullptr) || (jsonBufferLockMutex == nullptr) || (presetFileMux == nullptr)) {
     USER_PRINTLN(F("setup error: xSemaphoreCreateRecursiveMutex failed.")); // should never happen.
+  }
   xSemaphoreGiveRecursive(busDrawMux);                 // init semaphores to initially allow drawing
   xSemaphoreGiveRecursive(segmentMux);
   xSemaphoreGiveRecursive(jsonBufferLockMutex);
+  xSemaphoreGiveRecursive(presetFileMux);
   #endif
 
   #ifdef ARDUINO_ARCH_ESP32

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -7,7 +7,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2512291
+#define VERSION 2512292
 
 // WLEDMM  - you can check for this define in usermods, to only enabled WLEDMM specific code in the "right" fork. Its not defined in AC WLED.
 #define _MoonModules_WLED_
@@ -771,6 +771,7 @@ WLED_GLOBAL volatile bool OTAisRunning _INIT(false);        // WLEDMM temporaril
 WLED_GLOBAL SemaphoreHandle_t busDrawMux _INIT(nullptr);
 WLED_GLOBAL SemaphoreHandle_t segmentMux _INIT(nullptr);
 WLED_GLOBAL SemaphoreHandle_t jsonBufferLockMutex _INIT(nullptr);
+WLED_GLOBAL SemaphoreHandle_t presetFileMux _INIT(nullptr); // Protects presets.json file writes
 #define esp32SemTake(mux,timeout) xSemaphoreTakeRecursive(mux, pdMS_TO_TICKS(timeout)) // convenience macro that expands to xSemaphoreTakeRecursive - timeout is in milliseconds
 #define esp32SemGive(mux)  xSemaphoreGiveRecursive(mux)                 // convenience macro that expands to xSemaphoreGiveRecursive
 #define WLED_create_spinlock(theSname) static portMUX_TYPE theSname = portMUX_INITIALIZER_UNLOCKED

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -769,6 +769,7 @@ WLED_GLOBAL volatile bool OTAisRunning _INIT(false);        // WLEDMM temporaril
 // WLEDMM prevent concurrent strip.show() and strip.service() -> for DDP over ws, and other background tasks
 #ifdef ARDUINO_ARCH_ESP32
 WLED_GLOBAL SemaphoreHandle_t busDrawMux _INIT(nullptr);
+WLED_GLOBAL SemaphoreHandle_t segmentMux _INIT(nullptr);
 #define esp32SemTake(mux,timeout) xSemaphoreTakeRecursive(mux, timeout) // convenience macro that expands to xSemaphoreTakeRecursive
 #define esp32SemGive(mux)  xSemaphoreGiveRecursive(mux)                 // convenience macro that expands to xSemaphoreGiveRecursive
 #else

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -7,7 +7,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2512301
+#define VERSION 2601011
 
 // WLEDMM  - you can check for this define in usermods, to only enabled WLEDMM specific code in the "right" fork. Its not defined in AC WLED.
 #define _MoonModules_WLED_

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -765,6 +765,11 @@ WLED_GLOBAL volatile bool loadLedmap _INIT(false);          // WLEDMM use as boo
 WLED_GLOBAL volatile uint8_t loadedLedmap _INIT(0);         // WLEDMM default 0
 WLED_GLOBAL volatile bool suspendStripService _INIT(false); // WLEDMM temporarily prevent running strip.service, when strip or segments are "under update" and inconsistent
 WLED_GLOBAL volatile bool OTAisRunning _INIT(false);        // WLEDMM temporarily stop led updates during OTA
+
+#ifdef ARDUINO_ARCH_ESP32
+WLED_GLOBAL SemaphoreHandle_t busDrawMux _INIT(nullptr);    // WLEDMM prevent concurrent strip.show() and strip.service() -> for DDP over ws
+#endif
+
 #ifndef ESP8266
 WLED_GLOBAL char  *ledmapNames[WLED_MAX_LEDMAPS-1] _INIT_N(({nullptr}));
 #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -770,6 +770,7 @@ WLED_GLOBAL volatile bool OTAisRunning _INIT(false);        // WLEDMM temporaril
 #ifdef ARDUINO_ARCH_ESP32
 WLED_GLOBAL SemaphoreHandle_t busDrawMux _INIT(nullptr);
 WLED_GLOBAL SemaphoreHandle_t segmentMux _INIT(nullptr);
+WLED_GLOBAL SemaphoreHandle_t jsonBufferLockMutex _INIT(nullptr);
 #define esp32SemTake(mux,timeout) xSemaphoreTakeRecursive(mux, timeout) // convenience macro that expands to xSemaphoreTakeRecursive
 #define esp32SemGive(mux)  xSemaphoreGiveRecursive(mux)                 // convenience macro that expands to xSemaphoreGiveRecursive
 #define WLED_create_spinlock(theSname) static portMUX_TYPE theSname = portMUX_INITIALIZER_UNLOCKED

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -772,8 +772,9 @@ WLED_GLOBAL SemaphoreHandle_t busDrawMux _INIT(nullptr);
 WLED_GLOBAL SemaphoreHandle_t segmentMux _INIT(nullptr);
 #define esp32SemTake(mux,timeout) xSemaphoreTakeRecursive(mux, timeout) // convenience macro that expands to xSemaphoreTakeRecursive
 #define esp32SemGive(mux)  xSemaphoreGiveRecursive(mux)                 // convenience macro that expands to xSemaphoreGiveRecursive
+#define WLED_create_spinlock(theSname) static portMUX_TYPE theSname = portMUX_INITIALIZER_UNLOCKED
 #else
-// dummy for 8266
+// dummy semaphores for 8266
 #ifndef pdTRUE
 #define pdTRUE 1
 #endif
@@ -782,6 +783,10 @@ WLED_GLOBAL SemaphoreHandle_t segmentMux _INIT(nullptr);
 #endif
 #define esp32SemTake(mux,timeout) (pdTRUE)
 #define esp32SemGive(mux)
+// dummy critical section for 8266
+#define WLED_create_spinlock(sname)
+#define portENTER_CRITICAL(sname)
+#define portEXIT_CRITICAL(sname)
 #endif
 
 #ifndef ESP8266

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -771,7 +771,7 @@ WLED_GLOBAL volatile bool OTAisRunning _INIT(false);        // WLEDMM temporaril
 WLED_GLOBAL SemaphoreHandle_t busDrawMux _INIT(nullptr);
 WLED_GLOBAL SemaphoreHandle_t segmentMux _INIT(nullptr);
 WLED_GLOBAL SemaphoreHandle_t jsonBufferLockMutex _INIT(nullptr);
-#define esp32SemTake(mux,timeout) xSemaphoreTakeRecursive(mux, timeout) // convenience macro that expands to xSemaphoreTakeRecursive
+#define esp32SemTake(mux,timeout) xSemaphoreTakeRecursive(mux, pdMS_TO_TICKS(timeout)) // convenience macro that expands to xSemaphoreTakeRecursive - timeout is in milliseconds
 #define esp32SemGive(mux)  xSemaphoreGiveRecursive(mux)                 // convenience macro that expands to xSemaphoreGiveRecursive
 #define WLED_create_spinlock(theSname) static portMUX_TYPE theSname = portMUX_INITIALIZER_UNLOCKED
 #else

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -766,8 +766,21 @@ WLED_GLOBAL volatile uint8_t loadedLedmap _INIT(0);         // WLEDMM default 0
 WLED_GLOBAL volatile bool suspendStripService _INIT(false); // WLEDMM temporarily prevent running strip.service, when strip or segments are "under update" and inconsistent
 WLED_GLOBAL volatile bool OTAisRunning _INIT(false);        // WLEDMM temporarily stop led updates during OTA
 
+// WLEDMM prevent concurrent strip.show() and strip.service() -> for DDP over ws, and other background tasks
 #ifdef ARDUINO_ARCH_ESP32
-WLED_GLOBAL SemaphoreHandle_t busDrawMux _INIT(nullptr);    // WLEDMM prevent concurrent strip.show() and strip.service() -> for DDP over ws
+WLED_GLOBAL SemaphoreHandle_t busDrawMux _INIT(nullptr);
+#define esp32SemTake(mux,timeout) xSemaphoreTakeRecursive(mux, timeout) // convenience macro that expands to xSemaphoreTakeRecursive
+#define esp32SemGive(mux)  xSemaphoreGiveRecursive(mux)                 // convenience macro that expands to xSemaphoreGiveRecursive
+#else
+// dummy for 8266
+#ifndef pdTRUE
+#define pdTRUE 1
+#endif
+#ifndef portMAX_DELAY
+#define portMAX_DELAY UINT32_MAX
+#endif
+#define esp32SemTake(mux,timeout) (pdTRUE)
+#define esp32SemGive(mux)
 #endif
 
 #ifndef ESP8266

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -6,14 +6,27 @@
 #endif
 #include "html_settings.h"
 #include "html_other.h"
+
 #ifdef WLED_ENABLE_PIXART
   #include "html_pixart.h"
 #endif
-#ifdef WLED_ENABLE_PIXELFORGE
+#ifdef WLED_ENABLE_PXMAGIC
+  //#include "html_pxmagic.h"
+  #if !defined(WLED_ENABLE_PIXART)
+  #error "PIXEL MAGIC Tool is not supported in WLED-MM. Please use Pixel Art Converter instead: add -D WLED_ENABLE_PIXART to your build_flags"
+  // PIXEL MAGIC has known problems when creating image presets for larger images.
+  // if you still want to use it, upload pxmagic.htm to your device (<WLED-IP>/edit) and then start <WLED-IP>/pxmagic.htm
+  #endif
+#endif
+#if defined(WLED_ENABLE_PIXELFORGE) && !defined(WLED_DISABLE_PIXELFORGE) // WLEDMM uses WLED_ENABLE_PIXELFORGE, upstream has WLED_DISABLE_PIXELFORGE
   #include "html_pixelforge.h"
   static const char _pixelforge_htm[] PROGMEM = "/pixelforge.htm";
   static const char _common_js[]      PROGMEM = "/common.js";
+  #if !defined(WLED_ENABLE_GIF)
+  #error "GIF image support is missing. Please add -D WLED_ENABLE_GIF to your build flags."
+  #endif
 #endif
+
 #include "html_cpal.h"
 
 // define flash strings once (saves flash memory)
@@ -454,7 +467,7 @@ void initServer()
   });
   #endif
 
-  #ifdef WLED_ENABLE_PIXELFORGE
+#if defined(WLED_ENABLE_PIXELFORGE) && !defined(WLED_DISABLE_PIXELFORGE)
   server.on(_pixelforge_htm, HTTP_GET, [](AsyncWebServerRequest *request) {
     //handleStaticContent(request, FPSTR(_pixelforge_htm), 200, FPSTR(CONTENT_TYPE_HTML), PAGE_pixelforge, PAGE_pixelforge_length);
     if (handleFileRead(request, FPSTR(_pixelforge_htm))) return;
@@ -621,7 +634,7 @@ void serveSettingsJS(AsyncWebServerRequest* request)
   char buf[SETTINGS_STACK_BUF_SIZE+37] = { '\0' }; // WLEDMM ensure buffer is cleared initially
   buf[0] = 0;
 
-  #ifdef WLED_ENABLE_PIXELFORGE
+#if defined(WLED_ENABLE_PIXELFORGE) && !defined(WLED_DISABLE_PIXELFORGE) 
    // serve common.js if requested by subPage = 254 (.js)
   if (request->url().indexOf(FPSTR(_common_js)) > 0) {
     AsyncWebServerResponse *response = request->beginResponse_P(200, FPSTR(CONTENT_TYPE_JAVASCRIPT), JS_common, JS_common_length);

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -9,6 +9,9 @@
 #ifdef WLED_ENABLE_PIXART
   #include "html_pixart.h"
 #endif
+#ifdef WLED_ENABLE_PIXELFORGE
+  #include "html_pixelforge.h"
+#endif
 #include "html_cpal.h"
 
 // define flash strings once (saves flash memory)
@@ -448,6 +451,19 @@ void initServer()
   });
   #endif
 
+  #ifdef WLED_ENABLE_PIXELFORGE
+  static const char _pixelforge_htm[] PROGMEM = "/pixelforge.htm";
+  server.on(_pixelforge_htm, HTTP_GET, [](AsyncWebServerRequest *request) {
+    //handleStaticContent(request, FPSTR(_pixelforge_htm), 200, FPSTR(CONTENT_TYPE_HTML), PAGE_pixelforge, PAGE_pixelforge_length);
+    if (handleFileRead(request, FPSTR(_pixelforge_htm))) return;
+    if (handleIfNoneMatchCacheHeader(request)) return;
+    AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", PAGE_pixelforge, PAGE_pixelforge_L);
+    response->addHeader(FPSTR(s_content_enc),"gzip");
+    setStaticContentCacheHeaders(response);
+    request->send(response);
+  });
+  #endif
+
   server.on("/cpal.htm", HTTP_GET, [](AsyncWebServerRequest *request){
     if (handleFileRead(request, "/cpal.htm")) return;
     if (handleIfNoneMatchCacheHeader(request)) return;
@@ -463,8 +479,8 @@ void initServer()
 
   //called when the url is not defined here, ajax-in; get-settings
   server.onNotFound([](AsyncWebServerRequest *request){
-    DEBUG_PRINT("Not-Found HTTP call: ");
-    DEBUG_PRINTLN("URI: " + request->url());
+    USER_PRINT("Not-Found HTTP call: ");
+    USER_PRINTLN("URI: " + request->url());
     if (captivePortal(request)) return;
 
     //make API CORS compatible

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -479,8 +479,8 @@ void initServer()
 
   //called when the url is not defined here, ajax-in; get-settings
   server.onNotFound([](AsyncWebServerRequest *request){
-    USER_PRINT("Not-Found HTTP call: ");
-    USER_PRINTLN("URI: " + request->url());
+    DEBUG_PRINT("Not-Found HTTP call: ");
+    DEBUG_PRINTLN("URI: " + request->url());
     if (captivePortal(request)) return;
 
     //make API CORS compatible

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -462,6 +462,12 @@ void initServer()
     setStaticContentCacheHeaders(response);
     request->send(response);
   });
+  server.on("/common.js", HTTP_GET, [](AsyncWebServerRequest *request){
+    AsyncWebServerResponse *response = request->beginResponse_P(200, "application/javascript", JS_common, JS_common_length);
+    response->addHeader(FPSTR(s_content_enc),"gzip");
+    setStaticContentCacheHeaders(response);
+    request->send(response);
+  });
   #endif
 
   server.on("/cpal.htm", HTTP_GET, [](AsyncWebServerRequest *request){

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -11,6 +11,8 @@
 #endif
 #ifdef WLED_ENABLE_PIXELFORGE
   #include "html_pixelforge.h"
+  static const char _pixelforge_htm[] PROGMEM = "/pixelforge.htm";
+  static const char _common_js[]      PROGMEM = "/common.js";
 #endif
 #include "html_cpal.h"
 
@@ -22,6 +24,7 @@ static const char s_unlock_cfg [] PROGMEM = "Please unlock settings using PIN co
 static const char s_cache_control[]  PROGMEM = "Cache-Control";
 //static const char s_no_store[]       PROGMEM = "no-store";
 //static const char s_expires[]        PROGMEM = "Expires";
+static const char enc_gzip[] PROGMEM = "gzip";
 
 /*
  * Integrated HTTP web server page declarations
@@ -452,19 +455,18 @@ void initServer()
   #endif
 
   #ifdef WLED_ENABLE_PIXELFORGE
-  static const char _pixelforge_htm[] PROGMEM = "/pixelforge.htm";
   server.on(_pixelforge_htm, HTTP_GET, [](AsyncWebServerRequest *request) {
     //handleStaticContent(request, FPSTR(_pixelforge_htm), 200, FPSTR(CONTENT_TYPE_HTML), PAGE_pixelforge, PAGE_pixelforge_length);
     if (handleFileRead(request, FPSTR(_pixelforge_htm))) return;
     if (handleIfNoneMatchCacheHeader(request)) return;
-    AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", PAGE_pixelforge, PAGE_pixelforge_L);
-    response->addHeader(FPSTR(s_content_enc),"gzip");
+    AsyncWebServerResponse *response = request->beginResponse_P(200, FPSTR(CONTENT_TYPE_HTML), PAGE_pixelforge, PAGE_pixelforge_L);
+    response->addHeader(FPSTR(s_content_enc),FPSTR(enc_gzip));
     setStaticContentCacheHeaders(response);
     request->send(response);
   });
-  server.on("/common.js", HTTP_GET, [](AsyncWebServerRequest *request){
-    AsyncWebServerResponse *response = request->beginResponse_P(200, "application/javascript", JS_common, JS_common_length);
-    response->addHeader(FPSTR(s_content_enc),"gzip");
+  server.on(_common_js, HTTP_GET, [](AsyncWebServerRequest *request){
+    AsyncWebServerResponse *response = request->beginResponse_P(200, FPSTR(CONTENT_TYPE_JAVASCRIPT), JS_common, JS_common_length);
+    response->addHeader(FPSTR(s_content_enc),FPSTR(enc_gzip));
     setStaticContentCacheHeaders(response);
     request->send(response);
   });
@@ -618,6 +620,18 @@ void serveSettingsJS(AsyncWebServerRequest* request)
 {
   char buf[SETTINGS_STACK_BUF_SIZE+37] = { '\0' }; // WLEDMM ensure buffer is cleared initially
   buf[0] = 0;
+
+  #ifdef WLED_ENABLE_PIXELFORGE
+   // serve common.js if requested by subPage = 254 (.js)
+  if (request->url().indexOf(FPSTR(_common_js)) > 0) {
+    AsyncWebServerResponse *response = request->beginResponse_P(200, FPSTR(CONTENT_TYPE_JAVASCRIPT), JS_common, JS_common_length);
+    response->addHeader(FPSTR(s_content_enc),FPSTR(enc_gzip));
+    setStaticContentCacheHeaders(response);
+    request->send(response);
+    return;
+  }
+  #endif
+
   byte subPage = request->arg(F("p")).toInt();
   if (subPage > 10) {
     strcpy_P(buf, PSTR("alert('Settings for this request are not implemented.');"));

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -49,7 +49,7 @@ void wsEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventTyp
         }
 
         bool verboseResponse = false;
-        if (!requestJSONBufferLock(11)) {
+        if (!requestJSONBufferLock(11, 300)) {
           client->text(F("{\"error\":3}")); // ERR_NOBUF
           return;
         }
@@ -138,7 +138,7 @@ void sendDataWs(AsyncWebSocketClient * client)
   DEBUG_PRINTF("sendDataWs\n");
   if (!ws.count()) return;
 
-  if (!requestJSONBufferLock(12)) {
+  if (!requestJSONBufferLock(12, 300)) {
     if (client) {
       client->text(F("{\"error\":3}")); // ERR_NOBUF
     } else {

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -308,6 +308,17 @@ void getSettingsJS(AsyncWebServerRequest* request, byte subPage, char* dest) //W
   #ifdef WLED_ENABLE_DMX // include only if DMX is enabled
     oappend(PSTR("gId('dmxbtn').style.display='';"));
   #endif
+
+  #ifdef WLED_ENABLE_PIXART // include only if PixelArt tool is enabled
+    oappend(PSTR("gId('pixbtn').style.display='';"));
+  #endif
+  #if defined(WLED_ENABLE_PXMAGIC) && !defined(WLED_ENABLE_PIXART) // include only if PixelMagic tool is enabled - only when PixelArt is not enabled
+    oappend(PSTR("gId('pxmbtn').style.display='';"));
+  #endif
+  #if defined(WLED_ENABLE_PIXELFORGE) && !defined(WLED_DISABLE_PIXELFORGE) // include only if PixelForge is enabled
+    oappend(PSTR("gId('forgebtn').style.display='';"));
+  #endif
+
   }
 
   if (subPage == 1)


### PR DESCRIPTION
Backport of the new PixelForge by @Dedehai

<img width="330" height="167" alt="image" src="https://github.com/user-attachments/assets/9d2871cf-d083-4680-b2d8-0bd7705628bf" />
&nbsp; &nbsp;
<img width="534" height="341" alt="image" src="https://github.com/user-attachments/assets/68dfaba0-6df0-42b0-9b5e-1fb8d69c3996" />

<img width="762" height="904" alt="image" src="https://github.com/user-attachments/assets/4796a16c-c6f0-43b7-86e8-ad0939878b8a" />

<br/>

* [x] upgrade HTML build system
* [X] merge original PR from https://github.com/wled/WLED/pull/4982
* [x] some adaptations to make it work with 14.x API's

Additional Improvements
* [X] improved stability when several tasks try to draw/show leds in parallel
* [X] json de-serialializer: interlock added to prevent segment updates while strip.service() runs
* [X] json de-serialializer: reduced delay when updating presets (stip.service lock now released _before_ writing to presets.json)
* [x] UDP realtime streaming: small speedup, improved stability and prevent "broken frames".

toDo:
* [-] Make "scrolling text" tab work - adjustment to [reflect available tags](https://github.com/MoonModules/WLED-MM/blob/5deaf92373263c89ba330dd35177594217a00822/wled00/FX.cpp#L6907-L6945); also add ``#FPS``, ``#AMP``, ``#ERR``
   -> postponed. Back-porting the relevant upstream "scrolling text" part will come later in a separate PR.  
* [X] test if "other tools" work
   -> PixelPaint works, but refuses to accept more than 128 pixels in one dimension
   -> PixelMagic has known incompatibilities with WLED-MM (large image presets cause error message)
   -> we could add an additional download link for VideoLab (beta)
* [x] test with VideoLab output (DDP over ws)
* [x] more testing


## Known Issues and Caveats

### WebUI HTML build system:
* If you see strange "file read errors" - make sure your working folder path does not have any ``#`` characters. For example, i was working in ``C:\Users\frank\Arduino\#ESP32\MoonModules\WLED-MM``, had to rename ``#ESP32`` to ``ESP32`` to get npm run build working
* If you see compile errors, delete all ``html_*.h`` files, to force re-generation
* if "npm install" or "npm run build" still abort with errors, try to delete the content of your npm-cache folder (e.g. ``C:\Users\frank\AppData\Local\npm-cache``)

### other
* options in the "scrolling text" tab only work in upstream, but the syntax in WLED-MM is still based on 0.14.x. Need to adjust this later, or maybe we'll backport the upstream scrolling text code in a new PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds PixelForge, Pixel Magic and PixArt web tools with image/GIF editor, gallery, upload, preview and preset export; GIF encode/decode support and new PixelForge page.

* **Tests**
  * Adds Node.js test suite covering UI build tooling and incremental rebuild behavior.

* **Style**
  * Externalized stylesheet, improved button hover/transition effects and accessibility titles.

* **Refactor**
  * Modernized frontend build/minification and integrated UI build into device build process.

* **Chores**
  * Updated package metadata, added test script and now requires Node ≥20.

* **Stability**
  * Improved runtime synchronization, file-write locking, build validation and realtime/cache robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->