### PR TITLE
disable SPC optimizations when outputs overlap (solves #296)

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1318,8 +1318,8 @@ int BusManager::add(BusConfig &bc) {
     }
   }
   // if some busses overlap, we disable the bus caching optimization to allow multiple outputs for the same pixel
-  if (foundOverlap) { overlapingBusses = true; slowMode = true; }
-  if (numBusses < 1) { overlapingBusses = false; slowMode = false; }
+  if (foundOverlap) { overlappingBusses = true; slowMode = true; }
+  if (numBusses < 1) { overlappingBusses = false; slowMode = false; }
   USER_PRINT(slowMode ? "busses are in SlowMode\n" : "");
   return numBusses++;
 }
@@ -1340,7 +1340,7 @@ void BusManager::removeAll() {
   laststart = 0;
   lastlen = 0;
   slowMode = false;
-  overlapingBusses = false;
+  overlappingBusses = false;
 }
 
 void __attribute__((hot)) BusManager::show() {

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1323,7 +1323,6 @@ int BusManager::add(BusConfig &bc) {
   if (foundOverlap) { overlappingBusses = true; slowMode = true; }
   if (numBusses < 1) { overlappingBusses = false; slowMode = false; }
   USER_PRINT(slowMode && (lastSlowMode != slowMode) ? F("Warning: Outputs set to SlowMode, due to overlapping bus start indices!\n") : F("")); // only print message once when we switch over to slow mode
-#endif
   return numBusses++;
 }
 

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1313,7 +1313,7 @@ int BusManager::add(BusConfig &bc) {
       // see https://stackoverflow.com/questions/3269434/whats-the-most-efficient-way-to-test-if-two-ranges-overlap
       if ((newStart <= theEnd) && (theStart <= newEnd)) {  // catches all overlap scenarios - including "new is including (around) another range"
         foundOverlap = true;  
-        USER_PRINTF("bus %u[%u %u] overlaps with\t%u [%u %u]", numBusses, newStart, newEnd, i, theStart, theEnd);
+        USER_PRINTF("bus %u[%u %u] overlaps with\t%u [%u %u]\n", numBusses, newStart, newEnd, i, theStart, theEnd);
       }
     }
   }

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1295,14 +1295,13 @@ int BusManager::add(BusConfig &bc) {
 
   Bus *newBus = busses[numBusses];
   if (newBus == nullptr) return numBusses; // WLEDMM early exit if bus creation failed
-
-  unsigned newStart = newBus->getStart();
-  unsigned newLen = newBus->getLength();
-  unsigned newEnd = (newLen > 0) ? newStart + newLen - 1 : newStart; // handle zero-length edge case (only happens when bus could not initialize)
   // WLEDMM check if added bus overlaps with any existing bus
   bool foundOverlap = false;
   unsigned busCount = getNumBusses();
-  if (newBus != nullptr && newBus->isOk()) {
+  if (newBus->isOk()) {
+    unsigned newStart = newBus->getStart();
+    unsigned newLen = newBus->getLength();
+    unsigned newEnd = (newLen > 0) ? newStart + newLen - 1 : newStart; // handle zero-length edge case (only happens when bus could not initialize)
     for (unsigned i=0; i<busCount; i++) {
       if (i == numBusses) continue; // skip self - should not happen
       Bus *theBus = getBus(i);

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1309,7 +1309,8 @@ int BusManager::add(BusConfig &bc) {
       if (!theBus->isOk()) continue;
       // check for overlap
       unsigned theStart = theBus->getStart();
-      unsigned theEnd = theStart + theBus->getLength() - 1;
+      unsigned theLen = theBus->getLength();
+      unsigned theEnd = (theLen > 0) ? theStart + theLen - 1 : theStart;
       // see https://stackoverflow.com/questions/3269434/whats-the-most-efficient-way-to-test-if-two-ranges-overlap
       if ((newStart <= theEnd) && (theStart <= newEnd)) {  // catches all overlap scenarios - including "new is including (around) another range"
         foundOverlap = true;  

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1297,7 +1297,8 @@ int BusManager::add(BusConfig &bc) {
   if (newBus == nullptr) return numBusses; // WLEDMM early exit if bus creation failed
 
   unsigned newStart = newBus->getStart();
-  unsigned newEnd = newStart + max(newBus->getLength() - 1, 0); // "max" needed for single-pixel busses
+  unsigned newLen = newBus->getLength();
+  unsigned newEnd = (newLen > 0) ? newStart + newLen - 1 : newStart; // handle zero-length edge case (only happens when bus could not initialize)
   // WLEDMM check if added bus overlaps with any existing bus
   bool foundOverlap = false;
   unsigned busCount = getNumBusses();

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1293,10 +1293,11 @@ int BusManager::add(BusConfig &bc) {
     busses[numBusses] = new BusPwm(bc);
   }
 
-  // WLEDMM ToDO
   Bus *newBus = busses[numBusses];
+  if (newBus == nullptr) return numBusses; // WLEDMM early exit if bus creation failed
+
   unsigned newStart = newBus->getStart();
-  unsigned newEnd = newStart + newBus->getLength() - 1;
+  unsigned newEnd = newStart + max(newBus->getLength() - 1, 0); // "max" needed for single-pixel busses
   // WLEDMM check if added bus overlaps with any existing bus
   bool foundOverlap = false;
   unsigned busCount = getNumBusses();

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1272,7 +1272,6 @@ int BusManager::add(BusConfig &bc) {
   lastlen = 0;
   laststart = 0;
   lastBus = nullptr;
-  slowMode = false;
 
   DEBUG_PRINTF("BusManager::add(bc.type=%u)\n", bc.type);
   if (bc.type >= TYPE_NET_DDP_RGB && bc.type < 96) {
@@ -1293,6 +1292,34 @@ int BusManager::add(BusConfig &bc) {
   } else {
     busses[numBusses] = new BusPwm(bc);
   }
+
+  // WLEDMM ToDO
+  Bus *newBus = busses[numBusses];
+  unsigned newStart = newBus->getStart();
+  unsigned newEnd = newStart + newBus->getLength() - 1;
+  // WLEDMM check if added bus overlaps with any existing bus
+  bool foundOverlap = false;
+  unsigned busCount = getNumBusses();
+  if (newBus != nullptr && newBus->isOk()) {
+    for (unsigned i=0; i<busCount; i++) {
+      if (i == numBusses) continue; // skip self - should not happen
+      Bus *theBus = getBus(i);
+      if (theBus == nullptr) continue;
+      if (!theBus->isOk()) continue;
+      // check for overlap
+      unsigned theStart = theBus->getStart();
+      unsigned theEnd = theStart + theBus->getLength() - 1;
+      // see https://stackoverflow.com/questions/3269434/whats-the-most-efficient-way-to-test-if-two-ranges-overlap
+      if ((newStart <= theEnd) && (theStart <= newEnd)) {  // catches all overlap scenarios - including "new is including (around) another range"
+        foundOverlap = true;  
+        USER_PRINTF("bus %u[%u %u] overlaps with\t%u [%u %u]", numBusses, newStart, newEnd, i, theStart, theEnd);
+      }
+    }
+  }
+  // if some busses overlap, we disable the bus caching optimization to allow multiple outputs for the same pixel
+  if (foundOverlap) { overlapingBusses = true; slowMode = true; }
+  if (numBusses < 1) { overlapingBusses = false; slowMode = false; }
+  USER_PRINT(slowMode ? "busses are in SlowMode\n" : "");
   return numBusses++;
 }
 
@@ -1312,6 +1339,7 @@ void BusManager::removeAll() {
   laststart = 0;
   lastlen = 0;
   slowMode = false;
+  overlapingBusses = false;
 }
 
 void __attribute__((hot)) BusManager::show() {
@@ -1431,7 +1459,7 @@ uint32_t IRAM_ATTR  __attribute__((hot)) BusManager::getPixelColorRestored(uint_
 
 bool BusManager::canAllShow() const {
   for (uint8_t i = 0; i < numBusses; i++) {
-    if (!busses[i]->canShow()) return false;
+    if ((busses[i]->isOk()) && !busses[i]->canShow()) return false;
   }
   return true;
 }

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1272,6 +1272,7 @@ int BusManager::add(BusConfig &bc) {
   lastlen = 0;
   laststart = 0;
   lastBus = nullptr;
+  bool lastSlowMode = slowMode;
 
   DEBUG_PRINTF("BusManager::add(bc.type=%u)\n", bc.type);
   if (bc.type >= TYPE_NET_DDP_RGB && bc.type < 96) {
@@ -1314,14 +1315,15 @@ int BusManager::add(BusConfig &bc) {
       // see https://stackoverflow.com/questions/3269434/whats-the-most-efficient-way-to-test-if-two-ranges-overlap
       if ((newStart <= theEnd) && (theStart <= newEnd)) {  // catches all overlap scenarios - including "new is including (around) another range"
         foundOverlap = true;  
-        USER_PRINTF("bus %u[%u %u] overlaps with\t%u [%u %u]\n", numBusses, newStart, newEnd, i, theStart, theEnd);
+        DEBUG_PRINTF("bus %u[%u %u] overlaps with\t%u [%u %u]\n", numBusses, newStart, newEnd, i, theStart, theEnd);
       }
     }
   }
   // if some busses overlap, we disable the bus caching optimization to allow multiple outputs for the same pixel
   if (foundOverlap) { overlappingBusses = true; slowMode = true; }
   if (numBusses < 1) { overlappingBusses = false; slowMode = false; }
-  USER_PRINT(slowMode ? "busses are in SlowMode\n" : "");
+  USER_PRINT(slowMode && (lastSlowMode != slowMode) ? F("Warning: Outputs set to SlowMode, due to overlapping bus start indices!\n") : F("")); // only print message once when we switch over to slow mode
+#endif
   return numBusses++;
 }
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -373,7 +373,7 @@ class BusNetwork : public Bus {
       return _artnet_leds_per_output;
     }
 
-    void setColorOrder(uint8_t colorOrder);
+    void setColorOrder(uint8_t colorOrder); // ??? not implemented???
 
     uint8_t getColorOrder() const override {
       return _colorOrder;
@@ -464,7 +464,7 @@ class BusManager {
       lastBus = nullptr;
       laststart = 0;
       lastlen= 0;
-      slowMode = isRTMode;
+      if (isRTMode || !overlapingBusses) slowMode = isRTMode; // don't reset slowMode if we have overlaping busses
     }
 
     void setStatusPixel(uint32_t c);
@@ -507,6 +507,7 @@ class BusManager {
     unsigned laststart = 0;
     unsigned lastlen = 0;
     bool slowMode = false; // WLEDMM not sure why we need this. But its necessary.
+    bool overlapingBusses = false; // WLEDMM needed to enforce "slowMode" when busses overlap (=custom bus start indices)
 
     inline uint8_t getNumVirtualBusses() const {
       int j = 0;

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -464,7 +464,7 @@ class BusManager {
       lastBus = nullptr;
       laststart = 0;
       lastlen= 0;
-      if (isRTMode || !overlapingBusses) slowMode = isRTMode; // don't reset slowMode if we have overlaping busses
+      if (isRTMode || !overlappingBusses) slowMode = isRTMode; // don't reset slowMode if we have overlaping busses
     }
 
     void setStatusPixel(uint32_t c);
@@ -507,7 +507,7 @@ class BusManager {
     unsigned laststart = 0;
     unsigned lastlen = 0;
     bool slowMode = false; // WLEDMM not sure why we need this. But its necessary.
-    bool overlapingBusses = false; // WLEDMM needed to enforce "slowMode" when busses overlap (=custom bus start indices)
+    bool overlappingBusses = false; // WLEDMM needed to enforce "slowMode" when busses overlap (=custom bus start indices)
 
     inline uint8_t getNumVirtualBusses() const {
       int j = 0;


### PR DESCRIPTION
Support for "custom bus indices" that lead to overlaping output pixel ranges.

With overlapping outputs, MM specific optimizations in busses.setPixelColor() need to be disabled -  a single sPC must be forwarded to all busses. gPC can stay in optimized mode, because each possible bus pixel will have the same value.

Solves #296

Important: "slowmode" will cost performance, especially when you have many output pins with a large number of LEDs per pin!
In a test with esp32, 8 outputs with 512 LEDs each, performance dropped from 40fps to 30fps in "slowmode".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of overlapping LED bus address ranges; system enters SlowMode and logs a warning when overlaps are found.

* **Bug Fixes**
  * Overlap state now enforces SlowMode and is cleared when all buses are removed.
  * Visibility gating refined so only healthy buses that cannot display block overall visibility.
  * Bus creation failures now exit early to avoid further processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->