### PR TITLE
hotfix for DMX-serial output (prevents random crashes caused by array bounds violations)

### DIFF
--- a/wled00/dmx_input.cpp
+++ b/wled00/dmx_input.cpp
@@ -1,7 +1,7 @@
 #include "wled.h"
 
 #ifdef WLED_ENABLE_DMX_INPUT
-#pragma message "DMX physical input driver enabled"
+#pragma message "DMX physical input driver (esp-dmx) enabled"
 
 #ifdef ESP8266
 #error DMX input is only supported on ESP32

--- a/wled00/dmx_output.cpp
+++ b/wled00/dmx_output.cpp
@@ -11,7 +11,7 @@
  */
 
 #ifdef WLED_ENABLE_DMX
-#pragma message "DMX network output enabled"
+#pragma message "DMX output enabled"
 
 #define MAX_DMX_RATE 44 // max DMX update rate in Hz
 

--- a/wled00/dmx_output.cpp
+++ b/wled00/dmx_output.cpp
@@ -99,7 +99,7 @@ void handleDMXOutput()
 }
 
 void initDMXOutput() {
- #ifdef ESP8266
+ #if defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2)
   dmx.init(512);        // initialize with bus length
  #else
   dmx.initWrite(512);  // initialize with bus length

--- a/wled00/src/dependencies/dmx/ESPDMX.cpp
+++ b/wled00/src/dependencies/dmx/ESPDMX.cpp
@@ -73,6 +73,7 @@ void DMXESPSerial::write(int Channel, uint8_t value) {
 
   if (Channel < 1) Channel = 1;
   if (Channel > channelSize) Channel = channelSize;
+  if (Channel > dmxMaxChannel) Channel = dmxMaxChannel; // WLEDMM protect against array bounds violation
   if (value < 0) value = 0;
   if (value > 255) value = 255;
 
@@ -99,7 +100,7 @@ void DMXESPSerial::update() {
   //send data
   Serial1.begin(DMXSPEED, DMXFORMAT);
   digitalWrite(sendPin, LOW);
-  Serial1.write(dmxDataStore, channelSize);
+  Serial1.write(dmxDataStore, min(dmxMaxChannel+1, channelSize+1));
   Serial1.flush();
   delay(1);
   Serial1.end();

--- a/wled00/src/dependencies/dmx/ESPDMX.cpp
+++ b/wled00/src/dependencies/dmx/ESPDMX.cpp
@@ -11,7 +11,7 @@
 // - - - - -
 
 /* ----- LIBRARIES ----- */
-#if defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2)
+#if defined(WLED_ENABLE_DMX) && (defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2))
 
 #include <Arduino.h>
 

--- a/wled00/src/dependencies/dmx/ESPDMX.cpp
+++ b/wled00/src/dependencies/dmx/ESPDMX.cpp
@@ -11,12 +11,13 @@
 // - - - - -
 
 /* ----- LIBRARIES ----- */
-#ifdef ESP8266
+#if defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2)
 
 #include <Arduino.h>
 
 #include "ESPDMX.h"
 
+#pragma message "using ESPDMX"
 
 
 #define dmxMaxChannel  512
@@ -30,8 +31,8 @@
 bool dmxStarted = false;
 int sendPin = 2;		//default on ESP8266
 
-//DMX value array and size. Entry 0 will hold startbyte
-uint8_t dmxDataStore[dmxMaxChannel] = {};
+//DMX value array and size. Entry 0 will hold startbyte, so we need 512+1 elements
+uint8_t dmxDataStore[dmxMaxChannel+1] = {};
 int channelSize;
 
 

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -164,9 +164,9 @@ void SparkFunDMX::update() {
 	{
 		while (DMXSerial.available())
 		{
-      uint8_t newdata = DMXSerial.read();
-      if (currentChannel <= dmxMaxChannel)
-			  dmxData[currentChannel++] = newdata;
+		  uint8_t newdata = DMXSerial.read();
+		  if (currentChannel <= dmxMaxChannel)
+		    dmxData[currentChannel++] = newdata;
 		}
 	if ((currentChannel > chanSize) || (currentChannel > dmxMaxChannel)) //Set the channel counter back to 0 if we reach the known end size of our packet
 	{

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -124,6 +124,7 @@ void SparkFunDMX::initWrite (int chanQuant) {
 // Function to read DMX data
 uint8_t SparkFunDMX::read(int Channel) {
   if (Channel > chanSize) Channel = chanSize;
+  if ((Channel > dmxMaxChannel) || (Channel < 1)) return 0; // WLEDMM prevent array out-of-bounds access
   return(dmxData[Channel - 1]); //subtract one to account for start byte
 }
 #endif
@@ -132,6 +133,7 @@ uint8_t SparkFunDMX::read(int Channel) {
 void SparkFunDMX::write(int Channel, uint8_t value) {
   if (Channel < 0) Channel = 0;
   if (Channel > chanSize) chanSize = Channel;
+  if (Channel > dmxMaxChannel) Channel = dmxMaxChannel; // WLEDMM prevent array out-of-bounds access
   dmxData[0] = 0;
   dmxData[Channel] = value; //add one to account for start byte
 }
@@ -151,7 +153,7 @@ void SparkFunDMX::update() {
     
     //Send DMX data
     DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);//Begin the Serial port
-    DMXSerial.write(dmxData, chanSize);
+    DMXSerial.write(dmxData, min(dmxMaxChannel, chanSize));
     DMXSerial.flush();
     DMXSerial.end();//clear our DMX array, end the Hardware Serial port
   }
@@ -162,9 +164,11 @@ void SparkFunDMX::update() {
 	{
 		while (DMXSerial.available())
 		{
-			dmxData[currentChannel++] = DMXSerial.read();
+      uint8_t newdata = DMXSerial.read();
+      if (currentChannel <= dmxMaxChannel)
+			  dmxData[currentChannel++] = newdata;
 		}
-	if (currentChannel > chanSize) //Set the channel counter back to 0 if we reach the known end size of our packet
+	if ((currentChannel > chanSize) || (currentChannel > dmxMaxChannel)) //Set the channel counter back to 0 if we reach the known end size of our packet
 	{
 		
       portENTER_CRITICAL(&timerMux);

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -131,7 +131,7 @@ uint8_t SparkFunDMX::read(int Channel) {
 
 // Function to send DMX data
 void SparkFunDMX::write(int Channel, uint8_t value) {
-  if (Channel < 0) Channel = 0;
+  if (Channel < 1) Channel = 1;
   if (Channel+1 > chanSize) chanSize = min(dmxMaxChannel +1, Channel+1); // WLEDMM "+1" as we need to account for start byte
   if (Channel > dmxMaxChannel) Channel = dmxMaxChannel;                  // WLEDMM prevent array out-of-bounds access
   dmxData[0] = 0;

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -132,8 +132,8 @@ uint8_t SparkFunDMX::read(int Channel) {
 // Function to send DMX data
 void SparkFunDMX::write(int Channel, uint8_t value) {
   if (Channel < 0) Channel = 0;
-  if (Channel > chanSize) chanSize = Channel;
-  if (Channel > dmxMaxChannel) Channel = dmxMaxChannel; // WLEDMM prevent array out-of-bounds access
+  if (Channel+1 > chanSize) chanSize = min(dmxMaxChannel +1, Channel+1); // WLEDMM "+1" as we need to account for start byte
+  if (Channel > dmxMaxChannel) Channel = dmxMaxChannel;                  // WLEDMM prevent array out-of-bounds access
   dmxData[0] = 0;
   dmxData[Channel] = value; //add one to account for start byte
 }

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -22,6 +22,8 @@ Distributed as-is; no warranty is given.
 #include "SparkFunDMX.h"
 #include <HardwareSerial.h>
 
+#pragma message "using SparkFunDMX"
+
 #define dmxMaxChannel  512
 #define defaultMax 32
 
@@ -34,8 +36,8 @@ static const int enablePin = -1;		// disable the enable pin because it is not ne
 static const int rxPin = -1;       // disable the receiving pin because it is not needed - softhack007: Pin=-1 means "use default" not "disable"
 static const int txPin = 2;        // transmit DMX data over this pin (default is pin 2)
 
-//DMX value array and size. Entry 0 will hold startbyte
-static uint8_t dmxData[dmxMaxChannel] = { 0 };
+//DMX value array and size. Entry 0 will hold startbyte, so we need 512+1 elements
+static uint8_t dmxData[dmxMaxChannel+1] = { 0 };
 static int chanSize = 0;
 #if !defined(DMX_SEND_ONLY)
 static int currentChannel = 0;

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -14,7 +14,7 @@ Distributed as-is; no warranty is given.
 ******************************************************************************/
 
 /* ----- LIBRARIES ----- */
-#if defined(ARDUINO_ARCH_ESP32)
+#if defined(ARDUINO_ARCH_ESP32) && defined(WLED_ENABLE_DMX)
 
 #include <Arduino.h>
 #if !defined(CONFIG_IDF_TARGET_ESP32C3)  && !defined(CONFIG_IDF_TARGET_ESP32S2)

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -123,8 +123,8 @@ void SparkFunDMX::initWrite (int chanQuant) {
 #if !defined(DMX_SEND_ONLY)
 // Function to read DMX data
 uint8_t SparkFunDMX::read(int Channel) {
-  if (Channel > chanSize) Channel = chanSize;
   if ((Channel > dmxMaxChannel) || (Channel < 1)) return 0; // WLEDMM prevent array out-of-bounds access
+  if (Channel > chanSize) Channel = chanSize;
   return(dmxData[Channel - 1]); //subtract one to account for start byte
 }
 #endif

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -153,7 +153,7 @@ void SparkFunDMX::update() {
     
     //Send DMX data
     DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);//Begin the Serial port
-    DMXSerial.write(dmxData, min(dmxMaxChannel, chanSize));
+    DMXSerial.write(dmxData, min(dmxMaxChannel+1, chanSize)); // send max 513 bytes = start byte + 512 channels
     DMXSerial.flush();
     DMXSerial.end();//clear our DMX array, end the Hardware Serial port
   }

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -164,7 +164,7 @@
 #endif
 
 #ifdef WLED_ENABLE_DMX
- #ifdef ESP8266
+  #if defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2)
   #include "src/dependencies/dmx/ESPDMX.h"
  #else //ESP32
   #include "src/dependencies/dmx/SparkFunDMX.h"

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -166,7 +166,7 @@
 #ifdef WLED_ENABLE_DMX
   #if defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2)
   #include "src/dependencies/dmx/ESPDMX.h"
- #else //ESP32
+ #else //ESP32 or ESP32-S3
   #include "src/dependencies/dmx/SparkFunDMX.h"
  #endif
 #endif
@@ -468,7 +468,7 @@ WLED_GLOBAL bool arlsDisableGammaCorrection _INIT(true);          // activate if
 WLED_GLOBAL bool arlsForceMaxBri _INIT(false);                    // enable to force max brightness if source has very dark colors that would be black
 
 #ifdef WLED_ENABLE_DMX
- #ifdef ESP8266
+ #if defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2)
   WLED_GLOBAL DMXESPSerial dmx;
  #else //ESP32
   WLED_GLOBAL SparkFunDMX dmx;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -470,7 +470,7 @@ WLED_GLOBAL bool arlsForceMaxBri _INIT(false);                    // enable to f
 #ifdef WLED_ENABLE_DMX
  #if defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32S2)
   WLED_GLOBAL DMXESPSerial dmx;
- #else //ESP32
+ #else //ESP32 or ESP32-S3
   WLED_GLOBAL SparkFunDMX dmx;
  #endif
 WLED_GLOBAL uint16_t e131ProxyUniverse _INIT(0);                  // output this E1.31 (sACN) / ArtNet universe via MAX485 (0 = disabled)


### PR DESCRIPTION
* Align ESPDMX and SparkFunDMX with upstream code
* Prevent driver compilation when WLED_ENABLE_DMX is not set (saves ~1KB RAM)
* Protect against writing outside of array bounds

NB: there is a [PR in upstream](https://github.com/wled/WLED/pull/5316) that addresses possible logic errors in DMX output (not covered by this MM-specific PR)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadened DMX driver support to additional ESP-based targets for wider device compatibility.
  * Increased DMX channel buffer to accommodate a protocol start byte.

* **Bug Fixes**
  * Improved input validation to prevent out-of-range reads.
  * Clamped writes and tightened packet handling to avoid buffer overruns and ensure safer DMX transfers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->