### PR TITLE
Feat: Segment masks

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -722,15 +722,15 @@ typedef struct Segment {
 #else
     inline uint16_t virtualLength(void) const {return _virtuallength;}
 #endif
-    inline bool hasMask(void) const { return _mask != nullptr; } // WLEDMM
-    inline bool maskAllows(uint16_t i) const { // WLEDMM
+    [[gnu::hot]] inline bool hasMask(void) const { return _mask != nullptr; } // WLEDMM
+    [[gnu::hot]] inline bool maskAllows(uint16_t i) const { // WLEDMM
       if (!_mask || !_maskValid) return true;
       if (size_t(i) >= _maskLen) return false;
       // WLEDMM: bit-packed mask (LSB-first): byte = i>>3, bit = i&7
       bool bit = (_mask[i >> 3] >> (i & 7)) & 0x01;
       return maskInvert ? !bit : bit;
     }
-    inline bool maskAllowsXY(int x, int y) const { // WLEDMM
+    [[gnu::hot]] inline bool maskAllowsXY(int x, int y) const { // WLEDMM
       if (!_mask || !_maskValid) return true;
       if (x < 0 || y < 0) return false;
       size_t idx = size_t(x) + (size_t(y) * _maskW);

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -454,8 +454,8 @@ typedef struct Segment {
     uint16_t startY;  // start Y coodrinate 2D (top); there should be no more than 255 rows, but we cannot be sure.
     uint16_t stopY;   // stop Y coordinate 2D (bottom); there should be no more than 255 rows, but we cannot be sure.
     char *name = nullptr; // WLEDMM initialize to nullptr
-    uint8_t maskId = 0;   // segment mask ID (0 = none)
-    bool maskInvert = false;
+    uint8_t maskId = 0;   // WLEDMM segment mask ID (0 = none)
+    bool maskInvert = false; // WLEDMM invert mask bits (useful for "outside" masks)
 
     // runtime data
     unsigned long next_time;  // millis() of next update
@@ -471,11 +471,11 @@ typedef struct Segment {
     void *jMap = nullptr; //WLEDMM jMap
 
   private:
-    uint8_t *_mask = nullptr;
-    uint16_t _maskW = 0;
-    uint16_t _maskH = 0;
-    size_t _maskLen = 0;        // number of mask bits (virtual pixels)
-    bool _maskValid = false;
+    uint8_t *_mask = nullptr;   // WLEDMM bit-packed mask, 1 bit per virtual pixel
+    uint16_t _maskW = 0;        // WLEDMM mask width in virtual pixels
+    uint16_t _maskH = 0;        // WLEDMM mask height in virtual pixels
+    size_t _maskLen = 0;        // WLEDMM total bits (w*h), not bytes
+    bool _maskValid = false;    // WLEDMM cached dimension check vs virtual size
 
     union {
       uint8_t  _capabilities;
@@ -726,6 +726,7 @@ typedef struct Segment {
     inline bool maskAllows(uint16_t i) const {
       if (!_mask || !_maskValid) return true;
       if (size_t(i) >= _maskLen) return false;
+      // WLEDMM: bit-packed mask (LSB-first): byte = i>>3, bit = i&7
       bool bit = (_mask[i >> 3] >> (i & 7)) & 0x01;
       return maskInvert ? !bit : bit;
     }
@@ -734,6 +735,7 @@ typedef struct Segment {
       if (x < 0 || y < 0) return false;
       size_t idx = size_t(x) + (size_t(y) * _maskW);
       if (idx >= _maskLen) return false;
+      // WLEDMM: row-major (x + y*w), bit-packed mask (LSB-first in each byte)
       bool bit = (_mask[idx >> 3] >> (idx & 7)) & 0x01;
       return maskInvert ? !bit : bit;
     }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -722,15 +722,15 @@ typedef struct Segment {
 #else
     inline uint16_t virtualLength(void) const {return _virtuallength;}
 #endif
-    [[gnu::hot]] inline bool hasMask(void) const { return _mask != nullptr; } // WLEDMM
-    [[gnu::hot]] inline bool maskAllows(uint16_t i) const { // WLEDMM
+    inline bool hasMask(void) const { return _mask != nullptr; } // WLEDMM
+    inline bool maskAllows(uint16_t i) const { // WLEDMM
       if (!_mask || !_maskValid) return true;
       if (size_t(i) >= _maskLen) return false;
       // WLEDMM: bit-packed mask (LSB-first): byte = i>>3, bit = i&7
       bool bit = (_mask[i >> 3] >> (i & 7)) & 0x01;
       return maskInvert ? !bit : bit;
     }
-    [[gnu::hot]] inline bool maskAllowsXY(int x, int y) const { // WLEDMM
+    inline bool maskAllowsXY(int x, int y) const { // WLEDMM
       if (!_mask || !_maskValid) return true;
       if (x < 0 || y < 0) return false;
       size_t idx = size_t(x) + (size_t(y) * _maskW);

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -454,6 +454,8 @@ typedef struct Segment {
     uint16_t startY;  // start Y coodrinate 2D (top); there should be no more than 255 rows, but we cannot be sure.
     uint16_t stopY;   // stop Y coordinate 2D (bottom); there should be no more than 255 rows, but we cannot be sure.
     char *name = nullptr; // WLEDMM initialize to nullptr
+    uint8_t maskId = 0;   // segment mask ID (0 = none)
+    bool maskInvert = false;
 
     // runtime data
     unsigned long next_time;  // millis() of next update
@@ -469,6 +471,12 @@ typedef struct Segment {
     void *jMap = nullptr; //WLEDMM jMap
 
   private:
+    uint8_t *_mask = nullptr;
+    uint16_t _maskW = 0;
+    uint16_t _maskH = 0;
+    size_t _maskLen = 0;        // number of mask bits (virtual pixels)
+    bool _maskValid = false;
+
     union {
       uint8_t  _capabilities;
       struct {
@@ -563,6 +571,8 @@ typedef struct Segment {
       startY(0),
       stopY(1),
       name(nullptr),
+      maskId(0),
+      maskInvert(false),
       next_time(0),
       step(0),
       call(0),
@@ -571,6 +581,11 @@ typedef struct Segment {
       data(nullptr),
       ledsrgb(nullptr),
       ledsrgbSize(0), //WLEDMM
+      _mask(nullptr),
+      _maskW(0),
+      _maskH(0),
+      _maskLen(0),
+      _maskValid(false),
       _capabilities(0),
       _dataLen(0),
       _t(nullptr)
@@ -612,6 +627,7 @@ typedef struct Segment {
       if ((Segment::_globalLeds == nullptr) && !strip_uses_global_leds() && (ledsrgb != nullptr)) {free(ledsrgb); ledsrgb = nullptr;}  // WLEDMM we need "!strip_uses_global_leds()" to avoid crashes (#104)
       if (name) { delete[] name; name = nullptr; }
       if (_t)   { transitional = false; delete _t; _t = nullptr; }
+      clearMask();
       deallocateData();
     }
 
@@ -666,6 +682,8 @@ typedef struct Segment {
     inline void markForReset(void) { reset = true; }  // setOption(SEG_OPTION_RESET, true)
     inline void markForBlank(void) { needsBlank = true; } // WLEDMM serialize "blank" requests, avoid parallel drawing from different task
     void setUpLeds(void);   // set up leds[] array for loseless getPixelColor()
+    bool setMask(uint8_t id);
+    void clearMask();
 
     // transition functions
     void     startTransition(uint16_t dur); // transition has to start before actual segment values change
@@ -704,6 +722,21 @@ typedef struct Segment {
 #else
     inline uint16_t virtualLength(void) const {return _virtuallength;}
 #endif
+    inline bool hasMask(void) const { return _mask != nullptr; }
+    inline bool maskAllows(uint16_t i) const {
+      if (!_mask || !_maskValid) return true;
+      if (size_t(i) >= _maskLen) return false;
+      bool bit = (_mask[i >> 3] >> (i & 7)) & 0x01;
+      return maskInvert ? !bit : bit;
+    }
+    inline bool maskAllowsXY(int x, int y) const {
+      if (!_mask || !_maskValid) return true;
+      if (x < 0 || y < 0) return false;
+      size_t idx = size_t(x) + (size_t(y) * _maskW);
+      if (idx >= _maskLen) return false;
+      bool bit = (_mask[idx >> 3] >> (idx & 7)) & 0x01;
+      return maskInvert ? !bit : bit;
+    }
     void setPixelColor(int n, uint32_t c); // set relative pixel within segment with color
     inline void setPixelColor(int n, byte r, byte g, byte b, byte w = 0) { setPixelColor(n, RGBW32(r,g,b,w)); } // automatically inline
     inline void setPixelColor(int n, CRGB c)                             { setPixelColor(n, uint32_t(c) & 0x00FFFFFF); } // automatically inline
@@ -1044,7 +1077,8 @@ class WS2812FX {  // 96 bytes
       fixInvalidSegments(),
       show(void),
       setTargetFps(uint8_t fps),
-      enumerateLedmaps(); //WLEDMM (from fcn_declare)
+      enumerateLedmaps(), //WLEDMM (from fcn_declare)
+      enumerateSegmasks();
 
     void setColor(uint8_t slot, uint8_t r, uint8_t g, uint8_t b, uint8_t w = 0) { setColor(slot, RGBW32(r,g,b,w)); }
     void fill(uint32_t c) { for (int i = 0; i < getLengthTotal(); i++) setPixelColor(i, c); } // fill whole strip with color (inline)

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -571,8 +571,8 @@ typedef struct Segment {
       startY(0),
       stopY(1),
       name(nullptr),
-      maskId(0),
-      maskInvert(false),
+      maskId(0), // WLEDMM
+      maskInvert(false), // WLEDMM
       next_time(0),
       step(0),
       call(0),
@@ -581,11 +581,11 @@ typedef struct Segment {
       data(nullptr),
       ledsrgb(nullptr),
       ledsrgbSize(0), //WLEDMM
-      _mask(nullptr),
-      _maskW(0),
-      _maskH(0),
-      _maskLen(0),
-      _maskValid(false),
+      _mask(nullptr), // WLEDMM
+      _maskW(0), // WLEDMM
+      _maskH(0), // WLEDMM
+      _maskLen(0), // WLEDMM
+      _maskValid(false), // WLEDMM
       _capabilities(0),
       _dataLen(0),
       _t(nullptr)
@@ -627,7 +627,7 @@ typedef struct Segment {
       if ((Segment::_globalLeds == nullptr) && !strip_uses_global_leds() && (ledsrgb != nullptr)) {free(ledsrgb); ledsrgb = nullptr;}  // WLEDMM we need "!strip_uses_global_leds()" to avoid crashes (#104)
       if (name) { delete[] name; name = nullptr; }
       if (_t)   { transitional = false; delete _t; _t = nullptr; }
-      clearMask();
+      clearMask(); // WLEDMM
       deallocateData();
     }
 
@@ -682,8 +682,8 @@ typedef struct Segment {
     inline void markForReset(void) { reset = true; }  // setOption(SEG_OPTION_RESET, true)
     inline void markForBlank(void) { needsBlank = true; } // WLEDMM serialize "blank" requests, avoid parallel drawing from different task
     void setUpLeds(void);   // set up leds[] array for loseless getPixelColor()
-    bool setMask(uint8_t id);
-    void clearMask();
+    bool setMask(uint8_t id); // WLEDMM
+    void clearMask(); // WLEDMM
 
     // transition functions
     void     startTransition(uint16_t dur); // transition has to start before actual segment values change
@@ -722,15 +722,15 @@ typedef struct Segment {
 #else
     inline uint16_t virtualLength(void) const {return _virtuallength;}
 #endif
-    inline bool hasMask(void) const { return _mask != nullptr; }
-    inline bool maskAllows(uint16_t i) const {
+    inline bool hasMask(void) const { return _mask != nullptr; } // WLEDMM
+    inline bool maskAllows(uint16_t i) const { // WLEDMM
       if (!_mask || !_maskValid) return true;
       if (size_t(i) >= _maskLen) return false;
       // WLEDMM: bit-packed mask (LSB-first): byte = i>>3, bit = i&7
       bool bit = (_mask[i >> 3] >> (i & 7)) & 0x01;
       return maskInvert ? !bit : bit;
     }
-    inline bool maskAllowsXY(int x, int y) const {
+    inline bool maskAllowsXY(int x, int y) const { // WLEDMM
       if (!_mask || !_maskValid) return true;
       if (x < 0 || y < 0) return false;
       size_t idx = size_t(x) + (size_t(y) * _maskW);
@@ -1080,7 +1080,7 @@ class WS2812FX {  // 96 bytes
       show(void),
       setTargetFps(uint8_t fps),
       enumerateLedmaps(), //WLEDMM (from fcn_declare)
-      enumerateSegmasks();
+      enumerateSegmasks(); // WLEDMM
 
     void setColor(uint8_t slot, uint8_t r, uint8_t g, uint8_t b, uint8_t w = 0) { setColor(slot, RGBW32(r,g,b,w)); }
     void fill(uint32_t c) { for (int i = 0; i < getLengthTotal(); i++) setPixelColor(i, c); } // fill whole strip with color (inline)

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -254,7 +254,7 @@ void Segment::startFrame(void) {
 // * expects scaled color (final brightness) as additional input parameter, plus segment  virtualWidth() and virtualHeight()
 void IRAM_ATTR __attribute__((hot)) Segment::setPixelColorXY_fast(int x, int y, uint32_t col, uint32_t scaled_col, int cols, int rows) const //WLEDMM
 {
-  if (!maskAllowsXY(x, y)) return; // WLEDMM mask gate for 2D pixels
+  if (_maskValid && !maskAllowsXY(x, y)) return; // WLEDMM mask gate for 2D pixels
   unsigned i = UINT_MAX;
   bool sameColor = false;
   if (ledsrgb) { // WLEDMM small optimization
@@ -311,7 +311,7 @@ void IRAM_ATTR_YN Segment::setPixelColorXY(int x, int y, uint32_t col) //WLEDMM:
   const int_fast16_t rows = virtualHeight();
 
   if (x<0 || y<0 || x >= cols || y >= rows) return;  // if pixel would fall out of virtual segment just exit
-  if (!maskAllowsXY(x, y)) return; // WLEDMM mask gate for 2D pixels
+  if (_maskValid && !maskAllowsXY(x, y)) return; // WLEDMM mask gate for 2D pixels
 
   unsigned i = UINT_MAX;
   bool sameColor = false;

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -234,6 +234,14 @@ void Segment::startFrame(void) {
   _2dWidth    = _isValid2D ? calc_virtualWidth() : calc_virtualLength();
   _virtuallength = calc_virtualLength();
 #endif
+
+  if (_mask) {
+    uint16_t vW = calc_virtualWidth();
+    uint16_t vH = calc_virtualHeight();
+    _maskValid = (_maskW == vW && _maskH == vH);
+  } else {
+    _maskValid = false;
+  }
 }
 // WLEDMM end
 
@@ -245,6 +253,7 @@ void Segment::startFrame(void) {
 // * expects scaled color (final brightness) as additional input parameter, plus segment  virtualWidth() and virtualHeight()
 void IRAM_ATTR __attribute__((hot)) Segment::setPixelColorXY_fast(int x, int y, uint32_t col, uint32_t scaled_col, int cols, int rows) const //WLEDMM
 {
+  if (!maskAllowsXY(x, y)) return;
   unsigned i = UINT_MAX;
   bool sameColor = false;
   if (ledsrgb) { // WLEDMM small optimization
@@ -301,6 +310,7 @@ void IRAM_ATTR_YN Segment::setPixelColorXY(int x, int y, uint32_t col) //WLEDMM:
   const int_fast16_t rows = virtualHeight();
 
   if (x<0 || y<0 || x >= cols || y >= rows) return;  // if pixel would fall out of virtual segment just exit
+  if (!maskAllowsXY(x, y)) return;
 
   unsigned i = UINT_MAX;
   bool sameColor = false;

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -253,7 +253,7 @@ void Segment::startFrame(void) {
 // * expects scaled color (final brightness) as additional input parameter, plus segment  virtualWidth() and virtualHeight()
 void IRAM_ATTR __attribute__((hot)) Segment::setPixelColorXY_fast(int x, int y, uint32_t col, uint32_t scaled_col, int cols, int rows) const //WLEDMM
 {
-  if (!maskAllowsXY(x, y)) return;
+  if (!maskAllowsXY(x, y)) return; // WLEDMM mask gate for 2D pixels
   unsigned i = UINT_MAX;
   bool sameColor = false;
   if (ledsrgb) { // WLEDMM small optimization
@@ -310,7 +310,7 @@ void IRAM_ATTR_YN Segment::setPixelColorXY(int x, int y, uint32_t col) //WLEDMM:
   const int_fast16_t rows = virtualHeight();
 
   if (x<0 || y<0 || x >= cols || y >= rows) return;  // if pixel would fall out of virtual segment just exit
-  if (!maskAllowsXY(x, y)) return;
+  if (!maskAllowsXY(x, y)) return; // WLEDMM mask gate for 2D pixels
 
   unsigned i = UINT_MAX;
   bool sameColor = false;

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -235,6 +235,7 @@ void Segment::startFrame(void) {
   _virtuallength = calc_virtualLength();
 #endif
 
+  // WLEDMM validate mask dimensions against current virtual size
   if (_mask) {
     uint16_t vW = calc_virtualWidth();
     uint16_t vH = calc_virtualHeight();

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -95,6 +95,11 @@ Segment::Segment(const Segment &orig) {
   data = nullptr;
   _dataLen = 0;
   _t = nullptr;
+  _mask = nullptr;
+  _maskLen = 0;
+  _maskW = 0;
+  _maskH = 0;
+  _maskValid = false;
   if (ledsrgb && !Segment::_globalLeds) {ledsrgb = nullptr; ledsrgbSize = 0;}  // WLEDMM
   if (orig.name) { name = new(std::nothrow) char[strlen(orig.name)+1]; if (name) strcpy(name, orig.name); }
   if (orig.data) { if (allocateData(orig._dataLen, true)) memcpy(data, orig.data, orig._dataLen); }
@@ -142,6 +147,117 @@ void Segment::allocLeds() {
   }
 }
 
+void Segment::clearMask() {
+  if (_mask) {
+    free(_mask);
+    _mask = nullptr;
+  }
+  _maskLen = 0;
+  _maskW = 0;
+  _maskH = 0;
+  _maskValid = false;
+}
+
+bool Segment::setMask(uint8_t id) {
+  clearMask();
+  maskId = id;
+  if (id >= WLED_MAX_SEGMASKS) {
+    maskId = 0;
+    return false;
+  }
+  if (id == 0) return true;
+
+  char fileName[24] = {'\0'};
+  snprintf_P(fileName, sizeof(fileName), PSTR("/segmask%d.json"), id);
+  if (!WLED_FS.exists(fileName)) {
+    USER_PRINTF("Segment mask missing: %s\n", fileName);
+    return false;
+  }
+
+  File f = WLED_FS.open(fileName, "r");
+  if (!f) return false;
+
+  uint16_t w = 0;
+  uint16_t h = 0;
+  size_t bitLen = 0;
+  uint8_t* bits = nullptr;
+  bool inv = maskInvert;
+  bool ok = false;
+
+  do {
+    char buf[32] = { '\0' };
+    if (!f.find("\"w\":")) break;
+    f.readBytesUntil('\n', buf, sizeof(buf)-1);
+    w = atoi(cleanUpName(buf));
+
+    f.seek(0);
+    if (!f.find("\"h\":")) break;
+    memset(buf, 0, sizeof(buf));
+    f.readBytesUntil('\n', buf, sizeof(buf)-1);
+    h = atoi(cleanUpName(buf));
+
+    if (w == 0 || h == 0) break;
+    bitLen = size_t(w) * size_t(h);
+    if (bitLen == 0 || bitLen > (size_t(Segment::maxWidth) * size_t(Segment::maxHeight))) break;
+
+    size_t byteLen = (bitLen + 7) / 8;
+    bits = (uint8_t*)calloc(byteLen, 1);
+    if (!bits) {
+      errorFlag = ERR_LOW_MEM; // WLEDMM raise errorflag
+      break;
+    }
+
+    f.seek(0);
+    if (f.find("\"inv\":")) {
+      String entry = f.readStringUntil(',');
+      int end = entry.indexOf('}');
+      if (end >= 0) entry.remove(end);
+      entry.trim();
+      if (entry == "true") inv = true;
+      else if (entry == "false") inv = false;
+      else break;
+    }
+
+    f.seek(0);
+    if (!f.find("\"mask\":")) break;
+    f.readBytesUntil('[', buf, sizeof(buf)-1);
+
+    size_t i = 0;
+    bool endOfArray = false;
+    bool parsedOk = true;
+    do {
+      String entry = f.readStringUntil(',');
+      int bracket = entry.indexOf(']');
+      if (bracket >= 0) {
+        entry.remove(bracket);
+        endOfArray = true;
+      }
+      entry.trim();
+      if (entry.length() == 0) { parsedOk = false; break; }
+      if (i >= bitLen) { parsedOk = false; break; }
+      if (entry == "1") bits[i >> 3] |= (0x01U << (i & 7));
+      else if (entry != "0") { parsedOk = false; break; }
+      i++;
+      if (i > bitLen) { parsedOk = false; break; }
+    } while (f.available() && !endOfArray);
+
+    if (!parsedOk || !endOfArray || i != bitLen) break;
+
+    _mask = bits;
+    bits = nullptr;
+    _maskW = w;
+    _maskH = h;
+    _maskLen = bitLen;
+    maskInvert = inv;
+    _maskValid = (_maskW == calc_virtualWidth() && _maskH == calc_virtualHeight());
+    ok = true;
+  } while (false);
+
+  if (!ok && bits) free(bits);
+  f.close();
+  return ok;
+}
+
 // move constructor --> moves everything (including buffer) from orig to this
 Segment::Segment(Segment &&orig) noexcept {
   DEBUG_PRINTLN(F("-- Move segment constructor --"));
@@ -163,6 +279,11 @@ Segment::Segment(Segment &&orig) noexcept {
   orig.ledsrgb = nullptr; //WLEDMM
   orig.ledsrgbSize = 0;   // WLEDMM
   orig.jMap = nullptr;    //WLEDMM jMap
+  orig._mask = nullptr;
+  orig._maskLen = 0;
+  orig._maskW = 0;
+  orig._maskH = 0;
+  orig._maskValid = false;
 }
 
 // copy assignment --> overwrite segment with orig - deletes old buffers in "this", but does not change orig!
@@ -173,6 +294,7 @@ Segment& Segment::operator= (const Segment &orig) {
     transitional = false; // copied segment cannot be in transition
     if (name) delete[] name;
     if (_t)   delete _t;
+    clearMask();
     CRGB* oldLeds = ledsrgb;
     size_t oldLedsSize = ledsrgbSize;
     if (ledsrgb && !Segment::_globalLeds) free(ledsrgb);
@@ -191,6 +313,11 @@ Segment& Segment::operator= (const Segment &orig) {
     data = nullptr;
     _dataLen = 0;
     _t = nullptr;
+    _mask = nullptr;
+    _maskLen = 0;
+    _maskW = 0;
+    _maskH = 0;
+    _maskValid = false;
     //if (!Segment::_globalLeds) {ledsrgb = oldLeds; ledsrgbSize = oldLedsSize;}; // WLEDMM reuse leds instead of ledsrgb = nullptr;
     if (!Segment::_globalLeds) {ledsrgb = nullptr; ledsrgbSize = 0;};             // WLEDMM copy has no buffers (yet)
     // copy source data
@@ -211,6 +338,7 @@ Segment& Segment::operator= (Segment &&orig) noexcept {
     transitional = false; // just temporary
     if (name) { delete[] name; name = nullptr; } // free old name
     deallocateData(); // free old runtime data
+    clearMask();
     if (_t) { delete _t; _t = nullptr; }
     if (ledsrgb && !Segment::_globalLeds) free(ledsrgb); //WLEDMM: not needed anymore as we will use leds from copy. no need to nullify ledsrgb as it gets new value in memcpy
 
@@ -230,6 +358,11 @@ Segment& Segment::operator= (Segment &&orig) noexcept {
     orig.ledsrgb = nullptr;  //WLEDMM: do not free as moved to here
     orig.ledsrgbSize = 0;    //WLEDMM
     orig.jMap = nullptr; //WLEDMM jMap
+    orig._mask = nullptr;
+    orig._maskLen = 0;
+    orig._maskW = 0;
+    orig._maskH = 0;
+    orig._maskValid = false;
   }
   return *this;
 }
@@ -1001,6 +1134,8 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
   i &= 0xFFFF;
   if (unsigned(i) >= virtualLength()) return;  // if pixel would fall out of segment just exit //WLEDMM unsigned(i)>SEGLEN also catches "i<0"
 
+  if ((Segment::maxHeight == 1) && !maskAllows(i)) return;
+
 #ifndef WLED_DISABLE_2D
   if (is2D()) {
     uint16_t vH = virtualHeight();  // segment height in logical pixels
@@ -1397,6 +1532,8 @@ uint8_t Segment::differs(Segment& b) const {
   if (check3 != b.check3)       d |= SEG_DIFFERS_FX;
   if (startY != b.startY)       d |= SEG_DIFFERS_BOUNDS;
   if (stopY != b.stopY)         d |= SEG_DIFFERS_BOUNDS;
+  if (maskId != b.maskId)       d |= SEG_DIFFERS_OPT;
+  if (maskInvert != b.maskInvert) d |= SEG_DIFFERS_OPT;
 
   //bit pattern: (msb first) set:2, sound:1, mapping:3, transposed, mirrorY, reverseY, [transitional, reset,] paused, mirrored, on, reverse, [selected]
   if ((options & 0b1111111110011110U) != (b.options & 0b1111111110011110U)) d |= SEG_DIFFERS_OPT;
@@ -1791,6 +1928,16 @@ void WS2812FX::enumerateLedmaps() {
   }
 }
 
+// enumerate all segmaskX.json files on FS
+void WS2812FX::enumerateSegmasks() {
+  segMasks = 0;
+  for (int i = 1; i < WLED_MAX_SEGMASKS; i++) {
+    char fileName[24] = {'\0'};
+    snprintf_P(fileName, sizeof(fileName), PSTR("/segmask%d.json"), i);
+    if (WLED_FS.exists(fileName)) segMasks |= 1 << i;
+  }
+}
+
 
 //do not call this method from system context (network callback)
 void WS2812FX::finalizeInit(void)
@@ -1806,6 +1953,7 @@ void WS2812FX::finalizeInit(void)
   // if we do it in json.cpp (serializeInfo()) we are getting flashes on LEDs
   // unfortunately this means we do not get updates after uploads
   enumerateLedmaps();
+  enumerateSegmasks();
 
   _hasWhiteChannel = _isOffRefreshRequired = false;
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -59,7 +59,7 @@ WLED_create_spinlock(ledsrgb_mux); // to protect deleting Segment::_globalLeds a
 // WLEDMM experimental . this is a "C style" wrapper for strip.waitUntilIdle();
 // This workaround is just needed for the segment class, that does't know about "strip"
 void strip_wait_until_idle(String whoCalledMe) {
-#if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_PROTECT_SERVICE)  // WLEDMM experimental 
+#if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_PROTECT_SERVICE)  // WLEDMM experimental
   if (strip.isServicing() && (strncmp(pcTaskGetTaskName(NULL), "loopTask", 8) != 0)) { // if we are in looptask (arduino loop), its safe to proceed without waiting
   DEBUG_PRINTLN(whoCalledMe + String(": strip is still drawing effects."));
   strip.waitUntilIdle();
@@ -405,7 +405,7 @@ bool Segment::allocateData(size_t len, bool allowOverdraft) {  // WLEDMM allowOv
   if (!data) {
       _dataLen = 0; // WLEDMM reset dataLen
       if ((errorFlag != ERR_LOW_MEM) && (errorFlag != ERR_LOW_SEG_MEM)) { // spam filter
-        USER_PRINT(F("Segment::allocateData: FAILED to allocate ")); 
+        USER_PRINT(F("Segment::allocateData: FAILED to allocate "));
         USER_PRINT(len); USER_PRINTLN(F(" bytes."));
       }
       errorFlag = ERR_LOW_MEM; // WLEDMM raise errorflag
@@ -593,7 +593,7 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) c
     case 71: //WLEDMM netmindz ar palette +1
     case 72: //WLEDMM netmindz ar palette +2
     case 73: //WLEDMM netmindz ar palette +3
-        targetPalette.loadDynamicGradientPalette(getAudioPalette(pal)); break; 
+        targetPalette.loadDynamicGradientPalette(getAudioPalette(pal)); break;
     default: //progmem palettes
       if (pal>245) {
         targetPalette = strip.customPalettes[255-pal]; // we checked bounds above
@@ -903,7 +903,7 @@ class JMapC {
         return 0;
     }
   private:
-    std::vector<ArrayAndSize> jVectorMap; 
+    std::vector<ArrayAndSize> jVectorMap;
     StaticJsonDocument<4096> docChunk; //must fit forks with about 32 points each
     uint8_t scale=1;
 
@@ -931,7 +931,7 @@ class JMapC {
           DeserializationError err = deserializeJson(docChunk, jMapFile);
           // serializeJson(docChunk, Serial); USER_PRINTLN();
           // USER_PRINTF("docChunk  %u / %u%% (%u %u %u) %u\n", (unsigned int)docChunk.memoryUsage(), 100 * docChunk.memoryUsage() / docChunk.capacity(), (unsigned int)docChunk.size(), docChunk.overflowed(), (unsigned int)docChunk.nesting(), jMapFile.size());
-          if (err) 
+          if (err)
           {
             USER_PRINTF("deserializeJson() of parseTree failed with code %s\n", err.c_str());
             USER_FLUSH();
@@ -1084,7 +1084,7 @@ uint16_t Segment::calc_virtualLength() const {
       case M12_sBlock: //WLEDMM
         if (nrOfVStrips()>1)
           vLen = max(vW,vH) * 4;//0.5; // get the longest dimension
-        else 
+        else
           vLen = max(vW,vH) * 0.5f; // get the longest dimension
         break;
       case M12_sPinwheel:
@@ -1124,7 +1124,7 @@ static void xyFromBlock(uint16_t &x,uint16_t &y, uint16_t i, uint16_t vW, uint16
     y = vH / 2 + vStrip - i2 * vStrip * 2;
   }
   // softhack007 not sure if clamping is necessary
-  //x = min(x, uint16_t(vW-1)); // clamp x at vW-1  
+  //x = min(x, uint16_t(vW-1)); // clamp x at vW-1
   //y = min(y, uint16_t(vH-1)); // clamp y at vH-1
 }
 
@@ -1137,7 +1137,7 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
   i &= 0xFFFF;
   if (unsigned(i) >= virtualLength()) return;  // if pixel would fall out of segment just exit //WLEDMM unsigned(i)>SEGLEN also catches "i<0"
 
-  if ((Segment::maxHeight == 1) && !maskAllows(i)) return; // WLEDMM mask gate for 1D segments
+  if (!is2D() && !maskAllows(i)) return; // WLEDMM mask gate for 1D segments
 
 #ifndef WLED_DISABLE_2D
   if (is2D()) {
@@ -1159,17 +1159,17 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
           setPixelColorXY(0, 0, col);
         else {
           if (i == virtualLength() - 1) setPixelColorXY(vW-1, vH-1, col); // Last i always fill corner
-          if (!_isSuperSimpleSegment) { 
+          if (!_isSuperSimpleSegment) {
             // WLEDMM: drawArc() is faster if it's NOT "super simple" as the regular M12_pArc
             // can do "useSymmetry" to speed things along, but a more complicated segment likey
             // uses mirroring which generates a symmetry speed-up, or other things which mean
             // less pixels are calculated.
-            drawArc(0, 0, i, col); 
+            drawArc(0, 0, i, col);
           } else {
             //WLEDMM: some optimizations for the drawing loop
             //  pre-calculate loop limits, exploit symmetry at 45deg
             float radius = float(i);
-            
+
             // float step = HALF_PI / (2.85f * radius);  // upstream uses this
             float step = HALF_PI / (M_PI * radius);      // WLEDMM we use the correct circumference
             bool useSymmetry = (max(vH, vW) > 20);       // for segments wider than 20 pixels, we exploit symmetry
@@ -1284,7 +1284,7 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
         // Odd rays start further from center if prevRay started at center.
         static int prevRay = INT_MIN; // previous ray number
         if ((i % 2 == 1) && (i - 1 == prevRay || i + 1 == prevRay)) {
-          int jump = min(vW/3, vH/3); // can add 2 if using medium pinwheel 
+          int jump = min(vW/3, vH/3); // can add 2 if using medium pinwheel
           posx += inc_x * jump;
           posy += inc_y * jump;
         }
@@ -1298,7 +1298,7 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
           // set pixel
           if (x != lastX || y != lastY) { // only paint if pixel position is different
             if (simpleSegment) setPixelColorXY_fast(x, y, col, scaled_col, vW, vH);
-            else setPixelColorXY_slow(x, y, col);  
+            else setPixelColorXY_slow(x, y, col);
           }
           lastX = x;
           lastY = y;
@@ -1425,7 +1425,7 @@ uint32_t WLED_O2_ATTR __attribute__((hot)) Segment::getPixelColor(int i) const
         break;
       case M12_pCorner:
       case M12_pArc: {
-        if (i < max(vW, vH)) { 
+        if (i < max(vW, vH)) {
           return vW>vH ? getPixelColorXY(i, 0) : getPixelColorXY(0, i); // Corner and Arc
           break;
         }
@@ -1439,7 +1439,7 @@ uint32_t WLED_O2_ATTR __attribute__((hot)) Segment::getPixelColor(int i) const
           int newX2 = x * x;
           for (int y = startY; y < vH; y++) {
             int newY2 = y * y;
-            if (newX2 + newY2 >= minradius2) return getPixelColorXY(x, y);        
+            if (newX2 + newY2 >= minradius2) return getPixelColorXY(x, y);
           }
         }
         return getPixelColorXY(vW-1, vH-1); // Last pixel
@@ -1627,7 +1627,7 @@ void __attribute__((hot)) Segment::fill(uint32_t c) {
 
 // Blends the specified color with the existing pixel color.
 void Segment::blendPixelColor(int n, uint32_t color, uint8_t blend) {
-  if (blend == UINT8_MAX) setPixelColor(n, color); 
+  if (blend == UINT8_MAX) setPixelColor(n, color);
   else setPixelColor(n, color_blend(getPixelColor(n), color, blend));
 }
 
@@ -1803,7 +1803,7 @@ uint8_t Segment::get_random_wheel_index(uint8_t pos) const { // WLEDMM use fast 
  //WLEDMM netmindz ar palette
 uint8_t * Segment::getAudioPalette(int pal) const {
   // https://forum.makerforums.info/t/hi-is-it-possible-to-define-a-gradient-palette-at-runtime-the-define-gradient-palette-uses-the/63339
-  
+
   um_data_t *um_data;
   if (!usermods.getUMData(&um_data, USERMOD_ID_AUDIOREACTIVE)) {
     um_data = simulateSound(SEGMENT.soundSim);
@@ -1817,19 +1817,19 @@ uint8_t * Segment::getAudioPalette(int pal) const {
   xyz[1] = 0;
   xyz[2] = 0;
   xyz[3] = 0;
-  
+
   CRGB rgb = getCRGBForBand(1, fftResult, pal);
   xyz[4] = 1;  // anchor of first color
   xyz[5] = rgb.r;
   xyz[6] = rgb.g;
   xyz[7] = rgb.b;
-  
+
   rgb = getCRGBForBand(128, fftResult, pal);
   xyz[8] = 128;
   xyz[9] = rgb.r;
   xyz[10] = rgb.g;
   xyz[11] = rgb.b;
-  
+
   rgb = getCRGBForBand(255, fftResult, pal);
   xyz[12] = 255;  // anchor of last color - must be 255
   xyz[13] = rgb.r;
@@ -1878,7 +1878,7 @@ void WS2812FX::enumerateLedmaps() {
           if (len > 0 && len < (sizeof(name)-1)) {
             (void) cleanUpName(name);
             len = strlen(name);
-            ledmapNames[i-1] = new(std::nothrow) char[len+1]; // +1 to include terminating \0 
+            ledmapNames[i-1] = new(std::nothrow) char[len+1]; // +1 to include terminating \0
             if (ledmapNames[i-1]) strlcpy(ledmapNames[i-1], name, len+1);
           }
           if (!ledmapNames[i-1]) {
@@ -2011,7 +2011,7 @@ void WS2812FX::finalizeInit(void)
   if (Segment::_globalLeds) {
     // DONG - Valkyrie is about to die     [Gauntlet, 1985]
     // this is a critical section that will be removed with PR #278 which removes _globalLeds
-    // problem: suspendStripService provides interlocking, but there’s a window before service() observes it, 
+    // problem: suspendStripService provides interlocking, but there’s a window before service() observes it,
     //          and ESP32 is dual-core. A critical section closes that window so the pointer swap is atomic across cores.
     CRGB* oldGLeds = Segment::_globalLeds;
     portENTER_CRITICAL(&ledsrgb_mux);
@@ -2067,7 +2067,7 @@ void WS2812FX::waitUntilIdle(unsigned timeout) {
 void WS2812FX::service() {
   unsigned long nowUp = millis(); // Be aware, millis() rolls over every 49 days // WLEDMM avoid losing precision
   if (OTAisRunning) return; // WLEDMM avoid flickering during OTA
- 
+
   //#ifdef ARDUINO_ARCH_ESP32
   //if ((_isServicing == true) && (strncmp(pcTaskGetTaskName(NULL), "loopTask", 8) != 0)) return; // WLEDMM experimental: not in looptask context - avoid self-blocking (DDP over webSockets)
   //#endif
@@ -2130,7 +2130,7 @@ void WS2812FX::service() {
         if (frameDelay < speedLimit) frameDelay = FRAMETIME;                    // WLEDMM limit effects that want to go faster than target FPS
         if (seg.mode != FX_MODE_HALLOWEEN_EYES) seg.call++;
 
-        if (seg.transitional && frameDelay > max(int(FRAMETIME), int(FRAMETIME_FIXED))) 
+        if (seg.transitional && frameDelay > max(int(FRAMETIME), int(FRAMETIME_FIXED)))
           frameDelay = max(int(FRAMETIME), int(FRAMETIME_FIXED)); // force faster updates during transition // WLEDMM only if effect requested very slow updates
 
         seg.lastBri = seg.currentBri(seg.on ? seg.opacity:0);                   // WLEDMM remember for next time
@@ -2859,7 +2859,7 @@ bool WS2812FX::deserializeMap(uint8_t n) {
     if ((size > 0) && (customMappingTable == nullptr)) { // second try
       DEBUG_PRINTLN("deserializeMap: trying to get fresh memory block.");
       customMappingTable = (uint16_t*) calloc(size, sizeof(uint16_t));
-      if (customMappingTable == nullptr) { 
+      if (customMappingTable == nullptr) {
         DEBUG_PRINTLN("deserializeMap: alloc failed!");
         errorFlag = ERR_LOW_MEM; // WLEDMM raise errorflag
       }
@@ -2891,7 +2891,7 @@ bool WS2812FX::deserializeMap(uint8_t n) {
     loadedLedmap = n;
     f.close();
 
-    if ((customMappingTable != nullptr) && (customMappingSize>0)) { 
+    if ((customMappingTable != nullptr) && (customMappingSize>0)) {
       USER_PRINTF(PSTR("Ledmap #%d read. Size=%d (%d x %d); %d items found.\n"), loadedLedmap, customMappingSize, Segment::maxWidth, Segment::maxHeight, i);
     }
     #ifdef WLED_DEBUG_MAPS

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -95,11 +95,11 @@ Segment::Segment(const Segment &orig) {
   data = nullptr;
   _dataLen = 0;
   _t = nullptr;
-  _mask = nullptr;
-  _maskLen = 0;
-  _maskW = 0;
-  _maskH = 0;
-  _maskValid = false;
+  _mask = nullptr; // WLEDMM
+  _maskLen = 0; // WLEDMM
+  _maskW = 0; // WLEDMM
+  _maskH = 0; // WLEDMM
+  _maskValid = false; // WLEDMM
   if (ledsrgb && !Segment::_globalLeds) {ledsrgb = nullptr; ledsrgbSize = 0;}  // WLEDMM
   if (orig.name) { name = new(std::nothrow) char[strlen(orig.name)+1]; if (name) strcpy(name, orig.name); }
   if (orig.data) { if (allocateData(orig._dataLen, true)) memcpy(data, orig.data, orig._dataLen); }
@@ -147,7 +147,7 @@ void Segment::allocLeds() {
   }
 }
 
-void Segment::clearMask() {
+void Segment::clearMask() { // WLEDMM
   if (_mask) {
     free(_mask);
     _mask = nullptr;
@@ -158,7 +158,7 @@ void Segment::clearMask() {
   _maskValid = false;
 }
 
-bool Segment::setMask(uint8_t id) {
+bool Segment::setMask(uint8_t id) { // WLEDMM
   clearMask();
   maskId = id;
   if (id >= WLED_MAX_SEGMASKS) {
@@ -282,11 +282,11 @@ Segment::Segment(Segment &&orig) noexcept {
   orig.ledsrgb = nullptr; //WLEDMM
   orig.ledsrgbSize = 0;   // WLEDMM
   orig.jMap = nullptr;    //WLEDMM jMap
-  orig._mask = nullptr;
-  orig._maskLen = 0;
-  orig._maskW = 0;
-  orig._maskH = 0;
-  orig._maskValid = false;
+  orig._mask = nullptr; // WLEDMM
+  orig._maskLen = 0; // WLEDMM
+  orig._maskW = 0; // WLEDMM
+  orig._maskH = 0; // WLEDMM
+  orig._maskValid = false; // WLEDMM
 }
 
 // copy assignment --> overwrite segment with orig - deletes old buffers in "this", but does not change orig!
@@ -297,7 +297,7 @@ Segment& Segment::operator= (const Segment &orig) {
     transitional = false; // copied segment cannot be in transition
     if (name) delete[] name;
     if (_t)   delete _t;
-    clearMask();
+    clearMask(); // WLEDMM
     CRGB* oldLeds = ledsrgb;
     size_t oldLedsSize = ledsrgbSize;
     if (ledsrgb && !Segment::_globalLeds) free(ledsrgb);
@@ -316,11 +316,11 @@ Segment& Segment::operator= (const Segment &orig) {
     data = nullptr;
     _dataLen = 0;
     _t = nullptr;
-    _mask = nullptr;
-    _maskLen = 0;
-    _maskW = 0;
-    _maskH = 0;
-    _maskValid = false;
+    _mask = nullptr; // WLEDMM
+    _maskLen = 0; // WLEDMM
+    _maskW = 0; // WLEDMM
+    _maskH = 0; // WLEDMM
+    _maskValid = false; // WLEDMM
     //if (!Segment::_globalLeds) {ledsrgb = oldLeds; ledsrgbSize = oldLedsSize;}; // WLEDMM reuse leds instead of ledsrgb = nullptr;
     if (!Segment::_globalLeds) {ledsrgb = nullptr; ledsrgbSize = 0;};             // WLEDMM copy has no buffers (yet)
     // copy source data
@@ -341,7 +341,7 @@ Segment& Segment::operator= (Segment &&orig) noexcept {
     transitional = false; // just temporary
     if (name) { delete[] name; name = nullptr; } // free old name
     deallocateData(); // free old runtime data
-    clearMask();
+    clearMask(); // WLEDMM
     if (_t) { delete _t; _t = nullptr; }
     if (ledsrgb && !Segment::_globalLeds) free(ledsrgb); //WLEDMM: not needed anymore as we will use leds from copy. no need to nullify ledsrgb as it gets new value in memcpy
 
@@ -361,11 +361,11 @@ Segment& Segment::operator= (Segment &&orig) noexcept {
     orig.ledsrgb = nullptr;  //WLEDMM: do not free as moved to here
     orig.ledsrgbSize = 0;    //WLEDMM
     orig.jMap = nullptr; //WLEDMM jMap
-    orig._mask = nullptr;
-    orig._maskLen = 0;
-    orig._maskW = 0;
-    orig._maskH = 0;
-    orig._maskValid = false;
+    orig._mask = nullptr; // WLEDMM
+    orig._maskLen = 0; // WLEDMM
+    orig._maskW = 0; // WLEDMM
+    orig._maskH = 0; // WLEDMM
+    orig._maskValid = false; // WLEDMM
   }
   return *this;
 }
@@ -1535,8 +1535,8 @@ uint8_t Segment::differs(Segment& b) const {
   if (check3 != b.check3)       d |= SEG_DIFFERS_FX;
   if (startY != b.startY)       d |= SEG_DIFFERS_BOUNDS;
   if (stopY != b.stopY)         d |= SEG_DIFFERS_BOUNDS;
-  if (maskId != b.maskId)       d |= SEG_DIFFERS_OPT;
-  if (maskInvert != b.maskInvert) d |= SEG_DIFFERS_OPT;
+  if (maskId != b.maskId)       d |= SEG_DIFFERS_OPT; // WLEDMM
+  if (maskInvert != b.maskInvert) d |= SEG_DIFFERS_OPT; // WLEDMM
 
   //bit pattern: (msb first) set:2, sound:1, mapping:3, transposed, mirrorY, reverseY, [transitional, reset,] paused, mirrored, on, reverse, [selected]
   if ((options & 0b1111111110011110U) != (b.options & 0b1111111110011110U)) d |= SEG_DIFFERS_OPT;
@@ -1931,7 +1931,7 @@ void WS2812FX::enumerateLedmaps() {
   }
 }
 
-// enumerate all segmaskX.json files on FS
+// WLEDMM enumerate all segmaskX.json files on FS
 void WS2812FX::enumerateSegmasks() {
   segMasks = 0;
   for (int i = 1; i < WLED_MAX_SEGMASKS; i++) {
@@ -1956,7 +1956,7 @@ void WS2812FX::finalizeInit(void)
   // if we do it in json.cpp (serializeInfo()) we are getting flashes on LEDs
   // unfortunately this means we do not get updates after uploads
   enumerateLedmaps();
-  enumerateSegmasks();
+  enumerateSegmasks(); // WLEDMM
 
   _hasWhiteChannel = _isOffRefreshRequired = false;
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -148,21 +148,27 @@ void Segment::allocLeds() {
 }
 
 void Segment::clearMask() { // WLEDMM
-  if (_mask) {
-    free(_mask);
+  uint8_t* oldMask = nullptr;
+  strip_wait_until_idle("Segment::clearMask"); // WLEDMM avoid swapping while renderer is active
+  if (esp32SemTake(segmentMux, 2100) == pdTRUE) { // WLEDMM serialize mask pointer changes with renderer
+    oldMask = _mask;
     _mask = nullptr;
+    _maskLen = 0;
+    _maskW = 0;
+    _maskH = 0;
+    _maskValid = false;
+    maskId = 0; // WLEDMM keep id in sync with buffer
+    esp32SemGive(segmentMux);
+  } else {
+    DEBUG_PRINTLN(F("Segment::clearMask: Failed to acquire segmentMux, skipping clear."));
+    return;
   }
-  _maskLen = 0;
-  _maskW = 0;
-  _maskH = 0;
-  _maskValid = false;
+  if (oldMask) free(oldMask);
 }
 
 bool Segment::setMask(uint8_t id) { // WLEDMM
   clearMask();
-  maskId = id;
   if (id >= WLED_MAX_SEGMASKS) {
-    maskId = 0;
     return false;
   }
   if (id == 0) return true;
@@ -250,15 +256,26 @@ bool Segment::setMask(uint8_t id) { // WLEDMM
 
     if (!parsedOk || !endOfArray || i != bitLen) break;
 
-    _mask = bits;
-    bits = nullptr;
-    _maskW = w;
-    _maskH = h;
-    _maskLen = bitLen;
-    maskInvert = inv;
-    _maskValid = (_maskW == calc_virtualWidth() && _maskH == calc_virtualHeight());
     ok = true;
   } while (false);
+
+  if (ok) {
+    strip_wait_until_idle("Segment::setMask"); // WLEDMM avoid swapping while renderer is active
+    if (esp32SemTake(segmentMux, 2100) == pdTRUE) { // WLEDMM serialize mask pointer changes with renderer
+      _mask = bits;
+      bits = nullptr;
+      _maskW = w;
+      _maskH = h;
+      _maskLen = bitLen;
+      maskInvert = inv;
+      _maskValid = (_maskW == calc_virtualWidth() && _maskH == calc_virtualHeight());
+      maskId = id; // WLEDMM commit mask id only on success
+      esp32SemGive(segmentMux);
+    } else {
+      DEBUG_PRINTLN(F("Segment::setMask: Failed to acquire segmentMux, skipping mask update."));
+      ok = false;
+    }
+  }
 
   if (!ok && bits) free(bits);
   if (!ok) maskId = 0; // WLEDMM avoid repeated reload attempts
@@ -728,6 +745,14 @@ void Segment::setUp(uint16_t i1, uint16_t i2, uint8_t grp, uint8_t spc, uint16_t
       spacing = spc;
     }
     if (ofs < UINT16_MAX) offset = ofs;
+    // WLEDMM keep mask validity aligned with current virtual geometry
+    if (_mask) {
+      uint16_t vW = calc_virtualWidth();
+      uint16_t vH = calc_virtualHeight();
+      _maskValid = (_maskW == vW && _maskH == vH);
+    } else {
+      _maskValid = false;
+    }
     esp32SemGive(segmentMux);
   } else {
     DEBUG_PRINTLN(F("Segment::setUp: Failed to acquire segmentMux, skipping bounds update."));

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -179,9 +179,9 @@ bool Segment::setMask(uint8_t id) {
 
   uint16_t w = 0;
   uint16_t h = 0;
-  size_t bitLen = 0;
-  uint8_t* bits = nullptr;
-  bool inv = maskInvert;
+  size_t bitLen = 0;            // WLEDMM total mask pixels (w*h)
+  uint8_t* bits = nullptr;      // WLEDMM bit-packed mask, 1 bit per pixel
+  bool inv = maskInvert;        // WLEDMM default to current invert setting
   bool ok = false;
 
   do {
@@ -200,6 +200,7 @@ bool Segment::setMask(uint8_t id) {
     bitLen = size_t(w) * size_t(h);
     if (bitLen == 0 || bitLen > (size_t(Segment::maxWidth) * size_t(Segment::maxHeight))) break;
 
+    // WLEDMM pack 8 pixels per byte, LSB-first (bit 0 = pixel 0)
     size_t byteLen = (bitLen + 7) / 8;
     bits = (uint8_t*)calloc(byteLen, 1);
     if (!bits) {
@@ -208,6 +209,7 @@ bool Segment::setMask(uint8_t id) {
     }
 
     f.seek(0);
+    // WLEDMM strict "inv" boolean parsing (true/false only)
     if (f.find("\"inv\":")) {
       String entry = f.readStringUntil(',');
       int end = entry.indexOf('}');
@@ -219,6 +221,7 @@ bool Segment::setMask(uint8_t id) {
     }
 
     f.seek(0);
+    // WLEDMM strict 0/1 mask array, use streaming parse (ledmap-style)
     if (!f.find("\"mask\":")) break;
     f.readBytesUntil('[', buf, sizeof(buf)-1);
 
@@ -234,8 +237,8 @@ bool Segment::setMask(uint8_t id) {
       }
       entry.trim();
       if (entry.length() == 0) { parsedOk = false; break; }
-      if (i >= bitLen) { parsedOk = false; break; }
-      if (entry == "1") bits[i >> 3] |= (0x01U << (i & 7));
+      if (i >= bitLen) { parsedOk = false; break; } // WLEDMM guard against overflow
+      if (entry == "1") bits[i >> 3] |= (0x01U << (i & 7)); // WLEDMM set bit (pixel i) in packed mask
       else if (entry != "0") { parsedOk = false; break; }
       i++;
       if (i > bitLen) { parsedOk = false; break; }
@@ -1134,7 +1137,7 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
   i &= 0xFFFF;
   if (unsigned(i) >= virtualLength()) return;  // if pixel would fall out of segment just exit //WLEDMM unsigned(i)>SEGLEN also catches "i<0"
 
-  if ((Segment::maxHeight == 1) && !maskAllows(i)) return;
+  if ((Segment::maxHeight == 1) && !maskAllows(i)) return; // WLEDMM mask gate for 1D segments
 
 #ifndef WLED_DISABLE_2D
   if (is2D()) {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -178,7 +178,7 @@ bool Segment::setMask(uint8_t id) { // WLEDMM
   char fileName[24] = {'\0'};
   snprintf_P(fileName, sizeof(fileName), PSTR("/segmask%d.json"), id);
   if (!WLED_FS.exists(fileName)) {
-    USER_PRINTF("Segment mask missing: %s\n", fileName);
+    DEBUG_PRINTF("Segment mask missing: %s\n", fileName);
     maskId = 0; // WLEDMM avoid repeated reload attempts
     return false;
   }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1177,7 +1177,7 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
   i &= 0xFFFF;
   if (unsigned(i) >= virtualLength()) return;  // if pixel would fall out of segment just exit //WLEDMM unsigned(i)>SEGLEN also catches "i<0"
 
-  if (!is2D() && !maskAllows(i)) return; // WLEDMM mask gate for 1D segments
+  if (_maskValid && !maskAllows(i)) return; // WLEDMM mask gate for 1D segments
 
 #ifndef WLED_DISABLE_2D
   if (is2D()) {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -327,7 +327,11 @@ Segment& Segment::operator= (const Segment &orig) {
     transitional = false; // copied segment cannot be in transition
     if (name) delete[] name;
     if (_t)   delete _t;
-    clearMask(); // WLEDMM
+    if (_mask) { // WLEDMM free mask buffer directly to avoid deadlocks
+      strip_wait_until_idle("Segment::operator= mask cleanup"); // WLEDMM avoid freeing while renderer is active
+      free(_mask);
+      _mask = nullptr;
+    }
     CRGB* oldLeds = ledsrgb;
     size_t oldLedsSize = ledsrgbSize;
     if (ledsrgb && !Segment::_globalLeds) free(ledsrgb);
@@ -373,7 +377,11 @@ Segment& Segment::operator= (Segment &&orig) noexcept {
     transitional = false; // just temporary
     if (name) { delete[] name; name = nullptr; } // free old name
     deallocateData(); // free old runtime data
-    clearMask(); // WLEDMM
+    if (_mask) { // WLEDMM free mask buffer directly to avoid deadlocks
+      strip_wait_until_idle("Segment::operator= move mask cleanup"); // WLEDMM avoid freeing while renderer is active
+      free(_mask);
+      _mask = nullptr;
+    }
     if (_t) { delete _t; _t = nullptr; }
     if (ledsrgb && !Segment::_globalLeds) free(ledsrgb); //WLEDMM: not needed anymore as we will use leds from copy. no need to nullify ledsrgb as it gets new value in memcpy
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -171,11 +171,15 @@ bool Segment::setMask(uint8_t id) { // WLEDMM
   snprintf_P(fileName, sizeof(fileName), PSTR("/segmask%d.json"), id);
   if (!WLED_FS.exists(fileName)) {
     USER_PRINTF("Segment mask missing: %s\n", fileName);
+    maskId = 0; // WLEDMM avoid repeated reload attempts
     return false;
   }
 
   File f = WLED_FS.open(fileName, "r");
-  if (!f) return false;
+  if (!f) {
+    maskId = 0; // WLEDMM avoid repeated reload attempts
+    return false;
+  }
 
   uint16_t w = 0;
   uint16_t h = 0;
@@ -257,6 +261,7 @@ bool Segment::setMask(uint8_t id) { // WLEDMM
   } while (false);
 
   if (!ok && bits) free(bits);
+  if (!ok) maskId = 0; // WLEDMM avoid repeated reload attempts
   f.close();
   return ok;
 }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -59,7 +59,7 @@ WLED_create_spinlock(ledsrgb_mux); // to protect deleting Segment::_globalLeds a
 // WLEDMM experimental . this is a "C style" wrapper for strip.waitUntilIdle();
 // This workaround is just needed for the segment class, that does't know about "strip"
 void strip_wait_until_idle(String whoCalledMe) {
-#if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_PROTECT_SERVICE)  // WLEDMM experimental
+#if defined(ARDUINO_ARCH_ESP32) && defined(WLEDMM_PROTECT_SERVICE)  // WLEDMM experimental 
   if (strip.isServicing() && (strncmp(pcTaskGetTaskName(NULL), "loopTask", 8) != 0)) { // if we are in looptask (arduino loop), its safe to proceed without waiting
   DEBUG_PRINTLN(whoCalledMe + String(": strip is still drawing effects."));
   strip.waitUntilIdle();
@@ -433,7 +433,7 @@ bool Segment::allocateData(size_t len, bool allowOverdraft) {  // WLEDMM allowOv
   if (!data) {
       _dataLen = 0; // WLEDMM reset dataLen
       if ((errorFlag != ERR_LOW_MEM) && (errorFlag != ERR_LOW_SEG_MEM)) { // spam filter
-        USER_PRINT(F("Segment::allocateData: FAILED to allocate "));
+        USER_PRINT(F("Segment::allocateData: FAILED to allocate ")); 
         USER_PRINT(len); USER_PRINTLN(F(" bytes."));
       }
       errorFlag = ERR_LOW_MEM; // WLEDMM raise errorflag
@@ -621,7 +621,7 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) c
     case 71: //WLEDMM netmindz ar palette +1
     case 72: //WLEDMM netmindz ar palette +2
     case 73: //WLEDMM netmindz ar palette +3
-        targetPalette.loadDynamicGradientPalette(getAudioPalette(pal)); break;
+        targetPalette.loadDynamicGradientPalette(getAudioPalette(pal)); break; 
     default: //progmem palettes
       if (pal>245) {
         targetPalette = strip.customPalettes[255-pal]; // we checked bounds above
@@ -939,7 +939,7 @@ class JMapC {
         return 0;
     }
   private:
-    std::vector<ArrayAndSize> jVectorMap;
+    std::vector<ArrayAndSize> jVectorMap; 
     StaticJsonDocument<4096> docChunk; //must fit forks with about 32 points each
     uint8_t scale=1;
 
@@ -967,7 +967,7 @@ class JMapC {
           DeserializationError err = deserializeJson(docChunk, jMapFile);
           // serializeJson(docChunk, Serial); USER_PRINTLN();
           // USER_PRINTF("docChunk  %u / %u%% (%u %u %u) %u\n", (unsigned int)docChunk.memoryUsage(), 100 * docChunk.memoryUsage() / docChunk.capacity(), (unsigned int)docChunk.size(), docChunk.overflowed(), (unsigned int)docChunk.nesting(), jMapFile.size());
-          if (err)
+          if (err) 
           {
             USER_PRINTF("deserializeJson() of parseTree failed with code %s\n", err.c_str());
             USER_FLUSH();
@@ -1120,7 +1120,7 @@ uint16_t Segment::calc_virtualLength() const {
       case M12_sBlock: //WLEDMM
         if (nrOfVStrips()>1)
           vLen = max(vW,vH) * 4;//0.5; // get the longest dimension
-        else
+        else 
           vLen = max(vW,vH) * 0.5f; // get the longest dimension
         break;
       case M12_sPinwheel:
@@ -1160,7 +1160,7 @@ static void xyFromBlock(uint16_t &x,uint16_t &y, uint16_t i, uint16_t vW, uint16
     y = vH / 2 + vStrip - i2 * vStrip * 2;
   }
   // softhack007 not sure if clamping is necessary
-  //x = min(x, uint16_t(vW-1)); // clamp x at vW-1
+  //x = min(x, uint16_t(vW-1)); // clamp x at vW-1  
   //y = min(y, uint16_t(vH-1)); // clamp y at vH-1
 }
 
@@ -1195,17 +1195,17 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
           setPixelColorXY(0, 0, col);
         else {
           if (i == virtualLength() - 1) setPixelColorXY(vW-1, vH-1, col); // Last i always fill corner
-          if (!_isSuperSimpleSegment) {
+          if (!_isSuperSimpleSegment) { 
             // WLEDMM: drawArc() is faster if it's NOT "super simple" as the regular M12_pArc
             // can do "useSymmetry" to speed things along, but a more complicated segment likey
             // uses mirroring which generates a symmetry speed-up, or other things which mean
             // less pixels are calculated.
-            drawArc(0, 0, i, col);
+            drawArc(0, 0, i, col); 
           } else {
             //WLEDMM: some optimizations for the drawing loop
             //  pre-calculate loop limits, exploit symmetry at 45deg
             float radius = float(i);
-
+            
             // float step = HALF_PI / (2.85f * radius);  // upstream uses this
             float step = HALF_PI / (M_PI * radius);      // WLEDMM we use the correct circumference
             bool useSymmetry = (max(vH, vW) > 20);       // for segments wider than 20 pixels, we exploit symmetry
@@ -1320,7 +1320,7 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
         // Odd rays start further from center if prevRay started at center.
         static int prevRay = INT_MIN; // previous ray number
         if ((i % 2 == 1) && (i - 1 == prevRay || i + 1 == prevRay)) {
-          int jump = min(vW/3, vH/3); // can add 2 if using medium pinwheel
+          int jump = min(vW/3, vH/3); // can add 2 if using medium pinwheel 
           posx += inc_x * jump;
           posy += inc_y * jump;
         }
@@ -1334,7 +1334,7 @@ void IRAM_ATTR_YN WLED_O2_ATTR __attribute__((hot)) Segment::setPixelColor(int i
           // set pixel
           if (x != lastX || y != lastY) { // only paint if pixel position is different
             if (simpleSegment) setPixelColorXY_fast(x, y, col, scaled_col, vW, vH);
-            else setPixelColorXY_slow(x, y, col);
+            else setPixelColorXY_slow(x, y, col);  
           }
           lastX = x;
           lastY = y;
@@ -1461,7 +1461,7 @@ uint32_t WLED_O2_ATTR __attribute__((hot)) Segment::getPixelColor(int i) const
         break;
       case M12_pCorner:
       case M12_pArc: {
-        if (i < max(vW, vH)) {
+        if (i < max(vW, vH)) { 
           return vW>vH ? getPixelColorXY(i, 0) : getPixelColorXY(0, i); // Corner and Arc
           break;
         }
@@ -1475,7 +1475,7 @@ uint32_t WLED_O2_ATTR __attribute__((hot)) Segment::getPixelColor(int i) const
           int newX2 = x * x;
           for (int y = startY; y < vH; y++) {
             int newY2 = y * y;
-            if (newX2 + newY2 >= minradius2) return getPixelColorXY(x, y);
+            if (newX2 + newY2 >= minradius2) return getPixelColorXY(x, y);        
           }
         }
         return getPixelColorXY(vW-1, vH-1); // Last pixel
@@ -1663,7 +1663,7 @@ void __attribute__((hot)) Segment::fill(uint32_t c) {
 
 // Blends the specified color with the existing pixel color.
 void Segment::blendPixelColor(int n, uint32_t color, uint8_t blend) {
-  if (blend == UINT8_MAX) setPixelColor(n, color);
+  if (blend == UINT8_MAX) setPixelColor(n, color); 
   else setPixelColor(n, color_blend(getPixelColor(n), color, blend));
 }
 
@@ -1839,7 +1839,7 @@ uint8_t Segment::get_random_wheel_index(uint8_t pos) const { // WLEDMM use fast 
  //WLEDMM netmindz ar palette
 uint8_t * Segment::getAudioPalette(int pal) const {
   // https://forum.makerforums.info/t/hi-is-it-possible-to-define-a-gradient-palette-at-runtime-the-define-gradient-palette-uses-the/63339
-
+  
   um_data_t *um_data;
   if (!usermods.getUMData(&um_data, USERMOD_ID_AUDIOREACTIVE)) {
     um_data = simulateSound(SEGMENT.soundSim);
@@ -1853,19 +1853,19 @@ uint8_t * Segment::getAudioPalette(int pal) const {
   xyz[1] = 0;
   xyz[2] = 0;
   xyz[3] = 0;
-
+  
   CRGB rgb = getCRGBForBand(1, fftResult, pal);
   xyz[4] = 1;  // anchor of first color
   xyz[5] = rgb.r;
   xyz[6] = rgb.g;
   xyz[7] = rgb.b;
-
+  
   rgb = getCRGBForBand(128, fftResult, pal);
   xyz[8] = 128;
   xyz[9] = rgb.r;
   xyz[10] = rgb.g;
   xyz[11] = rgb.b;
-
+  
   rgb = getCRGBForBand(255, fftResult, pal);
   xyz[12] = 255;  // anchor of last color - must be 255
   xyz[13] = rgb.r;
@@ -1914,7 +1914,7 @@ void WS2812FX::enumerateLedmaps() {
           if (len > 0 && len < (sizeof(name)-1)) {
             (void) cleanUpName(name);
             len = strlen(name);
-            ledmapNames[i-1] = new(std::nothrow) char[len+1]; // +1 to include terminating \0
+            ledmapNames[i-1] = new(std::nothrow) char[len+1]; // +1 to include terminating \0 
             if (ledmapNames[i-1]) strlcpy(ledmapNames[i-1], name, len+1);
           }
           if (!ledmapNames[i-1]) {
@@ -2047,7 +2047,7 @@ void WS2812FX::finalizeInit(void)
   if (Segment::_globalLeds) {
     // DONG - Valkyrie is about to die     [Gauntlet, 1985]
     // this is a critical section that will be removed with PR #278 which removes _globalLeds
-    // problem: suspendStripService provides interlocking, but there’s a window before service() observes it,
+    // problem: suspendStripService provides interlocking, but there’s a window before service() observes it, 
     //          and ESP32 is dual-core. A critical section closes that window so the pointer swap is atomic across cores.
     CRGB* oldGLeds = Segment::_globalLeds;
     portENTER_CRITICAL(&ledsrgb_mux);
@@ -2103,7 +2103,7 @@ void WS2812FX::waitUntilIdle(unsigned timeout) {
 void WS2812FX::service() {
   unsigned long nowUp = millis(); // Be aware, millis() rolls over every 49 days // WLEDMM avoid losing precision
   if (OTAisRunning) return; // WLEDMM avoid flickering during OTA
-
+ 
   //#ifdef ARDUINO_ARCH_ESP32
   //if ((_isServicing == true) && (strncmp(pcTaskGetTaskName(NULL), "loopTask", 8) != 0)) return; // WLEDMM experimental: not in looptask context - avoid self-blocking (DDP over webSockets)
   //#endif
@@ -2166,7 +2166,7 @@ void WS2812FX::service() {
         if (frameDelay < speedLimit) frameDelay = FRAMETIME;                    // WLEDMM limit effects that want to go faster than target FPS
         if (seg.mode != FX_MODE_HALLOWEEN_EYES) seg.call++;
 
-        if (seg.transitional && frameDelay > max(int(FRAMETIME), int(FRAMETIME_FIXED)))
+        if (seg.transitional && frameDelay > max(int(FRAMETIME), int(FRAMETIME_FIXED))) 
           frameDelay = max(int(FRAMETIME), int(FRAMETIME_FIXED)); // force faster updates during transition // WLEDMM only if effect requested very slow updates
 
         seg.lastBri = seg.currentBri(seg.on ? seg.opacity:0);                   // WLEDMM remember for next time
@@ -2895,7 +2895,7 @@ bool WS2812FX::deserializeMap(uint8_t n) {
     if ((size > 0) && (customMappingTable == nullptr)) { // second try
       DEBUG_PRINTLN("deserializeMap: trying to get fresh memory block.");
       customMappingTable = (uint16_t*) calloc(size, sizeof(uint16_t));
-      if (customMappingTable == nullptr) {
+      if (customMappingTable == nullptr) { 
         DEBUG_PRINTLN("deserializeMap: alloc failed!");
         errorFlag = ERR_LOW_MEM; // WLEDMM raise errorflag
       }
@@ -2927,7 +2927,7 @@ bool WS2812FX::deserializeMap(uint8_t n) {
     loadedLedmap = n;
     f.close();
 
-    if ((customMappingTable != nullptr) && (customMappingSize>0)) {
+    if ((customMappingTable != nullptr) && (customMappingSize>0)) { 
       USER_PRINTF(PSTR("Ledmap #%d read. Size=%d (%d x %d); %d items found.\n"), loadedLedmap, customMappingSize, Segment::maxWidth, Segment::maxHeight, i);
     }
     #ifdef WLED_DEBUG_MAPS

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -261,6 +261,13 @@ bool Segment::setMask(uint8_t id) { // WLEDMM
 
   if (ok) {
     strip_wait_until_idle("Segment::setMask"); // WLEDMM avoid swapping while renderer is active
+    // WLEDMM clear segment before enabling mask to avoid stale pixels outside the mask
+    if (esp32SemTake(busDrawMux, 250) == pdTRUE) {
+      fill(BLACK);
+      esp32SemGive(busDrawMux);
+    } else {
+      DEBUG_PRINTLN(F("Segment::setMask: Failed to acquire busDrawMux, skipping pre-mask clear."));
+    }
     if (esp32SemTake(segmentMux, 2100) == pdTRUE) { // WLEDMM serialize mask pointer changes with renderer
       _mask = bits;
       bits = nullptr;

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -192,96 +192,95 @@ bool Segment::setMask(uint8_t id) { // WLEDMM
   size_t bitLen = 0;            // WLEDMM total mask pixels (w*h)
   uint8_t* bits = nullptr;      // WLEDMM bit-packed mask, 1 bit per pixel
   bool inv = maskInvert;        // WLEDMM default to current invert setting
+  auto fail = [&]() -> bool {
+    if (bits) free(bits);
+    maskId = 0; // WLEDMM avoid repeated reload attempts
+    f.close();
+    return false;
+  };
+
+  char buf[32] = { '\0' };
+  if (!f.find("\"w\":")) return fail();
+  f.readBytesUntil('\n', buf, sizeof(buf)-1);
+  w = atoi(cleanUpName(buf));
+
+  f.seek(0);
+  if (!f.find("\"h\":")) return fail();
+  memset(buf, 0, sizeof(buf));
+  f.readBytesUntil('\n', buf, sizeof(buf)-1);
+  h = atoi(cleanUpName(buf));
+
+  if (w == 0 || h == 0) return fail();
+  bitLen = size_t(w) * size_t(h);
+  if (bitLen == 0 || bitLen > (size_t(Segment::maxWidth) * size_t(Segment::maxHeight))) return fail();
+
+  // WLEDMM pack 8 pixels per byte, LSB-first (bit 0 = pixel 0)
+  size_t byteLen = (bitLen + 7) / 8;
+  bits = (uint8_t*)calloc(byteLen, 1);
+  if (!bits) {
+    errorFlag = ERR_LOW_MEM; // WLEDMM raise errorflag
+    return fail();
+  }
+
+  f.seek(0);
+  // WLEDMM strict "inv" boolean parsing (true/false only)
+  if (f.find("\"inv\":")) {
+    String entry = f.readStringUntil(',');
+    int end = entry.indexOf('}');
+    if (end >= 0) entry.remove(end);
+    entry.trim();
+    if (entry == "true") inv = true;
+    else if (entry == "false") inv = false;
+    else return fail();
+  }
+
+  f.seek(0);
+  // WLEDMM strict 0/1 mask array, use streaming parse (ledmap-style)
+  if (!f.find("\"mask\":")) return fail();
+  f.readBytesUntil('[', buf, sizeof(buf)-1);
+
+  size_t i = 0;
+  bool endOfArray = false;
+  while (f.available() && !endOfArray) {
+    String entry = f.readStringUntil(',');
+    int bracket = entry.indexOf(']');
+    if (bracket >= 0) {
+      entry.remove(bracket);
+      endOfArray = true;
+    }
+    entry.trim();
+    if (entry.length() == 0) return fail();
+    if (i >= bitLen) return fail(); // WLEDMM guard against overflow
+    if (entry == "1") bits[i >> 3] |= (0x01U << (i & 7)); // WLEDMM set bit (pixel i) in packed mask
+    else if (entry != "0") return fail();
+    i++;
+    if (i > bitLen) return fail();
+  }
+
+  if (!endOfArray || i != bitLen) return fail();
+
   bool ok = false;
-
-  do {
-    char buf[32] = { '\0' };
-    if (!f.find("\"w\":")) break;
-    f.readBytesUntil('\n', buf, sizeof(buf)-1);
-    w = atoi(cleanUpName(buf));
-
-    f.seek(0);
-    if (!f.find("\"h\":")) break;
-    memset(buf, 0, sizeof(buf));
-    f.readBytesUntil('\n', buf, sizeof(buf)-1);
-    h = atoi(cleanUpName(buf));
-
-    if (w == 0 || h == 0) break;
-    bitLen = size_t(w) * size_t(h);
-    if (bitLen == 0 || bitLen > (size_t(Segment::maxWidth) * size_t(Segment::maxHeight))) break;
-
-    // WLEDMM pack 8 pixels per byte, LSB-first (bit 0 = pixel 0)
-    size_t byteLen = (bitLen + 7) / 8;
-    bits = (uint8_t*)calloc(byteLen, 1);
-    if (!bits) {
-      errorFlag = ERR_LOW_MEM; // WLEDMM raise errorflag
-      break;
-    }
-
-    f.seek(0);
-    // WLEDMM strict "inv" boolean parsing (true/false only)
-    if (f.find("\"inv\":")) {
-      String entry = f.readStringUntil(',');
-      int end = entry.indexOf('}');
-      if (end >= 0) entry.remove(end);
-      entry.trim();
-      if (entry == "true") inv = true;
-      else if (entry == "false") inv = false;
-      else break;
-    }
-
-    f.seek(0);
-    // WLEDMM strict 0/1 mask array, use streaming parse (ledmap-style)
-    if (!f.find("\"mask\":")) break;
-    f.readBytesUntil('[', buf, sizeof(buf)-1);
-
-    size_t i = 0;
-    bool endOfArray = false;
-    bool parsedOk = true;
-    do {
-      String entry = f.readStringUntil(',');
-      int bracket = entry.indexOf(']');
-      if (bracket >= 0) {
-        entry.remove(bracket);
-        endOfArray = true;
-      }
-      entry.trim();
-      if (entry.length() == 0) { parsedOk = false; break; }
-      if (i >= bitLen) { parsedOk = false; break; } // WLEDMM guard against overflow
-      if (entry == "1") bits[i >> 3] |= (0x01U << (i & 7)); // WLEDMM set bit (pixel i) in packed mask
-      else if (entry != "0") { parsedOk = false; break; }
-      i++;
-      if (i > bitLen) { parsedOk = false; break; }
-    } while (f.available() && !endOfArray);
-
-    if (!parsedOk || !endOfArray || i != bitLen) break;
-
+  strip_wait_until_idle("Segment::setMask"); // WLEDMM avoid swapping while renderer is active
+  // WLEDMM clear segment before enabling mask to avoid stale pixels outside the mask
+  if (esp32SemTake(busDrawMux, 250) == pdTRUE) {
+    fill(BLACK);
+    esp32SemGive(busDrawMux);
+  } else {
+    DEBUG_PRINTLN(F("Segment::setMask: Failed to acquire busDrawMux, skipping pre-mask clear."));
+  }
+  if (esp32SemTake(segmentMux, 2100) == pdTRUE) { // WLEDMM serialize mask pointer changes with renderer
+    _mask = bits;
+    bits = nullptr;
+    _maskW = w;
+    _maskH = h;
+    _maskLen = bitLen;
+    maskInvert = inv;
+    _maskValid = (_maskW == calc_virtualWidth() && _maskH == calc_virtualHeight());
+    maskId = id; // WLEDMM commit mask id only on success
+    esp32SemGive(segmentMux);
     ok = true;
-  } while (false);
-
-  if (ok) {
-    strip_wait_until_idle("Segment::setMask"); // WLEDMM avoid swapping while renderer is active
-    // WLEDMM clear segment before enabling mask to avoid stale pixels outside the mask
-    if (esp32SemTake(busDrawMux, 250) == pdTRUE) {
-      fill(BLACK);
-      esp32SemGive(busDrawMux);
-    } else {
-      DEBUG_PRINTLN(F("Segment::setMask: Failed to acquire busDrawMux, skipping pre-mask clear."));
-    }
-    if (esp32SemTake(segmentMux, 2100) == pdTRUE) { // WLEDMM serialize mask pointer changes with renderer
-      _mask = bits;
-      bits = nullptr;
-      _maskW = w;
-      _maskH = h;
-      _maskLen = bitLen;
-      maskInvert = inv;
-      _maskValid = (_maskW == calc_virtualWidth() && _maskH == calc_virtualHeight());
-      maskId = id; // WLEDMM commit mask id only on success
-      esp32SemGive(segmentMux);
-    } else {
-      DEBUG_PRINTLN(F("Segment::setMask: Failed to acquire segmentMux, skipping mask update."));
-      ok = false;
-    }
+  } else {
+    DEBUG_PRINTLN(F("Segment::setMask: Failed to acquire segmentMux, skipping mask update."));
   }
 
   if (!ok && bits) free(bits);

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -100,6 +100,8 @@ Segment::Segment(const Segment &orig) {
   _maskW = 0; // WLEDMM
   _maskH = 0; // WLEDMM
   _maskValid = false; // WLEDMM
+  maskId = 0; // WLEDMM keep id in sync with buffer
+  maskInvert = false; // WLEDMM keep invert in sync with buffer
   if (ledsrgb && !Segment::_globalLeds) {ledsrgb = nullptr; ledsrgbSize = 0;}  // WLEDMM
   if (orig.name) { name = new(std::nothrow) char[strlen(orig.name)+1]; if (name) strcpy(name, orig.name); }
   if (orig.data) { if (allocateData(orig._dataLen, true)) memcpy(data, orig.data, orig._dataLen); }
@@ -349,6 +351,8 @@ Segment& Segment::operator= (const Segment &orig) {
     _maskW = 0; // WLEDMM
     _maskH = 0; // WLEDMM
     _maskValid = false; // WLEDMM
+    maskId = 0; // WLEDMM keep id in sync with buffer
+    maskInvert = false; // WLEDMM keep invert in sync with buffer
     //if (!Segment::_globalLeds) {ledsrgb = oldLeds; ledsrgbSize = oldLedsSize;}; // WLEDMM reuse leds instead of ledsrgb = nullptr;
     if (!Segment::_globalLeds) {ledsrgb = nullptr; ledsrgbSize = 0;};             // WLEDMM copy has no buffers (yet)
     // copy source data

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -91,6 +91,17 @@
   #endif
 #endif
 
+#if defined(WLED_MAX_SEGMASKS) && (WLED_MAX_SEGMASKS > 32 || WLED_MAX_SEGMASKS < 4)
+  #undef WLED_MAX_SEGMASKS
+#endif
+#ifndef WLED_MAX_SEGMASKS
+  #ifdef ESP8266
+    #define WLED_MAX_SEGMASKS 10
+  #else
+    #define WLED_MAX_SEGMASKS 16
+  #endif
+#endif
+
 #ifndef WLED_MAX_SEGNAME_LEN
   #ifdef ESP8266
     #define WLED_MAX_SEGNAME_LEN 32

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -91,6 +91,7 @@
   #endif
 #endif
 
+// WLEDMM segment mask slots (filesystem segmaskX.json)
 #if defined(WLED_MAX_SEGMASKS) && (WLED_MAX_SEGMASKS > 32 || WLED_MAX_SEGMASKS < 4)
   #undef WLED_MAX_SEGMASKS
 #endif

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -26,7 +26,7 @@ var ws, cpick, ranges;
 var cfg = {
 	theme:{base:"dark", bg:{url:""}, alpha:{bg:0.6,tab:0.8}, color:{bg:""}},
 	comp :{colors:{picker: true, rgb: false, quick: true, hex: false},
-          labels:true, pcmbot:false, pid:true, seglen:false, segpwr:false, segexp:true,
+          labels:true, pcmbot:false, pid:true, seglen:false, segpwr:false, segexp:true, 
           css:true, hdays:false, fxdef:true, fxdef2:false} //WLEDMM segexp true as default, fxdef2 added
 };
 var hol = [
@@ -722,13 +722,13 @@ ${inforow("Average FPS",i.leds.fps)}
 ${inforow("Signal strength",i.wifi.signal +"% ("+ i.wifi.rssi, " dBm)")}
 ${inforow("MAC address",i.mac)}
 ${inforow("Uptime",getRuntimeStr(i.uptime))}
-<!-- WLEDMM begin-->
+<!-- WLEDMM begin--> 
 <tr><td colspan=2><hr style="height:2px;border-width:0;color:SeaGreen;background-color:SeaGreen"></td></tr>
 ${inforow("Filesystem",i.fs.u + "/" + i.fs.t + " kB, " +Math.round(i.fs.u*100/i.fs.t) + "%")}
 ${theap>0?inforow("Heap ☾",((i.totalheap-i.freeheap)/1000).toFixed(0)+"/"+theap.toFixed(0)+" kB",", "+Math.round((i.totalheap-i.freeheap)/(10*theap))+"%"):inforow("Free heap",heap," kB")}  <!--WLEDMM different for 8266-->
-${i.minfreeheap?inforow("Max used heap ☾",((i.totalheap-i.minfreeheap)/1000).toFixed(0)+" kB",", "+Math.round((i.totalheap-i.minfreeheap)/(10*theap))+"%"):""}
-${i.psram?inforow("PSRAM ☾",((i.tpsram-i.psram)/1024).toFixed(0)+"/"+(i.tpsram/1024).toFixed(0)+" kB",", "+((i.tpsram-i.psram)*100.0/i.tpsram).toFixed(1)+"%"):""}
-${i.psusedram?inforow("Max used PSRAM ☾",((i.tpsram-i.psusedram)/1024).toFixed(0)+" kB",", "+((i.tpsram-i.psusedram)*100.0/i.tpsram).toFixed(1)+"%"):""}
+${i.minfreeheap?inforow("Max used heap ☾",((i.totalheap-i.minfreeheap)/1000).toFixed(0)+" kB",", "+Math.round((i.totalheap-i.minfreeheap)/(10*theap))+"%"):""} 
+${i.psram?inforow("PSRAM ☾",((i.tpsram-i.psram)/1024).toFixed(0)+"/"+(i.tpsram/1024).toFixed(0)+" kB",", "+((i.tpsram-i.psram)*100.0/i.tpsram).toFixed(1)+"%"):""} 
+${i.psusedram?inforow("Max used PSRAM ☾",((i.tpsram-i.psusedram)/1024).toFixed(0)+" kB",", "+((i.tpsram-i.psusedram)*100.0/i.tpsram).toFixed(1)+"%"):""} 
 ${i.freestack?inforow("Free stack ☾",(i.freestack/1000).toFixed(3)," kB"):""} <!--WLEDMM-->
 <tr><td colspan=2><hr style="height:1px;border-width:0;color:SeaGreen;background-color:SeaGreen"></td></tr>
 ${i.tpsram?inforow("PSRAM " + (i.psrmode?"("+i.psrmode+" mode) ":"") + " ☾",(i.tpsram/1024/1024).toFixed(0)," MB"):inforow("NO PSRAM found.", "")}
@@ -740,7 +740,7 @@ ${i.repo?inforow("Github",i.repo):""}
 ${i.e32code?inforow("Last ESP Restart ☾",i.e32code+" "+i.e32text):""}
 ${i.e32core0code?inforow("Core0 rst reason ☾",i.e32core0code, " "+i.e32core0text):""}
 ${i.e32core1code?inforow("Core1 rst reason ☾",i.e32core1code, " "+i.e32core1text):""}
-<!-- WLEDMM end-->
+<!-- WLEDMM end--> 
 </table>`;
 	gId('kv').innerHTML = cn;
 	//  update all sliders in Info
@@ -1298,7 +1298,7 @@ function populateNodes(i,n)
 				gId(`scale-bri${nodeNr}`).innerText = cfg.light["scale-bri"];
 				gId(`gcc${nodeNr}`).innerText = cfg.light.gc.col  > 1;
 				gId(`fps${nodeNr}`).innerText = cfg.hw.led.fps;
-
+				
 				//if the node has a matrix, show matrix info
 				if (cfg.hw.led.matrix) {
 					gId(`pnl0${nodeNr}`).innerText = showPanel(cfg.hw.led.matrix.panels[0]); //show the first panel
@@ -1309,11 +1309,11 @@ function populateNodes(i,n)
 						let panelIndex = 0; //loop over panels
 						for (let i=0; i<nnodes; i++) { //loop over all nodes found
 							if (panelIndex < cfg.hw.led.matrix.panels.length && n.nodes[i].ip != lastinfo.ip) { //loop over panels of self: assign each panel to a different node
-
+								
 								let panelX = cfg.hw.led.matrix.panels[panelIndex];
-
+								
 								gId(`pnlX${i}`).innerText = showPanel(panelX);
-
+								
 								//store data
 								//nodesData[i] does not exist if not all fetches done
 								if (!nodesData[i]) nodesData[i] = {};
@@ -1349,7 +1349,7 @@ function populateNodes(i,n)
 
 								panelIndex++;
 							}
-							else
+							else 
 								gId(`pnlX${i}`).innerText = "";
 						}
 					}
@@ -1362,7 +1362,7 @@ function populateNodes(i,n)
 		}, function(nodeNr, text) {
 			console.log("json error", nodeNr, ip, n.nodes[nodeNr].name, text);
 			callback(nodeNr); //also callback on error
-		});
+		}); 
 	} //fetchInfoAndCfg
 
 	if (n.nodes) {
@@ -1371,7 +1371,7 @@ function populateNodes(i,n)
 		thisNode.name = i.name;
 		thisNode.ip = i.ip;
 		n.nodes.push(thisNode);
-
+		
 		n.nodes.sort((a,b) => (a.name).localeCompare(b.name)); //alphabetic on name
 		// console.log("populateNodes",i,n);
 
@@ -1681,19 +1681,19 @@ function drawSegmentView() {
 	function post() {
 		for (let p=0; p<gId("segcont").children.length; p++) {
 			if (!initSegmentVars(p)) break;
-
+			
 			if (gId("segcont").children.length>1) { //only show number and name if more than one segment
-				ctx.font = '40px Arial';
+				ctx.font = '40px Arial'; 
 				ctx.fillStyle = "orange";
 				ctx.fillText(p, topLeftX + pw/2*ppL - 10, topLeftY + ph/2*ppL + 10);
 
 				//show name of fx
-				ctx.font = '20px Arial';
+				ctx.font = '20px Arial'; 
 				ctx.fillStyle = "white";
 				var name = eJson.find((o)=>{return o.id==fx}).name;
 				ctx.fillText(name, topLeftX+10, topLeftY + ph*ppL - 10);
 			}
-		}
+		}	
 	}
 
 	//draw the ledmap
@@ -1721,7 +1721,7 @@ function drawSegmentView() {
 			for (let i=0;i<customMappingTable.length;i++) {
 				let mapIndex = customMappingTable[i];
 				if (mapIndex != -1) {
-					ctx.font = parseInt(ppL/3) + 'px Arial';
+					ctx.font = parseInt(ppL/3) + 'px Arial'; 
 					ctx.fillStyle = "white";
 					if (lastinfo.outputs!=null) {
 						var ledcount = 0;
@@ -3382,7 +3382,7 @@ function genPresets()
 				if (!defaultString.includes("o2")) defaultString += ',"o2":0'; //Check 2
 				if (!defaultString.includes("o3")) defaultString += ',"o3":0'; //Check 3
 				if (!defaultString.includes("pal")) defaultString += ',"pal":11'; //Temporary for deterministic effects test: Set to 11/Raibow instead of 1/Random smooth palette (if not set different)
-				if (!defaultString.includes("m12") && m.includes("1") && !m.includes("1.5") && !m.includes("12"))
+				if (!defaultString.includes("m12") && m.includes("1") && !m.includes("1.5") && !m.includes("12")) 
 					defaultString += ',"rev":true,"mi":true,"rY":true,"mY":true,"m12":2'; //Arc expansion
 				else {
 					if (!defaultString.includes("rev")) defaultString += ',"rev":false';
@@ -3806,24 +3806,24 @@ function checkVersionUpgrade(info) {
 function showVersionUpgradePrompt(info, oldVersion, newVersion) {
 	// Determine if this is an install or upgrade
 	const isInstall = !oldVersion;
-
+	
 	// Create overlay and dialog
 	const overlay = d.createElement('div');
 	overlay.id = 'versionUpgradeOverlay';
 	overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);z-index:10000;display:flex;align-items:center;justify-content:center;';
-
+	
 	const dialog = d.createElement('div');
 	dialog.style.cssText = 'background:var(--c-1);border-radius:10px;padding:25px;max-width:500px;margin:20px;box-shadow:0 4px 6px rgba(0,0,0,0.3);';
-
+	
 	// Build contextual message based on install vs upgrade
-	const title = isInstall
-		? '🎉 Thank you for installing WLED-MM!'
+	const title = isInstall 
+		? '🎉 Thank you for installing WLED-MM!' 
 		: '🎉 WLED-MM Upgrade Detected!';
-
+	
 	const description = isInstall
 		? `You are now running WLED-MM <strong>${newVersion}</strong>.`
 		: `Your WLED-MM has been upgraded from <strong>${oldVersion}</strong> to <strong>${newVersion}</strong>.`;
-
+	
 	const question = 'Would you like to help the WLED development team by reporting your installation? This helps us understand what hardware and versions are being used.'
 
 	dialog.innerHTML = `
@@ -3836,21 +3836,21 @@ function showVersionUpgradePrompt(info, oldVersion, newVersion) {
 			<button id="versionReportNever" class="btn">Never Ask</button>
 		</div>
 	`;
-
+	
 	overlay.appendChild(dialog);
 	d.body.appendChild(overlay);
-
+	
 	// Add event listeners
 	gId('versionReportYes').addEventListener('click', () => {
 		reportUpgradeEvent(oldVersion, newVersion);
 		d.body.removeChild(overlay);
 	});
-
+	
 	gId('versionReportNo').addEventListener('click', () => {
 		// Don't update version, will ask again on next load
 		d.body.removeChild(overlay);
 	});
-
+	
 	gId('versionReportNever').addEventListener('click', () => {
 		updateVersionInfo(newVersion, true);
 		d.body.removeChild(overlay);
@@ -3860,7 +3860,7 @@ function showVersionUpgradePrompt(info, oldVersion, newVersion) {
 
 function reportUpgradeEvent(oldVersion, newVersion) {
 	showToast('Reporting upgrade...');
-
+	
 	// Fetch fresh data from /json/info endpoint as requested
 	fetch('/json/info', {
 		method: 'get'
@@ -3918,12 +3918,12 @@ function updateVersionInfo(version, neverAsk) {
 		version: version,
 		neverAsk: neverAsk
 	};
-
+	
 	// Create a Blob with JSON content and use /upload endpoint
 	const blob = new Blob([JSON.stringify(versionInfo)], { type: 'application/json' });
 	const formData = new FormData();
 	formData.append('data', blob, 'version-info.json');
-
+	
 	fetch('/upload', {
 		method: 'POST',
 		body: formData

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -817,6 +817,23 @@ function populateSegments(s)
 							`<option value="1" ${inst.si==1?' selected':''}>WeWillRockYou</option>`+
 						`</select></div>`+
 					`</div>`;
+		let maskSel = "";
+		let maskId = inst.mask || 0;
+		let maskInv = inst.minv || false;
+		let maskList = Array.isArray(li.masks) ? li.masks : [];
+		if (maskList.length > 0 || maskId > 0) {
+			let opts = `<option value="0"${maskId==0?' selected':''}>None</option>`;
+			for (const m of maskList) opts += `<option value="${m.id}"${maskId==m.id?' selected':''}>segmask${m.id}.json</option>`;
+			maskSel = `<div class="lbl-s">Mask<br>`+
+				`<div class="sel-p"><select class="sel-p" id="seg${i}msk" onchange="setMask(${i})">`+
+					`${opts}`+
+				`</select></div>`+
+			`</div>`+
+			`<label class="check revchkl">Invert mask`+
+				`<input type="checkbox" id="seg${i}minv" onchange="setMaskInv(${i})" ${maskInv?"checked":""}>`+
+				`<span class="checkmark"></span>`+
+			`</label>`;
+		}
 		//WLEDMM ARTIFX
 		let fxName = eJson.find((o)=>{return o.id==selectedFx}).name;
 		let cusEff = `<button class="btn" onclick="toggleCEEditor('${inst.n?inst.n:"default"}', ${i})">ARTI-FX Editor ☾</button><br>`;
@@ -870,6 +887,7 @@ function populateSegments(s)
 					`<div class="h bp" id="seg${i}len"></div>`+
 					(!isMSeg ? rvXck : '') +
 					(isMSeg&&stoY-staY>1&&stoX-staX>1 ? map2D : '') +
+					maskSel +
 					(s.AudioReactive && s.AudioReactive.on ? "" : sndSim) +
 					(s.ARTIFX && s.ARTIFX.on && fxName.includes("ARTI-FX") ? cusEff : "") + // <!--WLEDMM-->
 					`<label class="check revchkl" id="seg${i}lbtm">`+
@@ -2833,6 +2851,20 @@ function setM12(s)
 {
 	var value = gId(`seg${s}m12`).selectedIndex;
 	var obj = {"seg": {"id": s, "m12": value}};
+	requestJson(obj);
+}
+
+function setMask(s)
+{
+	var value = parseInt(gId(`seg${s}msk`).value);
+	var obj = {"seg": {"id": s, "mask": value}};
+	requestJson(obj);
+}
+
+function setMaskInv(s)
+{
+	var value = gId(`seg${s}minv`).checked;
+	var obj = {"seg": {"id": s, "minv": value}};
 	requestJson(obj);
 }
 

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -26,7 +26,7 @@ var ws, cpick, ranges;
 var cfg = {
 	theme:{base:"dark", bg:{url:""}, alpha:{bg:0.6,tab:0.8}, color:{bg:""}},
 	comp :{colors:{picker: true, rgb: false, quick: true, hex: false},
-          labels:true, pcmbot:false, pid:true, seglen:false, segpwr:false, segexp:true, 
+          labels:true, pcmbot:false, pid:true, seglen:false, segpwr:false, segexp:true,
           css:true, hdays:false, fxdef:true, fxdef2:false} //WLEDMM segexp true as default, fxdef2 added
 };
 var hol = [
@@ -722,13 +722,13 @@ ${inforow("Average FPS",i.leds.fps)}
 ${inforow("Signal strength",i.wifi.signal +"% ("+ i.wifi.rssi, " dBm)")}
 ${inforow("MAC address",i.mac)}
 ${inforow("Uptime",getRuntimeStr(i.uptime))}
-<!-- WLEDMM begin--> 
+<!-- WLEDMM begin-->
 <tr><td colspan=2><hr style="height:2px;border-width:0;color:SeaGreen;background-color:SeaGreen"></td></tr>
 ${inforow("Filesystem",i.fs.u + "/" + i.fs.t + " kB, " +Math.round(i.fs.u*100/i.fs.t) + "%")}
 ${theap>0?inforow("Heap ☾",((i.totalheap-i.freeheap)/1000).toFixed(0)+"/"+theap.toFixed(0)+" kB",", "+Math.round((i.totalheap-i.freeheap)/(10*theap))+"%"):inforow("Free heap",heap," kB")}  <!--WLEDMM different for 8266-->
-${i.minfreeheap?inforow("Max used heap ☾",((i.totalheap-i.minfreeheap)/1000).toFixed(0)+" kB",", "+Math.round((i.totalheap-i.minfreeheap)/(10*theap))+"%"):""} 
-${i.psram?inforow("PSRAM ☾",((i.tpsram-i.psram)/1024).toFixed(0)+"/"+(i.tpsram/1024).toFixed(0)+" kB",", "+((i.tpsram-i.psram)*100.0/i.tpsram).toFixed(1)+"%"):""} 
-${i.psusedram?inforow("Max used PSRAM ☾",((i.tpsram-i.psusedram)/1024).toFixed(0)+" kB",", "+((i.tpsram-i.psusedram)*100.0/i.tpsram).toFixed(1)+"%"):""} 
+${i.minfreeheap?inforow("Max used heap ☾",((i.totalheap-i.minfreeheap)/1000).toFixed(0)+" kB",", "+Math.round((i.totalheap-i.minfreeheap)/(10*theap))+"%"):""}
+${i.psram?inforow("PSRAM ☾",((i.tpsram-i.psram)/1024).toFixed(0)+"/"+(i.tpsram/1024).toFixed(0)+" kB",", "+((i.tpsram-i.psram)*100.0/i.tpsram).toFixed(1)+"%"):""}
+${i.psusedram?inforow("Max used PSRAM ☾",((i.tpsram-i.psusedram)/1024).toFixed(0)+" kB",", "+((i.tpsram-i.psusedram)*100.0/i.tpsram).toFixed(1)+"%"):""}
 ${i.freestack?inforow("Free stack ☾",(i.freestack/1000).toFixed(3)," kB"):""} <!--WLEDMM-->
 <tr><td colspan=2><hr style="height:1px;border-width:0;color:SeaGreen;background-color:SeaGreen"></td></tr>
 ${i.tpsram?inforow("PSRAM " + (i.psrmode?"("+i.psrmode+" mode) ":"") + " ☾",(i.tpsram/1024/1024).toFixed(0)," MB"):inforow("NO PSRAM found.", "")}
@@ -740,7 +740,7 @@ ${i.repo?inforow("Github",i.repo):""}
 ${i.e32code?inforow("Last ESP Restart ☾",i.e32code+" "+i.e32text):""}
 ${i.e32core0code?inforow("Core0 rst reason ☾",i.e32core0code, " "+i.e32core0text):""}
 ${i.e32core1code?inforow("Core1 rst reason ☾",i.e32core1code, " "+i.e32core1text):""}
-<!-- WLEDMM end--> 
+<!-- WLEDMM end-->
 </table>`;
 	gId('kv').innerHTML = cn;
 	//  update all sliders in Info
@@ -791,6 +791,10 @@ function populateSegments(s)
 		let staY = inst.startY;
 		let stoY = inst.stopY;
 		let isMSeg = isM && staX<mw*mh; // 2D matrix segment
+		// WLEDMM segment masks
+		let maskId = inst.mask || 0; // WLEDMM
+		let maskInv = inst.minv || false; // WLEDMM
+		let maskActive = (maskId > 0); // WLEDMM
 		let rvXck = `<label class="check revchkl">Reverse ${isM?'':'direction'}<input type="checkbox" id="seg${i}rev" onchange="setRev(${i})" ${inst.rev?"checked":""}><span class="checkmark"></span></label>`;
 		let miXck = `<label class="check revchkl">Mirror<input type="checkbox" id="seg${i}mi" onchange="setMi(${i})" ${inst.mi?"checked":""}><span class="checkmark"></span></label>`;
 		let rvYck = "", miYck ="";
@@ -817,23 +821,35 @@ function populateSegments(s)
 							`<option value="1" ${inst.si==1?' selected':''}>WeWillRockYou</option>`+
 						`</select></div>`+
 					`</div>`;
+		// WLEDMM begin: segment mask UI
 		let maskSel = "";
-		let maskId = inst.mask || 0;
-		let maskInv = inst.minv || false;
+		let maskInvSel = "";
+		let maskInfo = "";
 		let maskList = Array.isArray(li.masks) ? li.masks : [];
 		if (maskList.length > 0 || maskId > 0) {
 			let opts = `<option value="0"${maskId==0?' selected':''}>None</option>`;
-			for (const m of maskList) opts += `<option value="${m.id}"${maskId==m.id?' selected':''}>segmask${m.id}.json</option>`;
-			maskSel = `<div class="lbl-s">Mask<br>`+
+			let hasMaskId = false;
+			for (const m of maskList) {
+				if (m.id == maskId) hasMaskId = true;
+				opts += `<option value="${m.id}"${maskId==m.id?' selected':''}>segmask${m.id}.json</option>`;
+			}
+			if (maskId > 0 && !hasMaskId) {
+				opts += `<option value="${maskId}" selected>segmask${maskId}.json (missing)</option>`; // WLEDMM keep unknown mask visible
+			}
+			maskSel = `<div class="lbl-s">Mask ☾<br>`+
 				`<div class="sel-p"><select class="sel-p" id="seg${i}msk" onchange="setMask(${i})">`+
 					`${opts}`+
 				`</select></div>`+
-			`</div>`+
-			`<label class="check revchkl">Invert mask`+
-				`<input type="checkbox" id="seg${i}minv" onchange="setMaskInv(${i})" ${maskInv?"checked":""}>`+
-				`<span class="checkmark"></span>`+
-			`</label>`;
+			`</div>`;
+			if (maskActive) {
+				maskInvSel = `<label class="check revchkl">Invert mask ☾`+
+					`<input type="checkbox" id="seg${i}minv" onchange="setMaskInv(${i})" ${maskInv?"checked":""}>`+
+					`<span class="checkmark"></span>`+
+				`</label>`;
+				maskInfo = `<div class="lbl-l">Mask clips output ☾; bounds and mapping still apply.</div>`; // WLEDMM
+			}
 		}
+		// WLEDMM end: segment mask UI
 		//WLEDMM ARTIFX
 		let fxName = eJson.find((o)=>{return o.id==selectedFx}).name;
 		let cusEff = `<button class="btn" onclick="toggleCEEditor('${inst.n?inst.n:"default"}', ${i})">ARTI-FX Editor ☾</button><br>`;
@@ -887,7 +903,7 @@ function populateSegments(s)
 					`<div class="h bp" id="seg${i}len"></div>`+
 					(!isMSeg ? rvXck : '') +
 					(isMSeg&&stoY-staY>1&&stoX-staX>1 ? map2D : '') +
-					maskSel +
+					maskSel + maskInvSel + maskInfo + // WLEDMM
 					(s.AudioReactive && s.AudioReactive.on ? "" : sndSim) +
 					(s.ARTIFX && s.ARTIFX.on && fxName.includes("ARTI-FX") ? cusEff : "") + // <!--WLEDMM-->
 					`<label class="check revchkl" id="seg${i}lbtm">`+
@@ -1282,7 +1298,7 @@ function populateNodes(i,n)
 				gId(`scale-bri${nodeNr}`).innerText = cfg.light["scale-bri"];
 				gId(`gcc${nodeNr}`).innerText = cfg.light.gc.col  > 1;
 				gId(`fps${nodeNr}`).innerText = cfg.hw.led.fps;
-				
+
 				//if the node has a matrix, show matrix info
 				if (cfg.hw.led.matrix) {
 					gId(`pnl0${nodeNr}`).innerText = showPanel(cfg.hw.led.matrix.panels[0]); //show the first panel
@@ -1293,11 +1309,11 @@ function populateNodes(i,n)
 						let panelIndex = 0; //loop over panels
 						for (let i=0; i<nnodes; i++) { //loop over all nodes found
 							if (panelIndex < cfg.hw.led.matrix.panels.length && n.nodes[i].ip != lastinfo.ip) { //loop over panels of self: assign each panel to a different node
-								
+
 								let panelX = cfg.hw.led.matrix.panels[panelIndex];
-								
+
 								gId(`pnlX${i}`).innerText = showPanel(panelX);
-								
+
 								//store data
 								//nodesData[i] does not exist if not all fetches done
 								if (!nodesData[i]) nodesData[i] = {};
@@ -1333,7 +1349,7 @@ function populateNodes(i,n)
 
 								panelIndex++;
 							}
-							else 
+							else
 								gId(`pnlX${i}`).innerText = "";
 						}
 					}
@@ -1346,7 +1362,7 @@ function populateNodes(i,n)
 		}, function(nodeNr, text) {
 			console.log("json error", nodeNr, ip, n.nodes[nodeNr].name, text);
 			callback(nodeNr); //also callback on error
-		}); 
+		});
 	} //fetchInfoAndCfg
 
 	if (n.nodes) {
@@ -1355,7 +1371,7 @@ function populateNodes(i,n)
 		thisNode.name = i.name;
 		thisNode.ip = i.ip;
 		n.nodes.push(thisNode);
-		
+
 		n.nodes.sort((a,b) => (a.name).localeCompare(b.name)); //alphabetic on name
 		// console.log("populateNodes",i,n);
 
@@ -1474,7 +1490,14 @@ function updateLen(s, draw=true) //WLEDMM conditionally draw segment view
 			if (stop-start>1 && stopY-startY>1) {
 				// 2D segment
 				if (tPL) tPL.classList.remove('hide'); // unhide transpose checkbox
-				let sE = gId('fxlist').querySelector(`.lstI[data-id="${selectedFx}"]`);
+				// WLEDMM use per-segment effect to decide 1D mapping UI
+				let segFx = selectedFx;
+				let segFxEl = gId(`seg${s}fx`);
+				if (segFxEl && segFxEl.value !== "") {
+					let fxVal = parseInt(segFxEl.value);
+					if (!isNaN(fxVal)) segFx = fxVal;
+				}
+				let sE = gId('fxlist').querySelector(`.lstI[data-id="${segFx}"]`);
 				if (sE) {
 					let sN = sE.querySelector(".lstIname").innerText;
 					let seg = gId(`seg${s}map2D`);
@@ -1658,19 +1681,19 @@ function drawSegmentView() {
 	function post() {
 		for (let p=0; p<gId("segcont").children.length; p++) {
 			if (!initSegmentVars(p)) break;
-			
+
 			if (gId("segcont").children.length>1) { //only show number and name if more than one segment
-				ctx.font = '40px Arial'; 
+				ctx.font = '40px Arial';
 				ctx.fillStyle = "orange";
 				ctx.fillText(p, topLeftX + pw/2*ppL - 10, topLeftY + ph/2*ppL + 10);
 
 				//show name of fx
-				ctx.font = '20px Arial'; 
+				ctx.font = '20px Arial';
 				ctx.fillStyle = "white";
 				var name = eJson.find((o)=>{return o.id==fx}).name;
 				ctx.fillText(name, topLeftX+10, topLeftY + ph*ppL - 10);
 			}
-		}	
+		}
 	}
 
 	//draw the ledmap
@@ -1698,7 +1721,7 @@ function drawSegmentView() {
 			for (let i=0;i<customMappingTable.length;i++) {
 				let mapIndex = customMappingTable[i];
 				if (mapIndex != -1) {
-					ctx.font = parseInt(ppL/3) + 'px Arial'; 
+					ctx.font = parseInt(ppL/3) + 'px Arial';
 					ctx.fillStyle = "white";
 					if (lastinfo.outputs!=null) {
 						var ledcount = 0;
@@ -2854,6 +2877,7 @@ function setM12(s)
 	requestJson(obj);
 }
 
+// WLEDMM segment mask selection
 function setMask(s)
 {
 	var value = parseInt(gId(`seg${s}msk`).value);
@@ -2861,6 +2885,7 @@ function setMask(s)
 	requestJson(obj);
 }
 
+// WLEDMM segment mask invert
 function setMaskInv(s)
 {
 	var value = gId(`seg${s}minv`).checked;
@@ -3357,7 +3382,7 @@ function genPresets()
 				if (!defaultString.includes("o2")) defaultString += ',"o2":0'; //Check 2
 				if (!defaultString.includes("o3")) defaultString += ',"o3":0'; //Check 3
 				if (!defaultString.includes("pal")) defaultString += ',"pal":11'; //Temporary for deterministic effects test: Set to 11/Raibow instead of 1/Random smooth palette (if not set different)
-				if (!defaultString.includes("m12") && m.includes("1") && !m.includes("1.5") && !m.includes("12")) 
+				if (!defaultString.includes("m12") && m.includes("1") && !m.includes("1.5") && !m.includes("12"))
 					defaultString += ',"rev":true,"mi":true,"rY":true,"mY":true,"m12":2'; //Arc expansion
 				else {
 					if (!defaultString.includes("rev")) defaultString += ',"rev":false';
@@ -3781,24 +3806,24 @@ function checkVersionUpgrade(info) {
 function showVersionUpgradePrompt(info, oldVersion, newVersion) {
 	// Determine if this is an install or upgrade
 	const isInstall = !oldVersion;
-	
+
 	// Create overlay and dialog
 	const overlay = d.createElement('div');
 	overlay.id = 'versionUpgradeOverlay';
 	overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);z-index:10000;display:flex;align-items:center;justify-content:center;';
-	
+
 	const dialog = d.createElement('div');
 	dialog.style.cssText = 'background:var(--c-1);border-radius:10px;padding:25px;max-width:500px;margin:20px;box-shadow:0 4px 6px rgba(0,0,0,0.3);';
-	
+
 	// Build contextual message based on install vs upgrade
-	const title = isInstall 
-		? '🎉 Thank you for installing WLED-MM!' 
+	const title = isInstall
+		? '🎉 Thank you for installing WLED-MM!'
 		: '🎉 WLED-MM Upgrade Detected!';
-	
+
 	const description = isInstall
 		? `You are now running WLED-MM <strong>${newVersion}</strong>.`
 		: `Your WLED-MM has been upgraded from <strong>${oldVersion}</strong> to <strong>${newVersion}</strong>.`;
-	
+
 	const question = 'Would you like to help the WLED development team by reporting your installation? This helps us understand what hardware and versions are being used.'
 
 	dialog.innerHTML = `
@@ -3811,21 +3836,21 @@ function showVersionUpgradePrompt(info, oldVersion, newVersion) {
 			<button id="versionReportNever" class="btn">Never Ask</button>
 		</div>
 	`;
-	
+
 	overlay.appendChild(dialog);
 	d.body.appendChild(overlay);
-	
+
 	// Add event listeners
 	gId('versionReportYes').addEventListener('click', () => {
 		reportUpgradeEvent(oldVersion, newVersion);
 		d.body.removeChild(overlay);
 	});
-	
+
 	gId('versionReportNo').addEventListener('click', () => {
 		// Don't update version, will ask again on next load
 		d.body.removeChild(overlay);
 	});
-	
+
 	gId('versionReportNever').addEventListener('click', () => {
 		updateVersionInfo(newVersion, true);
 		d.body.removeChild(overlay);
@@ -3835,7 +3860,7 @@ function showVersionUpgradePrompt(info, oldVersion, newVersion) {
 
 function reportUpgradeEvent(oldVersion, newVersion) {
 	showToast('Reporting upgrade...');
-	
+
 	// Fetch fresh data from /json/info endpoint as requested
 	fetch('/json/info', {
 		method: 'get'
@@ -3893,12 +3918,12 @@ function updateVersionInfo(version, neverAsk) {
 		version: version,
 		neverAsk: neverAsk
 	};
-	
+
 	// Create a Blob with JSON content and use /upload endpoint
 	const blob = new Blob([JSON.stringify(versionInfo)], { type: 'application/json' });
 	const formData = new FormData();
 	formData.append('data', blob, 'version-info.json');
-	
+
 	fetch('/upload', {
 		method: 'POST',
 		body: formData

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -846,7 +846,6 @@ function populateSegments(s)
 					`<input type="checkbox" id="seg${i}minv" onchange="setMaskInv(${i})" ${maskInv?"checked":""}>`+
 					`<span class="checkmark"></span>`+
 				`</label>`;
-				maskInfo = `<div class="lbl-l">Mask clips output ☾; bounds and mapping still apply.</div>`; // WLEDMM
 			}
 		}
 		// WLEDMM end: segment mask UI
@@ -903,7 +902,7 @@ function populateSegments(s)
 					`<div class="h bp" id="seg${i}len"></div>`+
 					(!isMSeg ? rvXck : '') +
 					(isMSeg&&stoY-staY>1&&stoX-staX>1 ? map2D : '') +
-					maskSel + maskInvSel + maskInfo + // WLEDMM
+					maskSel + maskInvSel + // WLEDMM
 					(s.AudioReactive && s.AudioReactive.on ? "" : sndSim) +
 					(s.ARTIFX && s.ARTIFX.on && fxName.includes("ARTI-FX") ? cusEff : "") + // <!--WLEDMM-->
 					`<label class="check revchkl" id="seg${i}lbtm">`+

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -365,7 +365,11 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
     int maskVal = elem["mask"] | 0;
     if (maskVal < 0) maskVal = 0;
     uint8_t maskId = constrain(maskVal, 0, WLED_MAX_SEGMASKS-1);
-    if (maskId != seg.maskId || (maskId != 0 && !seg.hasMask())) seg.setMask(maskId);
+    if (maskId == 0) { // WLEDMM explicit clear path
+      if (seg.hasMask()) seg.clearMask();
+    } else if (maskId != seg.maskId || !seg.hasMask()) {
+      seg.setMask(maskId);
+    }
   }
   if (elem.containsKey("minv")) { // WLEDMM segment mask invert
     seg.maskInvert = elem["minv"] | seg.maskInvert;

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -361,13 +361,13 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
   seg.check2 = elem["o2"] | seg.check2;
   seg.check3 = elem["o3"] | seg.check3;
 
-  if (elem.containsKey("mask")) {
+  if (elem.containsKey("mask")) { // WLEDMM segment mask id
     int maskVal = elem["mask"] | 0;
     if (maskVal < 0) maskVal = 0;
     uint8_t maskId = constrain(maskVal, 0, WLED_MAX_SEGMASKS-1);
     if (maskId != seg.maskId || (maskId != 0 && !seg.hasMask())) seg.setMask(maskId);
   }
-  if (elem.containsKey("minv")) {
+  if (elem.containsKey("minv")) { // WLEDMM segment mask invert
     seg.maskInvert = elem["minv"] | seg.maskInvert;
   }
 
@@ -768,8 +768,8 @@ void serializeSegment(JsonObject& root, Segment& seg, byte id, bool forPreset, b
   root["o3"]  = seg.check3;
   root["si"]  = seg.soundSim;
   root["m12"] = seg.map1D2D;
-  root["mask"] = seg.maskId;
-  root["minv"] = seg.maskInvert;
+  root["mask"] = seg.maskId;     // WLEDMM segment mask id
+  root["minv"] = seg.maskInvert; // WLEDMM segment mask invert
 }
 
 void serializeState(JsonObject root, bool forPreset, bool includeBri, bool segmentBounds, bool selectedSegmentsOnly)
@@ -1073,7 +1073,7 @@ void serializeInfo(JsonObject root)
     }
   }
 
-  JsonArray masks = root.createNestedArray(F("masks"));
+  JsonArray masks = root.createNestedArray(F("masks")); // WLEDMM segment mask files
   for (size_t i=1; i<WLED_MAX_SEGMASKS; i++) {
     if ((segMasks>>i) & 0x00000001U) {
       JsonObject masks0 = masks.createNestedObject();

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -361,6 +361,16 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
   seg.check2 = elem["o2"] | seg.check2;
   seg.check3 = elem["o3"] | seg.check3;
 
+  if (elem.containsKey("mask")) {
+    int maskVal = elem["mask"] | 0;
+    if (maskVal < 0) maskVal = 0;
+    uint8_t maskId = constrain(maskVal, 0, WLED_MAX_SEGMASKS-1);
+    if (maskId != seg.maskId || (maskId != 0 && !seg.hasMask())) seg.setMask(maskId);
+  }
+  if (elem.containsKey("minv")) {
+    seg.maskInvert = elem["minv"] | seg.maskInvert;
+  }
+
   JsonArray iarr = elem[F("i")]; //set individual LEDs
   if (!iarr.isNull()) {
     uint8_t oldMap1D2D = seg.map1D2D;
@@ -758,6 +768,8 @@ void serializeSegment(JsonObject& root, Segment& seg, byte id, bool forPreset, b
   root["o3"]  = seg.check3;
   root["si"]  = seg.soundSim;
   root["m12"] = seg.map1D2D;
+  root["mask"] = seg.maskId;
+  root["minv"] = seg.maskInvert;
 }
 
 void serializeState(JsonObject root, bool forPreset, bool includeBri, bool segmentBounds, bool selectedSegmentsOnly)
@@ -1058,6 +1070,14 @@ void serializeInfo(JsonObject root)
       #ifndef ESP8266
       if (i && ledmapNames[i-1]) ledmaps0["n"] = ledmapNames[i-1];
       #endif
+    }
+  }
+
+  JsonArray masks = root.createNestedArray(F("masks"));
+  for (size_t i=1; i<WLED_MAX_SEGMASKS; i++) {
+    if ((segMasks>>i) & 0x00000001U) {
+      JsonObject masks0 = masks.createNestedObject();
+      masks0["id"] = i;
     }
   }
 

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -307,7 +307,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
   #endif
     DEBUG_PRINTLN(F("Enumerating ledmaps"));
     strip.enumerateLedmaps();
-    strip.enumerateSegmasks();
+    strip.enumerateSegmasks(); // WLEDMM
     DEBUG_PRINTLN(F("Loading custom palettes"));
     strip.loadCustomPalettes(); // (re)load all custom palettes
   }

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -307,6 +307,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
   #endif
     DEBUG_PRINTLN(F("Enumerating ledmaps"));
     strip.enumerateLedmaps();
+    strip.enumerateSegmasks();
     DEBUG_PRINTLN(F("Loading custom palettes"));
     strip.loadCustomPalettes(); // (re)load all custom palettes
   }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -335,7 +335,7 @@ void WLED::loop()
   if (loadLedmap) {
     if (!strip.deserializeMap(loadedLedmap) && strip.isMatrix) strip.setUpMatrix(); //WLEDMM: always if nonexistent:  && loadedLedmap == 0
     strip.enumerateLedmaps(); //WLEDMM
-    strip.enumerateSegmasks();
+    strip.enumerateSegmasks(); // WLEDMM
     loadLedmap = false;
   }
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -335,6 +335,7 @@ void WLED::loop()
   if (loadLedmap) {
     if (!strip.deserializeMap(loadedLedmap) && strip.isMatrix) strip.setUpMatrix(); //WLEDMM: always if nonexistent:  && loadedLedmap == 0
     strip.enumerateLedmaps(); //WLEDMM
+    strip.enumerateSegmasks();
     loadLedmap = false;
   }
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
 
 // version code in format yymmddb (b = daily build)
 #ifndef WLED_BUILD_VERSION // WLEDMM allow override by nightly build script
-  #define VERSION 2601201
+  #define VERSION 2601211
 #else
   #define VERSION WLED_BUILD_VERSION
 #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -816,6 +816,11 @@ WLED_GLOBAL uint32_t ledMaps _INIT(0); // bitfield representation of available l
 #else
 WLED_GLOBAL uint16_t ledMaps _INIT(0); // bitfield representation of available ledmaps
 #endif
+#if WLED_MAX_SEGMASKS>16
+WLED_GLOBAL uint32_t segMasks _INIT(0); // bitfield representation of available segment masks
+#else
+WLED_GLOBAL uint16_t segMasks _INIT(0); // bitfield representation of available segment masks
+#endif
 
 // Usermod manager
 WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
 
 // version code in format yymmddb (b = daily build)
 #ifndef WLED_BUILD_VERSION // WLEDMM allow override by nightly build script
-  #define VERSION 2601151
+  #define VERSION 2601201
 #else
   #define VERSION WLED_BUILD_VERSION
 #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -817,9 +817,9 @@ WLED_GLOBAL uint32_t ledMaps _INIT(0); // bitfield representation of available l
 WLED_GLOBAL uint16_t ledMaps _INIT(0); // bitfield representation of available ledmaps
 #endif
 #if WLED_MAX_SEGMASKS>16
-WLED_GLOBAL uint32_t segMasks _INIT(0); // bitfield representation of available segment masks
+WLED_GLOBAL uint32_t segMasks _INIT(0); // WLEDMM bitfield of available segment masks
 #else
-WLED_GLOBAL uint16_t segMasks _INIT(0); // bitfield representation of available segment masks
+WLED_GLOBAL uint16_t segMasks _INIT(0); // WLEDMM bitfield of available segment masks
 #endif
 
 // Usermod manager

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
 
 // version code in format yymmddb (b = daily build)
 #ifndef WLED_BUILD_VERSION // WLEDMM allow override by nightly build script
-  #define VERSION 2601211
+  #define VERSION 2601231
 #else
   #define VERSION WLED_BUILD_VERSION
 #endif
@@ -816,11 +816,7 @@ WLED_GLOBAL uint32_t ledMaps _INIT(0); // bitfield representation of available l
 #else
 WLED_GLOBAL uint16_t ledMaps _INIT(0); // bitfield representation of available ledmaps
 #endif
-#if WLED_MAX_SEGMASKS>16
 WLED_GLOBAL uint32_t segMasks _INIT(0); // WLEDMM bitfield of available segment masks
-#else
-WLED_GLOBAL uint16_t segMasks _INIT(0); // WLEDMM bitfield of available segment masks
-#endif
 
 // Usermod manager
 WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());


### PR DESCRIPTION
## Overview

<img height="512" alt="image" src="https://github.com/user-attachments/assets/417ebeff-5809-4833-96a4-ac0c84a93f20" />
<img width="297" height="413" alt="image" src="https://github.com/user-attachments/assets/94169b01-a6f7-46c0-9689-728110971c3b" /> 
<img width="195" height="354" alt="image" src="https://github.com/user-attachments/assets/6d744aac-6c20-404a-a8fa-4194b6a8b58c" />

I'm designing a fancy sign for a craft fair booth with an engraved sheet of acrylic in front. In order to properly light it, I would like to define segments for various shapes in the engraved sheet such that I can apply different effects to each area. Currently, support for this is limited to ledmaps (only one across all segments), jMaps (1D -> 2D translation only), and grouping (only works for specific designs)

This PR adds support for clipping masks per segment, defined in virtual LED space. This enables overlapping segments to render distinct effects/palettes while preserving normal segment geometry and mappings.

## Summary of changes

- Add per‑segment mask clipping via segmaskX.json files (1D + 2D).
- Expose mask selection + invert in the UI (MM‑specific items marked with 🌜).
- Stream‑parse mask files (ledmap‑style) and enumerate available masks.
- Make 1D mask gating work on matrix installs and add a safety reset on failed mask loads.

## How it works

- Mask storage: bit‑packed 0/1 mask loaded from /segmaskX.json (stream parser like ledmap).
- Mask checks:
    - 2D: mask checked in setPixelColorXY_*.
    - 1D: mask checked in setPixelColor with !is2D() so 1D segments still mask on matrix installs.
- JSON API: segment state uses mask + minv; /json/info exposes available mask IDs.
- UI: adds “Mask 🌜” dropdown and “Invert mask 🌜”

## Segmask.json

Masks are defined by 1/0 values in a list similar to ledmapN.json files:

```json
{"w":16,"h":32,"mask":[0,0,0,1,1,1,0,0,0,0,...,0,1,1],"inv":false}
```

- w: Mask width
- h: Mask height
- mask: JSON array of bits
- inv: Invert mask by default (can be changed at runtime in the UI)

## Other Notes

- I'd appreciate confirmation that this works on something other than the ESP32-S3 boards I have on hand
- Performance seems unchanged on three segments with masks over 512 LEDs despite checking each virtual LED on each segment against its segment mask. I'm using bitwise ops here and storing the masks as u_int8_t byte arrays, so lookups and memory footprint remains efficient. Still, I expected a small hit to perf, and I'm seeing a perf _gain_ when enabling segment masks on my device. I'd love someone to double check on a larger installation
- Documentation PR: https://github.com/MoonModules/WLED-Docs/pull/13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-segment masks: discover, select and invert masks from the UI; masks persisted in configs and reported in device info.
  * Device-aware default limit for mask slots (different default for ESP8266 and other platforms).
  * UI controls to set/clear masks and invert mask bits per segment.

* **Bug Fixes / Reliability**
  * Mask geometry validated at render time; rendering respects masks across 1D/2D update paths.
  * Mask state initialized, cleaned up and synchronized safely during segment lifecycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->