### PR TITLE
Give HUB75 Color Order Overrides

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1035,6 +1035,7 @@ BusHub75Matrix::BusHub75Matrix(BusConfig &bc) : Bus(bc.type, bc.start, bc.autoWh
     
     USER_PRINT(F("heap usage: ")); USER_PRINTLN(int(lastHeap - ESP.getFreeHeap()));
     delay(18);   // experiment - give the driver a moment (~ one full frame @ 60hz) to settle
+    _colorOrder = bc.colorOrder;
     _valid = true;
     display->setBrightness8(_bri);    // range is 0-255, 0 - 0%, 255 - 100% //  [setBrightness()] Tried to set output brightness before begin()
     display->clearScreen();   // initially clear the screen buffer
@@ -1196,8 +1197,19 @@ void __attribute__((hot)) IRAM_ATTR BusHub75Matrix::show(void) {
         uint8_t g = c.g;
         uint8_t b = c.b;
         #endif
-        if (isFourScan) fourScanPanel->drawPixelRGB888(int16_t(x), int16_t(y), r, g, b);
-        else display->drawPixelRGB888(int16_t(x), int16_t(y), r, g, b);
+        // apply color order mapping (COL_ORDER_* values from const.h)
+        uint8_t r2=r, g2=g, b2=b;
+        switch (_colorOrder & 0x0F) {
+          case COL_ORDER_RGB: /* 1 */                           break; // no swap (HUB75 default)
+          case COL_ORDER_GRB: /* 0 */ r2=g; g2=r;              break; // swap R and G
+          case COL_ORDER_BRG: /* 2 */ r2=b; g2=r; b2=g;        break;
+          case COL_ORDER_RBG: /* 3 */       g2=b; b2=g;        break; // swap G and B
+          case COL_ORDER_BGR: /* 4 */ r2=b;       b2=r;        break; // swap R and B
+          case COL_ORDER_GBR: /* 5 */ r2=g; g2=b; b2=r;        break;
+          default:                                              break;
+        }
+        if (isFourScan) fourScanPanel->drawPixelRGB888(int16_t(x), int16_t(y), r2, g2, b2);
+        else display->drawPixelRGB888(int16_t(x), int16_t(y), r2, g2, b2);
       }
       pix ++;
     }

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -426,12 +426,15 @@ class BusHub75Matrix : public Bus {
 
     void cleanup(void) override;
 
+    uint8_t getColorOrder() const override { return _colorOrder; }
+
     ~BusHub75Matrix() {
       cleanup();
     }
 
   private:
     unsigned _panelWidth = 0;
+    uint8_t  _colorOrder = COL_ORDER_RGB;
     CRGB *_ledBuffer = nullptr;
     byte *_ledsDirty = nullptr;
     // C++ dirty trick: private static variables are actually _not_ part of the class (however only visibile to class instances). 

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -223,7 +223,7 @@
 					}
 					gId("rf"+n).onclick = (t == 31) ? (()=>{return false}) : (()=>{});  // prevent change for TM1814
 					gRGBW |= isRGBW = ((t > 17 && t < 22) || (t > 28 && t < 32) || (t > 40 && t < 46 && t != 43) || t == 88); // RGBW checkbox, TYPE_xxxx values from const.h
-					gId("co"+n).style.display = ((t >= 83 && t < 96) || (t >= 40 && t < 48)||(t >= 100 && t < 110)) ? "none":"inline";  // hide color order for PWM
+					gId("co"+n).style.display = ((t >= 83 && t < 96) || (t >= 40 && t < 48)) ? "none":"inline";  // hide color order for PWM/analog (not HUB75)
 					gId("dig"+n+"w").style.display = (t > 28 && t < 32) ? "inline":"none";  // show swap channels dropdown
 					gId("dig"+n+"O").style.display = (t == 82 || t == 83) ? "inline":"none";  // show Art-Net output number
 					gId("dig"+n+"L").style.display = (t == 82 || t == 83) ? "inline":"none";  // show Art-Net LEDs per output

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -220,6 +220,7 @@
 					if (change) {
 						gId("rf"+n).checked = (gId("rf"+n).checked || t == 31); // LEDs require data in off state
 						if (t > 31 && t < 48) d.getElementsByName("LC"+n)[0].value = 1; // for sanity change analog count just to 1 LED
+						if (t >= 100 && t < 110) d.getElementsByName("CO"+n)[0].value = 1; // default to RGB color order for HUB75
 					}
 					gId("rf"+n).onclick = (t == 31) ? (()=>{return false}) : (()=>{});  // prevent change for TM1814
 					gRGBW |= isRGBW = ((t > 17 && t < 22) || (t > 28 && t < 32) || (t > 40 && t < 46 && t != 43) || t == 88); // RGBW checkbox, TYPE_xxxx values from const.h


### PR DESCRIPTION
Not all HUB75 panels are RGB.

This just enables the standard color order stuff we already have in the bus system for HUB75 too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color-order initialization and per-pixel RGB remapping for HUB75 matrix displays so colors render correctly across all panel types.

* **New Features**
  * HUB75 matrix color-order settings are now preserved and configurable in the LED settings UI, and the Color Order control is shown for HUB75 types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->