### PR TITLE
show HUB75 and DMX pins in usermods pin dropdown

### DIFF
--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -10,6 +10,8 @@
 	d.um_p = [];
 	d.rsvd = [];
 	d.ro_gpio = [];
+	d.h_pins = [];
+	d.x_pins = [];
 	var umCfg = {};
 	var pins = [], pinO = [], owner;
 	var loc = false, locip;

--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -58,6 +58,8 @@
 	// function check(o,k) {}   //WLEDMM not needed as we use dropdowns
 	function getPins(o) {
 		if (isO(o)) {
+			// If this object is a bus instance, extract the "type" field
+			let busType = o.type !== undefined ? o.type : -1;
 			for (const [k,v] of Object.entries(o)) {
 				if (isO(v)) {
 					owner = k;
@@ -65,6 +67,10 @@
 					continue;
 				}
 				if (k.replace("[]","").substr(-3)=="pin") {
+					// Skip pin arrays for special bus types where pin array doesn't contain GPIO numbers, but allow all other entries
+					if (busType >= 80 && busType < 96) continue;    // Network buses - pin array stores IP address
+					if (busType >= 100 && busType <= 110) continue; // HUB75 buses - pin array stores chain length
+
 					if (Array.isArray(v)) {
 						for (var i=0; i<v.length; i++) if (v[i]>=0) { pins.push(v[i]); pinO.push(owner); }
 					} else {

--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -269,6 +269,8 @@
 					// console.log("pinPost option", c, c.value, d.ro_gpio.includes(c.value));
 					for (let j=0; j<d.ro_gpio.length; j++) if (d.ro_gpio[j] == c.value) c.text += " read only 🟠"; //if (d.ro_gpio.includes(c.value)) not working ???
 					for (let j=0; j<d.rsvd.length; j++) if (d.rsvd[j] == c.value) {c.text += " reserved 🟣"; c.disabled=true;} //now always disabled as post is done last if (d.rsvd.includes(c.value))
+					for (let j=0; j<d.h_pins.length; j++) if (d.h_pins[j] == c.value && c.text.length <= 4) {c.text += " HUB75 🔴"; c.disabled=true;} // HUB75 pins
+					for (let j=0; j<d.x_pins.length; j++) if (d.x_pins[j] == c.value && c.text.length <= 4) {c.text += " DMX   🔴"; c.disabled=true;} // DMX pins
 					//remove pins > max_gpio
 					if (c.value > d.max_gpio) {
 						select.removeChild(c);

--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -270,7 +270,7 @@
 					for (let j=0; j<d.ro_gpio.length; j++) if (d.ro_gpio[j] == c.value) c.text += " read only 🟠"; //if (d.ro_gpio.includes(c.value)) not working ???
 					for (let j=0; j<d.rsvd.length; j++) if (d.rsvd[j] == c.value) {c.text += " reserved 🟣"; c.disabled=true;} //now always disabled as post is done last if (d.rsvd.includes(c.value))
 					for (let j=0; j<d.h_pins.length; j++) if (d.h_pins[j] == c.value && c.text.length <= 4) {c.text += " HUB75 🔴"; c.disabled=true;} // HUB75 pins
-					for (let j=0; j<d.x_pins.length; j++) if (d.x_pins[j] == c.value && c.text.length <= 4) {c.text += " DMX   🔴"; c.disabled=true;} // DMX pins
+					for (let j=0; j<d.x_pins.length; j++) if (d.x_pins[j] == c.value && c.text.length <= 4) {c.text += " DMX 🔴"; c.disabled=true;} // DMX pins
 					//remove pins > max_gpio
 					if (c.value > d.max_gpio) {
 						select.removeChild(c);
@@ -280,7 +280,7 @@
 					//https://www.javascripttutorial.net/javascript-dom/javascript-remove-items-from-a-select-conditionally/
 					if (c.text.length <= 4) c.text += " 🟢"; //2 digit number space and ⍼/⎌. If no reserved/read only/other um, then pin can be freely used (green)
 					for (let jj=0; jj<d.dt_pins.length; jj++) if (d.dt_pins[jj] == c.value) c.text += ((jj<9)?` D${jj}`:((jj==9)?` RX`:` TX`));  //WLEDMM: Add D0-D8, RX/TX to name
-					for (let jj=0; jj<d.a_pins.length; jj++) if (d.a_pins[jj] == c.value) c.text += ` A${jj}`;  //WLEDMM: Add A0-A10
+					for (let jj=0; jj<d.a_pins.length; jj++) if (d.a_pins[jj] == c.value) c.text += `   A${jj}`;  //WLEDMM: Add A0-A10
 				}
 			}
 		}

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -287,6 +287,30 @@ void appendGPIOinfo() {
   char a_pins[64]  = { '\0' }; // fix warning: output 45 bytes into a destination of size 30
   snprintf(a_pins, 64, "d.a_pins=[%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d];", pinManager.getADCPin(PM_ADC1, 0), pinManager.getADCPin(PM_ADC1, 1), pinManager.getADCPin(PM_ADC1, 2), pinManager.getADCPin(PM_ADC1, 3), pinManager.getADCPin(PM_ADC1, 4), pinManager.getADCPin(PM_ADC1, 5), pinManager.getADCPin(PM_ADC1, 6), pinManager.getADCPin(PM_ADC1, 7), pinManager.getADCPin(PM_ADC1, 8), pinManager.getADCPin(PM_ADC1, 9), pinManager.getADCPin(PM_ADC1, 10));
   oappend(a_pins);
+
+  // WLEDMM add HUB75 pins, as they are not stored directly in cfg.json
+  strcpy(ro_gpio, "d.h_pins=["); // WLEDMM we re-use this array, instead of creating an addition one; 140 bytes is more than enough for 14 pins.
+  bool isFirstHub = true;
+  for(int pinNr = 0; pinNr < WLED_NUM_PINS; pinNr++) {
+    if ((pinManager.isPinOk(pinNr)) && (pinManager.getPinOwner(pinNr) == PinOwner::HUB75)) {
+      sprintf(pinString, "%s%d", isFirstHub?"":",", pinNr);
+      strcat(ro_gpio, pinString); isFirstHub = false;
+    }
+  }
+  oappend(ro_gpio);
+  oappend(SET_F("];"));
+
+  // WLEDMM same procedure for DMX pins
+  strcpy(ro_gpio, "d.x_pins=["); // WLEDMM we re-use this array, instead of creating an addition one; 140 bytes is more than enough for max 4 pins.
+  isFirstHub = true;
+  for(int pinNr = 0; pinNr < WLED_NUM_PINS; pinNr++) {
+    if ((pinManager.isPinOk(pinNr)) && (pinManager.getPinOwner(pinNr) == PinOwner::DMX || pinManager.getPinOwner(pinNr) == PinOwner::DMX_INPUT)) {
+      sprintf(pinString, "%s%d", isFirstHub?"":",", pinNr);
+      strcat(ro_gpio, pinString); isFirstHub = false;
+    }
+  }
+  oappend(ro_gpio);
+  oappend(SET_F("];"));
 }
 
 //get values for settings form in javascript

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -290,11 +290,11 @@ void appendGPIOinfo() {
 
   // WLEDMM add HUB75 pins, as they are not stored directly in cfg.json
   strcpy(ro_gpio, "d.h_pins=["); // WLEDMM we re-use this array, instead of creating an addition one; 140 bytes is more than enough for 14 pins.
-  bool isFirstHub = true;
+  bool isFirstPin = true;
   for(int pinNr = 0; pinNr < WLED_NUM_PINS; pinNr++) {
     if ((pinManager.isPinOk(pinNr)) && (pinManager.getPinOwner(pinNr) == PinOwner::HUB75)) {
-      sprintf(pinString, "%s%d", isFirstHub?"":",", pinNr);
-      strcat(ro_gpio, pinString); isFirstHub = false;
+      sprintf(pinString, "%s%d", isFirstPin ? "" : ",", pinNr);
+      strcat(ro_gpio, pinString); isFirstPin = false;
     }
   }
   oappend(ro_gpio);
@@ -302,11 +302,11 @@ void appendGPIOinfo() {
 
   // WLEDMM same procedure for DMX pins
   strcpy(ro_gpio, "d.x_pins=["); // WLEDMM we re-use this array, instead of creating an addition one; 140 bytes is more than enough for max 4 pins.
-  isFirstHub = true;
+  isFirstPin = true;
   for(int pinNr = 0; pinNr < WLED_NUM_PINS; pinNr++) {
     if ((pinManager.isPinOk(pinNr)) && (pinManager.getPinOwner(pinNr) == PinOwner::DMX || pinManager.getPinOwner(pinNr) == PinOwner::DMX_INPUT)) {
-      sprintf(pinString, "%s%d", isFirstHub?"":",", pinNr);
-      strcat(ro_gpio, pinString); isFirstHub = false;
+      sprintf(pinString, "%s%d", isFirstPin ? "" : ",", pinNr);
+      strcat(ro_gpio, pinString); isFirstPin = false;
     }
   }
   oappend(ro_gpio);


### PR DESCRIPTION
Previously the pins allocated to HUB75 and DMX were wrongly shown as available 🟢 in the pin dropdown.

now it looks like this
<img width="463" height="431" alt="image" src="https://github.com/user-attachments/assets/f981e9ed-eb7d-47d2-8055-6a4dd46abcdf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual indicators added for HUB75 and DMX pins so reserved pins are clearly marked.
  * HUB75 and DMX pins are now listed and automatically disabled in pin selection to prevent conflicts.

* **Style / UI**
  * Improved spacing in analog pin labels for clearer display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->