### PR TITLE
Full WiFi scan (backport of upstream 5351)

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -777,6 +777,11 @@ void WLED::setup()
 
   if (strcmp(clientSSID, DEFAULT_CLIENT_SSID) == 0)
     showWelcomePage = true;
+
+  #if !defined(ESP8266) && (ESP_IDF_VERSION_MAJOR >= 4)
+  WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);   // bugfix: ensure that all channels are scanned, and the strongest signal is used
+  #endif
+
   WiFi.persistent(false);
   #ifdef WLED_USE_ETHERNET
   WiFi.onEvent(WiFiEvent);


### PR DESCRIPTION
As found in https://github.com/wled/WLED/issues/5345:
fixes an arduino-esp32 v2.0.x bug: don't use quick scan (and use the first matching channel) but do a full scan instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WiFi scanning to automatically select the strongest available signal for more reliable wireless connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->